### PR TITLE
Adding request cancellation

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -17,7 +17,7 @@ const queries = {
 };
 
 export const getQuery = async (query: DataSourceRequestOptions, backendSrv: BackendSrv) => {
-  const stringQuery = JSON.stringify(query);
+  const stringQuery = JSON.stringify({ ...query, requestId: undefined });
 
   if (queries.requests.has(stringQuery)) {
     return queries.requests.get(stringQuery);

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -189,6 +189,7 @@ export default class CogniteDatasource {
             url: `${this.url}/cogniteapi/${this.project}/timeseries/dataquery`,
             method: 'POST',
             data: q,
+            requestId: Utils.getRequestId(options, queryTargets[queries.findIndex(x => x === q)]),
           },
           this.backendSrv
         )
@@ -209,13 +210,16 @@ export default class CogniteDatasource {
         const refId = targetQueriesCount[i].refId;
         const target = queryTargets.find(x => x.refId === refId);
         if (isError(response)) {
-          let errmsg: string;
-          if (response.error.data && response.error.data.error) {
-            errmsg = `[${response.error.status} ERROR] ${response.error.data.error.message}`;
-          } else {
-            errmsg = 'Unknown error';
+          // if response was cancelled, no need to show error message
+          if (!response.error.cancelled) {
+            let errmsg: string;
+            if (response.error.data && response.error.data.error) {
+              errmsg = `[${response.error.status} ERROR] ${response.error.data.error.message}`;
+            } else {
+              errmsg = 'Unknown error';
+            }
+            target.error = errmsg;
           }
-          target.error = errmsg;
           count += targetQueriesCount[i].count; // skip over these labels
           return datapoints;
         }

--- a/src/spec/__snapshots__/datasource.test.ts.snap
+++ b/src/spec/__snapshots__/datasource.test.ts.snap
@@ -232,6 +232,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_10_A",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -254,6 +255,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_10_B",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -279,6 +281,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_10_C",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -298,6 +301,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_10_D",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -476,6 +480,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_5_A",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -495,6 +500,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_5_B",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -514,6 +520,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_5_C",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -601,6 +608,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_7_A",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -618,6 +626,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_7_B",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -637,6 +646,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_3_A",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -767,6 +777,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_14_A",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -786,6 +797,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_14_B",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -805,6 +817,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_14_C",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -822,6 +835,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_14_D",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -851,6 +865,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_14_E",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -1254,6 +1269,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_18_A",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -1298,6 +1314,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_18_B",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -1420,6 +1437,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_18_C",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -1458,6 +1476,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_18_D",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -1477,6 +1496,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_18_E",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -1496,6 +1516,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_18_F",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -2230,6 +2251,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_18_G",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -2274,6 +2296,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_18_H",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -2293,6 +2316,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_18_I",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -3024,6 +3048,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_22_A",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;
@@ -3051,6 +3076,7 @@ Object {
     "start": 1549336675000,
   },
   "method": "POST",
+  "requestId": "1_22_A",
   "url": "/api/datasources/proxy/6/cogniteapi/TestProject/timeseries/dataquery",
 }
 `;

--- a/src/spec/datasource.test.ts
+++ b/src/spec/datasource.test.ts
@@ -130,6 +130,7 @@ describe('CogniteDatasource', () => {
         maxDataPoints: 760,
         format: 'json',
         panelId: 1,
+        dashboardId: 1,
       };
     });
     beforeEach(() => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,7 @@ export interface DataQueryRequestResponse {
 
 export type DataQueryError = {
   error: {
+    cancelled?: boolean;
     data: {
       error?: {
         message: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -155,4 +155,9 @@ export default class Utils {
       target.assetQuery.templatedTarget
     }_${target.assetQuery.includeSubtrees}`;
   }
+
+  // used for generating the options.requestId
+  static getRequestId(options: QueryOptions, target: QueryTarget) {
+    return `${options.dashboardId}_${options.panelId}_${target.refId}`;
+  }
 }


### PR DESCRIPTION
Working on #63, and was looking at https://github.com/grafana/grafana/blob/master/public/app/core/services/backend_srv.ts in order to see if Grafana has implemented any type of retrying - but it seems like the retry option that is there is only used for grafana 401 errors.

Either way, I was able to find out that `backendSrv` does support cancelling requests that have the same `requestId` if a newer request is made, so I added in that support. Currently only adding this for `dataquery` requests (using `dashboardId_panelId_targetRefId` as the `requestId`) as most other requests don't really need this functionality. 
This should help to make #63 a bit easier to implement now, since we don't have to worry about cancellation tokens (see my comments there)
