### PR TITLE
Allowing for the base url to be configured

### DIFF
--- a/src/partials/config.html
+++ b/src/partials/config.html
@@ -45,4 +45,23 @@
       </a>
     </div>
   </div>
+  <div class="gf-form-inline">
+    <div class="gf-form">
+      <span class="gf-form-label width-9">API url</span>
+      <input
+        type="text"
+        class="gf-form-input"
+        ng-model="ctrl.current.jsonData.cogniteApiUrl"
+        placeholder="api.cognitedata.com"
+      >
+      <info-popover mode="right-absolute">
+        <p>This is the URL used to reach the API.
+          If the project is deployed on the default multi-tenant installation (most are),
+          then keep the default value and do not change the URL.
+          If the project is deployed on a separate custom cluster,
+          then change the URL to point at the API server for that cluster.
+          If unsure, leave the URL as default.</p>
+      </info-popover>
+    </div>
+  </div>
 </div>

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -36,7 +36,7 @@
   "routes": [
     {
       "path": "cogniteapi",
-      "url": "https://api.cognitedata.com/api/0.5/projects",
+      "url": "https://{{if .JsonData.cogniteApiUrl}}{{.JsonData.cogniteApiUrl}}{{else}}api.cognitedata.com{{end}}/api/0.5/projects",
       "headers": [
         {
           "name": "api-key",
@@ -47,7 +47,7 @@
     {
       "path": "cogniteloginstatus",
       "method": "GET",
-      "url": "https://api.cognitedata.com/login/status",
+      "url": "https://{{if .JsonData.cogniteApiUrl}}{{.JsonData.cogniteApiUrl}}{{else}}api.cognitedata.com{{end}}/login/status",
       "headers": [
         {
           "name": "api-key",


### PR DESCRIPTION
Closes #66.

A little tricky because of backwards compatibility issues, since we are introducing a new template variable to the routes (which need a server reload upon any changes), which means that I got to learn about how Go's `template` works.
For any future references, [this is the code Grafana uses to update parts of the url](https://github.com/briangann/grafana/blob/d64971e35b09e13ff95624cadbe11141e2ae27eb/pkg/api/pluginproxy/utils.go#L30-L49).