### PR TITLE
Improved functions

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -331,7 +331,9 @@ export default class CogniteDatasource {
             const aliasParts = match
               .substr(1, match.length - 2)
               .split(',')
+              .filter(string => string.length)
               .map(x => _.trim(x, ' \'"'));
+            // if we only get [ID], then there is no need to make an alias
             if (aliasParts.length === 1) continue;
             const alias: DataQueryAlias = {
               alias: `alias${aliasParts.join('_')}`,
@@ -722,9 +724,11 @@ export default class CogniteDatasource {
     let splitfilters: string[];
     if (timeseriesMatch) {
       // regex finds commas that are not followed by a closed bracket
-      splitfilters = _.split(timeseriesMatch[1], /,(?![^\(\[]*[\]\)])/g);
+      splitfilters = _.split(timeseriesMatch[1], /,(?![^\(\[]*[\]\)])/g).filter(
+        string => string.length
+      );
     } else if (assetMatch) {
-      splitfilters = assetMatch[1].split(',');
+      splitfilters = assetMatch[1].split(',').filter(string => string.length);
     } else {
       return filtersOptions;
     }

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -165,7 +165,7 @@
     Instead, specify aggregations on each individual timeseries by using [ID,aggregation] or [ID,aggregation,granularity].
   Examples: timeseries{name=~'.*temp.*', function = ([ID] - 32) * 5/9}
             timeseries{ function = [ID] - [ID,avg,24h] }
-            timeseries{ function = [ID,step] - [123456789,step] }      
+            timeseries{ function = [ID,step] - [123456789,step] }
       </pre>
   </div>
 </script>

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -162,7 +162,10 @@
   Example: timeseries{assetId=[[asset]],metadata.key1 =~ ".*test.*",isStep=1}[average,12h] <br>
   Functions can also be applied to the results by adding a function property. Use '[ID]' to access the timeseries values.
     Note: No aggregates can be used when using functions.
-  Example: timeseries{name=~'.*temp.*', function = ([ID] - 32) * 5/9}
+    Instead, specify aggregations on each individual timeseries by using [ID,aggregation] or [ID,aggregation,granularity].
+  Examples: timeseries{name=~'.*temp.*', function = ([ID] - 32) * 5/9}
+            timeseries{ function = [ID] - [ID,avg,24h] }
+            timeseries{ function = [ID,step] - [123456789,step] }      
       </pre>
   </div>
 </script>


### PR DESCRIPTION
Allowing for aggregations to be used within functions, via the syntax [ID,aggregation,granularity]
For example: 
```  
timeseries{name=~'.*temp.*', function = ([ID] - 32) * 5/9}
timeseries{ function = [ID] - [ID,avg,24h] }
timeseries{ function = [ID,step] - [123456789,step] }
```