### PR TITLE
Optimizing QueryTarget Object

### DIFF
--- a/src/__mocks__/cache.ts
+++ b/src/__mocks__/cache.ts
@@ -1,7 +1,30 @@
+import { TimeSeriesResponseItem, QueryOptions, QueryTarget } from '../types';
+
 // for tests just send the request to the mocked backendsrv
 export const getQuery = async (query, backendSrv) => backendSrv.datasourceRequest(query);
+
+const assetTimeseries = new Map<string, TimeSeriesResponseItem[]>();
+export const getTimeseries = (options: QueryOptions, target: QueryTarget) => {
+  const id: string = `${options.dashboardId}_${options.panelId}_${target.refId}_${
+    target.assetQuery.templatedTarget
+  }_${target.assetQuery.includeSubtrees}`;
+  return assetTimeseries.get(id);
+};
+export const setTimeseries = (
+  options: QueryOptions,
+  target: QueryTarget,
+  timeseries: TimeSeriesResponseItem[]
+) => {
+  const id: string = `${options.dashboardId}_${options.panelId}_${target.refId}_${
+    target.assetQuery.templatedTarget
+  }_${target.assetQuery.includeSubtrees}`;
+  assetTimeseries.set(id, timeseries);
+};
+
 const cache = {
   getQuery,
+  getTimeseries,
+  setTimeseries,
 };
 
 export default cache;

--- a/src/__mocks__/cache.ts
+++ b/src/__mocks__/cache.ts
@@ -1,24 +1,15 @@
-import { TimeSeriesResponseItem, QueryOptions, QueryTarget } from '../types';
+import { TimeSeriesResponseItem } from '../types';
+import Utils from '../utils';
 
 // for tests just send the request to the mocked backendsrv
 export const getQuery = async (query, backendSrv) => backendSrv.datasourceRequest(query);
 
 const assetTimeseries = new Map<string, TimeSeriesResponseItem[]>();
