### PR TITLE
fixing issue with labels for custom queries

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -165,7 +165,14 @@ export default class CogniteDatasource {
           cache.getTimeseries(options, target).forEach(ts => {
             if (ts.selected && count < queryList.length) {
               count += 1;
-              if (!target.label) target.label = '';
+              if (!target.label) {
+                if (queryList[0].function) {
+                  // if using custom functions and no label is specified just use the name of the last timeseries in the function
+                  labels.push(ts.name);
+                  return;
+                }
+                target.label = '';
+              }
               labels.push(this.getTimeseriesLabel(target.label, ts));
             }
           });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -23,13 +23,10 @@ export const parseExpression = (
   // first check if it is just a simple `timeseries{}` or `timeseries{}[]`
   if (isSimpleTimeseriesExpression(trimmedExpr)) {
     const filterOptions = getAndApplyFilterOptions(trimmedExpr, templateSrv, options, timeseries);
-    target.aggregation = filterOptions.aggregation;
+    target.aggregation = Utils.getAggregationDropdownString(filterOptions.aggregation);
     target.granularity = filterOptions.granularity;
     return timeseries.filter(ts => ts.selected).map(ts => ({ name: ts.name }));
   }
-
-  target.aggregation = '';
-  target.granularity = '';
 
   const exprWithSpecialFunctions = parseSpecialFunctions(
     trimmedExpr,

--- a/src/spec/__snapshots__/datasource.test.ts.snap
+++ b/src/spec/__snapshots__/datasource.test.ts.snap
@@ -767,7 +767,7 @@ Object {
 exports[`CogniteDatasource Datasource Query Given custom queries should generate the correct filtered queries 11`] = `
 Object {
   "data": Object {
-    "aggregates": "cv",
+    "aggregates": "continuousVariance",
     "end": 1549338475000,
     "granularity": "10d",
     "items": Array [
@@ -786,7 +786,7 @@ Object {
 exports[`CogniteDatasource Datasource Query Given custom queries should generate the correct filtered queries 12`] = `
 Object {
   "data": Object {
-    "aggregates": "dv",
+    "aggregates": "discreteVariance",
     "end": 1549338475000,
     "granularity": "24h",
     "items": Array [

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,6 +20,7 @@ export default class Utils {
 
   static getDatasourceValueString(aggregation: string): string {
     const mapping = {
+      '': 'value',
       undefined: 'value',
       none: 'value',
       avg: 'average',
@@ -35,6 +36,14 @@ export default class Utils {
       tv: 'totalVariation',
     };
     return mapping[aggregation] || aggregation;
+  }
+
+  static getAggregationDropdownString(aggregation: string): string {
+    let val = Utils.getDatasourceValueString(aggregation);
+    if (val === 'continousVariance') val = 'continuousVariance';
+    // temp 0.5 fix
+    else if (val === 'value') val = 'none';
+    return val;
   }
 
   static splitFilters(filterString: string, filtersOptions: any, onlyAllowEquals: boolean) {


### PR DESCRIPTION
now if no label is specified for a custom query, we will just use the name of the last timeseries in the function