### PR TITLE
Replace variables outside filters

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -68,7 +68,7 @@ export default class CogniteDatasource {
     const timeFrom = Math.ceil(dateMath.parse(options.range.from));
     const timeTo = Math.ceil(dateMath.parse(options.range.to));
     const targetQueriesCount = [];
-    const labels = [];
+    let labels = [];
 
     const dataQueryRequestPromises: Promise<DataQueryRequestItem[]>[] = [];
     for (const target of queryTargets) {
@@ -179,6 +179,8 @@ export default class CogniteDatasource {
         }
       }
     }
+    // replace variables in labels as well
+    labels = labels.map(label => this.templateSrv.replace(label, options.scopedVars));
 
     const queryRequests = queries.map(q =>
       cache

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -19,7 +19,8 @@ export const parseExpression = (
   templateSrv: TemplateSrv,
   target: QueryTarget
 ): DataQueryRequestItem[] => {
-  const trimmedExpr = expr.trim();
+  // trim and replace all variables here (will also replace variables outside of timeseries{} filters)
+  const trimmedExpr = templateSrv.replace(expr.trim(), options.scopedVars);
   // first check if it is just a simple `timeseries{}` or `timeseries{}[]`
   if (isSimpleTimeseriesExpression(trimmedExpr)) {
     const filterOptions = getAndApplyFilterOptions(trimmedExpr, templateSrv, options, timeseries);

--- a/src/spec/__snapshots__/datasource.test.ts.snap
+++ b/src/spec/__snapshots__/datasource.test.ts.snap
@@ -2886,7 +2886,7 @@ Object {
           1549338475000,
         ],
       ],
-      "target": "Timeseries1",
+      "target": "Timeseries2",
     },
     Object {
       "datapoints": Array [
@@ -2907,7 +2907,7 @@ Object {
           1549338475000,
         ],
       ],
-      "target": "Timeseries1",
+      "target": "Timeseries3",
     },
     Object {
       "datapoints": Array [
@@ -2928,7 +2928,7 @@ Object {
           1549338475000,
         ],
       ],
-      "target": "Timeseries1",
+      "target": "Timeseries4",
     },
     Object {
       "datapoints": Array [
@@ -2949,7 +2949,7 @@ Object {
           1549338475000,
         ],
       ],
-      "target": "Timeseries1",
+      "target": "Timeseries5",
     },
     Object {
       "datapoints": Array [
@@ -2970,7 +2970,7 @@ Object {
           1549338475000,
         ],
       ],
-      "target": "Timeseries1",
+      "target": "Test",
     },
     Object {
       "datapoints": Array [

--- a/src/spec/__snapshots__/datasource.test.ts.snap
+++ b/src/spec/__snapshots__/datasource.test.ts.snap
@@ -1221,6 +1221,13 @@ Object {
 
 exports[`CogniteDatasource Datasource Query Given custom queries with functions should generate the correct filtered queries 10`] = `
 Object {
+  "method": "GET",
+  "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries?assetId=123&limit=10000",
+}
+`;
+
+exports[`CogniteDatasource Datasource Query Given custom queries with functions should generate the correct filtered queries 11`] = `
+Object {
   "data": Object {
     "end": 1549338475000,
     "items": Array [
@@ -1251,7 +1258,7 @@ Object {
 }
 `;
 
-exports[`CogniteDatasource Datasource Query Given custom queries with functions should generate the correct filtered queries 11`] = `
+exports[`CogniteDatasource Datasource Query Given custom queries with functions should generate the correct filtered queries 12`] = `
 Object {
   "data": Object {
     "end": 1549338475000,
@@ -1295,7 +1302,7 @@ Object {
 }
 `;
 
-exports[`CogniteDatasource Datasource Query Given custom queries with functions should generate the correct filtered queries 12`] = `
+exports[`CogniteDatasource Datasource Query Given custom queries with functions should generate the correct filtered queries 13`] = `
 Object {
   "data": Object {
     "end": 1549338475000,
@@ -1417,7 +1424,7 @@ Object {
 }
 `;
 
-exports[`CogniteDatasource Datasource Query Given custom queries with functions should generate the correct filtered queries 13`] = `
+exports[`CogniteDatasource Datasource Query Given custom queries with functions should generate the correct filtered queries 14`] = `
 Object {
   "data": Object {
     "end": 1549338475000,
@@ -1455,7 +1462,7 @@ Object {
 }
 `;
 
-exports[`CogniteDatasource Datasource Query Given custom queries with functions should generate the correct filtered queries 14`] = `
+exports[`CogniteDatasource Datasource Query Given custom queries with functions should generate the correct filtered queries 15`] = `
 Object {
   "data": Object {
     "end": 1549338475000,
@@ -1474,7 +1481,7 @@ Object {
 }
 `;
 
-exports[`CogniteDatasource Datasource Query Given custom queries with functions should generate the correct filtered queries 15`] = `
+exports[`CogniteDatasource Datasource Query Given custom queries with functions should generate the correct filtered queries 16`] = `
 Object {
   "data": Object {
     "end": 1549338475000,
@@ -1493,7 +1500,7 @@ Object {
 }
 `;
 
-exports[`CogniteDatasource Datasource Query Given custom queries with functions should generate the correct filtered queries 16`] = `
+exports[`CogniteDatasource Datasource Query Given custom queries with functions should generate the correct filtered queries 17`] = `
 Object {
   "data": Object {
     "end": 1549338475000,
@@ -2227,7 +2234,7 @@ Object {
 }
 `;
 
-exports[`CogniteDatasource Datasource Query Given custom queries with functions should generate the correct filtered queries 17`] = `
+exports[`CogniteDatasource Datasource Query Given custom queries with functions should generate the correct filtered queries 18`] = `
 Object {
   "data": Object {
     "end": 1549338475000,
@@ -2264,6 +2271,25 @@ Object {
       },
     ],
     "limit": 2777,
+    "start": 1549336675000,
+  },
+  "method": "POST",
+  "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
+}
+`;
+
+exports[`CogniteDatasource Datasource Query Given custom queries with functions should generate the correct filtered queries 19`] = `
+Object {
+  "data": Object {
+    "end": 1549338475000,
+    "items": Array [
+      Object {
+        "aliases": Array [],
+        "function": "[12] + [[TimeseriesVariable]]",
+        "name": "Timeseries1",
+      },
+    ],
+    "limit": 50000,
     "start": 1549336675000,
   },
   "method": "POST",
@@ -2860,7 +2886,7 @@ Object {
           1549338475000,
         ],
       ],
-      "target": "Timeseries2",
+      "target": "Timeseries1",
     },
     Object {
       "datapoints": Array [
@@ -2881,7 +2907,7 @@ Object {
           1549338475000,
         ],
       ],
-      "target": "Timeseries3",
+      "target": "Timeseries1",
     },
     Object {
       "datapoints": Array [
@@ -2902,7 +2928,7 @@ Object {
           1549338475000,
         ],
       ],
-      "target": "Timeseries4",
+      "target": "Timeseries1",
     },
     Object {
       "datapoints": Array [
@@ -2923,7 +2949,7 @@ Object {
           1549338475000,
         ],
       ],
-      "target": "Timeseries5",
+      "target": "Timeseries1",
     },
     Object {
       "datapoints": Array [
@@ -2944,7 +2970,28 @@ Object {
           1549338475000,
         ],
       ],
-      "target": "Test",
+      "target": "Timeseries1",
+    },
+    Object {
+      "datapoints": Array [
+        Array [
+          0,
+          1549336675000,
+        ],
+        Array [
+          1,
+          1549337275000,
+        ],
+        Array [
+          2,
+          1549337875000,
+        ],
+        Array [
+          3,
+          1549338475000,
+        ],
+      ],
+      "target": "test timeseriesA : Timeseries1",
     },
   ],
 }

--- a/src/spec/datasource.test.ts
+++ b/src/spec/datasource.test.ts
@@ -688,7 +688,7 @@ describe('CogniteDatasource', () => {
       };
       const targetJ: QueryTarget = {
         ..._.cloneDeep(targetA),
-        refId: 'I',
+        refId: 'J',
         expr: 'timeseries{name=[[TimeseriesVariable]]} + [[TimeseriesVariable]]',
         label: '{{description}} : [[TimeseriesVariable]]',
       };

--- a/src/spec/datasource.test.ts
+++ b/src/spec/datasource.test.ts
@@ -451,7 +451,7 @@ describe('CogniteDatasource', () => {
         expect(result).toMatchSnapshot();
       });
       it('should call templateSrv.replace the correct number of times', () => {
-        expect(ctx.templateSrvMock.replace.mock.calls.length).toBe(7);
+        expect(ctx.templateSrvMock.replace.mock.calls.length).toBe(20);
       });
       it('should display errors for malformed queries', () => {
         expect(targetError1.error).toBe('[400 ERROR] error message');
@@ -609,7 +609,7 @@ describe('CogniteDatasource', () => {
       });
 
       it('should call templateSrv.replace the correct number of times', () => {
-        expect(ctx.templateSrvMock.replace.mock.calls.length).toBe(15);
+        expect(ctx.templateSrvMock.replace.mock.calls.length).toBe(37);
       });
 
       it('should display errors for malformed queries', () => {
@@ -686,6 +686,12 @@ describe('CogniteDatasource', () => {
         refId: 'I',
         expr: 'max(max(timeseries{},5),5) + max(timeseries{})',
       };
+      const targetJ: QueryTarget = {
+        ..._.cloneDeep(targetA),
+        refId: 'I',
+        expr: 'timeseries{name=[[TimeseriesVariable]]} + [[TimeseriesVariable]]',
+        label: '{{description}} : [[TimeseriesVariable]]',
+      };
 
       const tsResponse = getTimeseriesResponse([
         {
@@ -738,9 +744,11 @@ describe('CogniteDatasource', () => {
           targetG,
           targetH,
           targetI,
+          targetJ,
         ];
         ctx.ds.backendSrv.datasourceRequest = jest
           .fn()
+          .mockImplementationOnce(() => Promise.resolve(_.cloneDeep(tsResponse)))
           .mockImplementationOnce(() => Promise.resolve(_.cloneDeep(tsResponse)))
           .mockImplementationOnce(() => Promise.resolve(_.cloneDeep(tsResponse)))
           .mockImplementationOnce(() => Promise.resolve(_.cloneDeep(tsResponse)))
@@ -757,12 +765,13 @@ describe('CogniteDatasource', () => {
           .mockRejectedValueOnce(tsError)
           .mockImplementationOnce(x => Promise.resolve(getDataqueryResponse(x.data)))
           .mockImplementationOnce(x => Promise.resolve(getDataqueryResponse(x.data)))
+          .mockImplementationOnce(x => Promise.resolve(getDataqueryResponse(x.data)))
           .mockImplementationOnce(x => Promise.resolve(getDataqueryResponse(x.data)));
         result = await ctx.ds.query(ctx.options);
       });
 
       it('should generate the correct filtered queries', () => {
-        expect(ctx.backendSrvMock.datasourceRequest.mock.calls.length).toBe(17);
+        expect(ctx.backendSrvMock.datasourceRequest.mock.calls.length).toBe(19);
         for (let i = 0; i < ctx.backendSrvMock.datasourceRequest.mock.calls.length; ++i) {
           expect(ctx.backendSrvMock.datasourceRequest.mock.calls[i][0]).toMatchSnapshot();
         }
@@ -770,6 +779,10 @@ describe('CogniteDatasource', () => {
 
       it('should return correct datapoints and labels', () => {
         expect(result).toMatchSnapshot();
+      });
+
+      it('should call templateSrv.replace the correct number of times', () => {
+        expect(ctx.templateSrvMock.replace.mock.calls.length).toBe(89);
       });
 
       it('should display errors for malformed queries', () => {


### PR DESCRIPTION
Adding more variable support. 
`$Variable` or `[[Variable]]`  can now be used in labels, as well as outside of `timeseries{}` filters in custom queries (this allows you to do things like make a custom text box variable, and then having `timeseries{} $Variable`, thus making the query completely customizable via variables (set `$Variable` to things like ` + 100` or `* 3600`, etc.))