-export const getTimeseries = (options: QueryOptions, target: QueryTarget) => {
-  const id: string = `${options.dashboardId}_${options.panelId}_${target.refId}_${
-    target.assetQuery.templatedTarget
-  }_${target.assetQuery.includeSubtrees}`;
-  return assetTimeseries.get(id);
+export const getTimeseries = (options, target) => {
+  return assetTimeseries.get(Utils.timeseriesHash(options, target));
 };
-export const setTimeseries = (
-  options: QueryOptions,
-  target: QueryTarget,
-  timeseries: TimeSeriesResponseItem[]
-) => {
-  const id: string = `${options.dashboardId}_${options.panelId}_${target.refId}_${
-    target.assetQuery.templatedTarget
-  }_${target.assetQuery.includeSubtrees}`;
-  assetTimeseries.set(id, timeseries);
+export const setTimeseries = (options, target, timeseries) => {
+  assetTimeseries.set(Utils.timeseriesHash(options, target), timeseries);
 };
 
 const cache = {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -6,6 +6,7 @@ import {
   QueryOptions,
 } from './types';
 import { BackendSrv } from 'grafana/app/core/services/backend_srv';
+import Utils from './utils';
 
 // Cache requests for 10 seconds
 const cacheTime = 1000 * 10;
@@ -56,10 +57,7 @@ export const getQuery = async (query: DataSourceRequestOptions, backendSrv: Back
 const assetTimeseries = new Map<string, TimeSeriesResponseItem[]>();
 
 export const getTimeseries = (options: QueryOptions, target: QueryTarget) => {
-  const id: string = `${options.dashboardId}_${options.panelId}_${target.refId}_${
-    target.assetQuery.templatedTarget
-  }_${target.assetQuery.includeSubtrees}`;
-  return assetTimeseries.get(id);
+  return assetTimeseries.get(Utils.timeseriesHash(options, target));
 };
 
 export const setTimeseries = (
@@ -67,10 +65,7 @@ export const setTimeseries = (
   target: QueryTarget,
   timeseries: TimeSeriesResponseItem[]
 ) => {
-  const id: string = `${options.dashboardId}_${options.panelId}_${target.refId}_${
-    target.assetQuery.templatedTarget
-  }_${target.assetQuery.includeSubtrees}`;
-  assetTimeseries.set(id, timeseries);
+  assetTimeseries.set(Utils.timeseriesHash(options, target), timeseries);
 };
 
 const cache = {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,4 +1,10 @@
-import { DataSourceRequestOptions, isError } from './types';
+import {
+  DataSourceRequestOptions,
+  isError,
+  TimeSeriesResponseItem,
+  QueryTarget,
+  QueryOptions,
+} from './types';
 import { BackendSrv } from 'grafana/app/core/services/backend_srv';
 
 // Cache requests for 10 seconds
@@ -47,8 +53,30 @@ export const getQuery = async (query: DataSourceRequestOptions, backendSrv: Back
   return promise;
 };
 
+const assetTimeseries = new Map<string, TimeSeriesResponseItem[]>();
+
+export const getTimeseries = (options: QueryOptions, target: QueryTarget) => {
+  const id: string = `${options.dashboardId}_${options.panelId}_${target.refId}_${
+    target.assetQuery.templatedTarget
+  }_${target.assetQuery.includeSubtrees}`;
+  return assetTimeseries.get(id);
+};
+
+export const setTimeseries = (
+  options: QueryOptions,
+  target: QueryTarget,
+  timeseries: TimeSeriesResponseItem[]
+) => {
+  const id: string = `${options.dashboardId}_${options.panelId}_${target.refId}_${
+    target.assetQuery.templatedTarget
+  }_${target.assetQuery.includeSubtrees}`;
+  assetTimeseries.set(id, timeseries);
+};
+
 const cache = {
   getQuery,
+  getTimeseries,
+  setTimeseries,
 };
 
 export default cache;

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -138,6 +138,7 @@ export default class CogniteDatasource {
   public async query(options: QueryOptions): Promise<QueryResponse> {
     const queryTargets: QueryTarget[] = options.targets.reduce((targets, target) => {
       target.error = '';
+      target.warning = '';
       if (
         !target ||
         target.hide ||
@@ -455,7 +456,15 @@ export default class CogniteDatasource {
       includeSubtrees: target.assetQuery.includeSubtrees,
     };
 
+    // since /dataquery can only have 100 items and checkboxes become difficult to use past 100 items,
+    //  we only get the first 100 timeseries, and show a warning if there are too many timeseries
+    searchQuery.limit = 101;
     const ts = await this.getTimeseries(searchQuery, target);
+    if (ts.length === 101) {
+      target.warning =
+        "[WARNING] Only showing first 100 timeseries. To get better results, either change the selected asset or use 'Custom Query'.";
+      ts.splice(-1);
+    }
     target.assetQuery.timeseries = ts.map(ts => {
       ts.selected = true;
       return ts;

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -21,8 +21,11 @@
     </div>
 
     <!-- error messages -->
-    <div class="gf-form-inline panel-container">
-      <label class="gf-form-label--error">{{ ctrl.target.error }}</label>
+    <div class="gf-form panel-container" ng-if="ctrl.target.error">
+      <label class="text-error">{{ ctrl.target.error }}</label>
+    </div>
+    <div class="gf-form panel-container" ng-if="ctrl.target.warning">
+      <label class="text-warning">{{ ctrl.target.warning }}</label>
     </div>
   </div>
 </query-editor-row>

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -48,10 +48,11 @@ export class CogniteQueryCtrl extends QueryCtrl {
     expr: '',
     assetQuery: {
       target: '',
-      old: {},
+      old: undefined,
       timeseries: [],
       includeSubtrees: false,
       func: '',
+      templatedTarget: '',
     },
   };
   isAllSelected: boolean;
@@ -63,6 +64,10 @@ export class CogniteQueryCtrl extends QueryCtrl {
     _.defaultsDeep(this.target, this.defaults);
 
     this.currentTabIndex = this.tabs.findIndex(x => x.value === this.target.tab) || 0;
+    if (this.target.tab !== Tab.Asset) {
+      this.target.assetQuery.timeseries = [];
+      this.target.assetQuery.old = undefined;
+    }
     this.isAllSelected =
       this.target.assetQuery.timeseries &&
       this.target.assetQuery.timeseries.every(ts => ts.selected);
@@ -79,6 +84,7 @@ export class CogniteQueryCtrl extends QueryCtrl {
   changeTab(index: number) {
     this.currentTabIndex = index;
     this.target.tab = this.tabs[index].value;
+    this.refresh();
   }
 
   toggleCheckboxes() {

--- a/src/spec/__snapshots__/datasource.test.ts.snap
+++ b/src/spec/__snapshots__/datasource.test.ts.snap
@@ -173,49 +173,49 @@ Array [
 exports[`CogniteDatasource Datasource Query Given "Select Timeseries from Asset" queries should generate the correct queries 1`] = `
 Object {
   "method": "GET",
-  "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries?assetId=123&limit=10000",
+  "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries?assetId=123&limit=101",
 }
 `;
 
 exports[`CogniteDatasource Datasource Query Given "Select Timeseries from Asset" queries should generate the correct queries 2`] = `
 Object {
   "method": "GET",
-  "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries?path=[456]&limit=10000",
+  "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries?path=[456]&limit=101",
 }
 `;
 
 exports[`CogniteDatasource Datasource Query Given "Select Timeseries from Asset" queries should generate the correct queries 3`] = `
 Object {
   "method": "GET",
-  "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries?assetId=789&limit=10000",
+  "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries?assetId=789&limit=101",
 }
 `;
 
 exports[`CogniteDatasource Datasource Query Given "Select Timeseries from Asset" queries should generate the correct queries 4`] = `
 Object {
   "method": "GET",
-  "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries?assetId=123&limit=10000",
+  "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries?assetId=123&limit=101",
 }
 `;
 
 exports[`CogniteDatasource Datasource Query Given "Select Timeseries from Asset" queries should generate the correct queries 5`] = `
 Object {
   "method": "GET",
-  "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries?path=[000]&limit=10000",
+  "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries?path=[000]&limit=101",
 }
 `;
 
 exports[`CogniteDatasource Datasource Query Given "Select Timeseries from Asset" queries should generate the correct queries 6`] = `
 Object {
   "method": "GET",
-  "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries?assetId=123&limit=10000",
+  "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries?assetId=123&limit=101",
 }
 `;
 
 exports[`CogniteDatasource Datasource Query Given "Select Timeseries from Asset" queries should generate the correct queries 7`] = `
 Object {
   "method": "GET",
-  "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries?assetId=123&limit=10000",
+  "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries?assetId=123&limit=101",
 }
 `;
 
@@ -1865,14 +1865,14 @@ Object {
 exports[`CogniteDatasource Datasource Query Given multiple "Select Timeseries from Asset" queries in a row should generate the correct queries and not requery for asset timeseries 1`] = `
 Object {
   "method": "GET",
-  "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries?assetId=123&limit=10000",
+  "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries?assetId=123&limit=101",
 }
 `;
 
 exports[`CogniteDatasource Datasource Query Given multiple "Select Timeseries from Asset" queries in a row should generate the correct queries and not requery for asset timeseries 2`] = `
 Object {
   "method": "GET",
-  "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries?path=[123]&limit=10000",
+  "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries?path=[123]&limit=101",
 }
 `;
 
@@ -1896,7 +1896,7 @@ Object {
 exports[`CogniteDatasource Datasource Query Given multiple "Select Timeseries from Asset" queries in a row should generate the correct queries and not requery for asset timeseries 4`] = `
 Object {
   "method": "GET",
-  "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries?path=[456]&limit=10000",
+  "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries?path=[456]&limit=101",
 }
 `;
 

--- a/src/spec/datasource.test.ts
+++ b/src/spec/datasource.test.ts
@@ -161,6 +161,7 @@ describe('CogniteDatasource', () => {
         },
         error: undefined,
         hide: undefined,
+        warning: undefined,
       };
       const emptyAsset: QueryTarget = {
         ...emptyTimeseries,
@@ -196,6 +197,7 @@ describe('CogniteDatasource', () => {
         hide: undefined,
         assetQuery: undefined,
         expr: undefined,
+        warning: undefined,
       };
 
       beforeAll(async () => {
@@ -228,6 +230,7 @@ describe('CogniteDatasource', () => {
         hide: undefined,
         assetQuery: undefined,
         expr: undefined,
+        warning: undefined,
       };
       const tsTargetB: QueryTarget = {
         ...tsTargetA,
@@ -283,6 +286,7 @@ describe('CogniteDatasource', () => {
         hide: undefined,
         assetQuery: undefined,
         expr: undefined,
+        warning: undefined,
       };
       const tsTargetB = {
         ...tsTargetA,
@@ -333,6 +337,7 @@ describe('CogniteDatasource', () => {
           func: undefined,
         },
         expr: undefined,
+        warning: undefined,
       };
       const targetB: QueryTarget = {
         ...targetA,
@@ -472,6 +477,7 @@ describe('CogniteDatasource', () => {
           func: undefined,
         },
         expr: 'timeseries{}',
+        warning: undefined,
       };
       const targetB: QueryTarget = {
         ..._.cloneDeep(targetA),
@@ -592,6 +598,7 @@ describe('CogniteDatasource', () => {
           func: undefined,
         },
         expr: 'timeseries{function=[ID]}',
+        warning: undefined,
       };
       const targetB: QueryTarget = {
         ..._.cloneDeep(targetA),
@@ -717,6 +724,7 @@ describe('CogniteDatasource', () => {
           func: undefined,
         },
         expr: undefined,
+        warning: undefined,
       };
       const targetB: QueryTarget = {
         ...targetA,

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,7 @@ export interface AssetQuery {
   old?: AssetQuery;
   timeseries?: TimeSeriesResponseItem[];
   func?: string;
+  templatedTarget?: string;
 }
 
 export interface QueryTarget extends DataQuery {

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,7 @@ export interface QueryTarget extends DataQuery {
   tab: Tab;
   assetQuery: AssetQuery;
   expr: string;
+  warning: string;
 }
 
 export type QueryFormat = 'json';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { QueryOptions, QueryTarget } from './types';
 
 export default class Utils {
   // Converts an object to a query string, ignores properties with undefined/null values
@@ -83,5 +84,11 @@ export default class Utils {
       }
     }
     return filterStrings;
+  }
+
+  static timeseriesHash(options: QueryOptions, target: QueryTarget) {
+    return `${options.dashboardId}_${options.panelId}_${target.refId}_${
+      target.assetQuery.templatedTarget
+    }_${target.assetQuery.includeSubtrees}`;
   }
 }


### PR DESCRIPTION
Since we have no need to save all asset timeseries for custom queries, I am adding a cache to store the timeseries separately from the `QueryTarget` object. We still need to keep the timeseries array in `QueryTarget` since `Get Timeseries from Asset` still needs to keep track of which ones are selected. However, when we load in the target object in `query_ctrl` we now also check if we are on the assets tab, if not we can clear that array.

Also choosing to limit `Get Timeseries from Asset` to only fetch the first 100 timeseries since `/dataquery` can only show 100 items, and also because that section really should not be used for that many timeseries. A warning will be shown if not all timeseries can be shown. 

Mostly solves #36, although we may be able to further optimize `QueryTarget` by reducing how much we store for the each timeseries in the timeseries array. Also, with the limitation to 100 timeseries, explore no longer has issues with the url length (at least in chrome).

As an extra note, this will help when we have a way to concurrently fetch all timeseries belonging to an asset, as we won't have to store them in `QueryTarget`.