### PR TITLE
Remove incorrect dataquery parameter

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -197,7 +197,6 @@ export default class CogniteDatasource {
         //       still looks ok for aggregates, so perhaps we should use it for those?
         //limit: options.maxDataPoints,
         limit: query.aggregates ? 10_000 : 100_000,
-        aggregation: query.aggregates,
       };
     });
 


### PR DESCRIPTION
Aggregates are already specified per time series in the query items, so this parameter should not be necessary.

The time series team wants to enforce more strict query parameter checking, so we need to remove this.