### PR TITLE
Change build order to work without an existing dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Cognite AS",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "rm -rf dist/* && cp -r src/plugin.json src/css src/partials src/img dist/ && npx tsc"
+    "build": "rm -rf dist && npx tsc && cp -r src/plugin.json src/css src/partials src/img dist/"
   },
   "devDependencies": {
     "typescript": "^3.0.1"


### PR DESCRIPTION
The current build assumes you already have a `dist` folder which is not checked into git.