### PR TITLE
allowing custom queries to return more than 100 timeseries

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -203,8 +203,7 @@ export default class CogniteDatasource {
           if (queryReq.aggregates) {
             target.error =
               '[ERROR] To use aggregations with functions, use [ID,aggregation,granularity] or [ID,aggregation]';
-            targetQueriesCount.pop();
-            continue;
+            break;
           }
           let ids = 0;
           const idRegex = /\[.*?\]/g; // look for [something]
@@ -228,6 +227,10 @@ export default class CogniteDatasource {
         }
         queries.push(queryReq);
         queryList = queryList.slice(100); // get the rest of the items
+      }
+      if (target.error) {
+        targetQueriesCount.pop();
+        continue;
       }
       // assign labels to each timeseries
       if (target.tab === Tab.Timeseries || target.tab === undefined) {


### PR DESCRIPTION
There is currently a limit for `/dataquery` to only contain 100 items per request, but this should not limit a user
Now checking if a request will contain more than 100 items and if it does, split it up into more requests.
Fixes #48 