### PR TITLE
V1 update

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -308,6 +308,11 @@ export default class CogniteDatasource {
       return [];
     }
 
+    // TODO (v1 migration)
+    // if we want to keep supporting things like `event{assetSubtrees=[$VAL_WELLS]}`
+    //  then we need to implement something here to get all the subassets, and then
+    //  replace that filter with "assetIds": [list of ids]
+
     // use maxStartTime and minEndTime so that we include events that are partially in range
     const queryParams = {
       limit: 1000,
@@ -321,9 +326,7 @@ export default class CogniteDatasource {
 
     const result = await cache.getQuery(
       {
-        url: `${this.url}/oldcogniteapi/${this.project}/events/search?${Utils.getQueryString(
-          queryParams
-        )}`,
+        url: `${this.url}/cogniteapi/${this.project}/events?${Utils.getQueryString(queryParams)}`,
         method: 'GET',
       },
       this.backendSrv
@@ -359,8 +362,9 @@ export default class CogniteDatasource {
       } else {
         urlEnd = `/cogniteapi/${this.project}/assets/search`;
         method = 'POST';
+        // TODO (v1 migration)
         // assets/search doesn't support query yet
-        // TODO: implement parallel calls to check for name and description, and then join results
+        // -> implement parallel calls to check for name and description, and then join results
         postBody = {
           search: {
             name: query,
@@ -375,7 +379,7 @@ export default class CogniteDatasource {
         method = 'POST';
         postBody = {
           search: {
-            query: query,
+            query,
           },
         };
       }

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -36,6 +36,16 @@
   "routes": [
     {
       "path": "cogniteapi",
+      "url": "https://{{if .JsonData.cogniteApiUrl}}{{.JsonData.cogniteApiUrl}}{{else}}api.cognitedata.com{{end}}/api/v1/projects",
+      "headers": [
+        {
+          "name": "api-key",
+          "content": "{{.SecureJsonData.cogniteDataPlatformApiKey}}"
+        }
+      ]
+    },
+    {
+      "path": "oldcogniteapi",
       "url": "https://{{if .JsonData.cogniteApiUrl}}{{.JsonData.cogniteApiUrl}}{{else}}api.cognitedata.com{{end}}/api/0.5/projects",
       "headers": [
         {

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,7 @@ export interface TimeSeriesResponseItem {
 
 export interface TimeSeriesResponse {
   items: TimeSeriesResponseItem[];
+  nextCursor: string;
 }
 
 export interface AssetQuery {
@@ -243,6 +244,14 @@ export interface TimeseriesSearchQuery {
   includeMetadata: boolean;
   path: string[];
   assetId: string;
+}
+
+export interface TimeseriesListQuery {
+  limit?: number;
+  includeMetadata?: boolean;
+  cursor?: string;
+  assetIds?: number[];
+  rootAssetIds?: number[];
 }
 
 export interface VariableQueryData {

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,9 +47,7 @@ export interface TimeSeriesResponseItem {
 }
 
 export interface TimeSeriesResponse {
-  data: {
-    items: TimeSeriesResponseItem[];
-  };
+  items: TimeSeriesResponseItem[];
 }
 
 export interface AssetQuery {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -160,4 +160,16 @@ export default class Utils {
   static getRequestId(options: QueryOptions, target: QueryTarget) {
     return `${options.dashboardId}_${options.panelId}_${target.refId}`;
   }
+
+  static getFilterVal(filter: string) {
+    if (filter.length === 0) return filter;
+    // check if it array-like
+    if (filter.slice(0, 1) === '[' && filter.slice(-1) === ']') {
+      try {
+        return JSON.parse(filter);
+      } catch {}
+    }
+
+    return filter;
+  }
 }


### PR DESCRIPTION
Converting api calls from v0.5 to v1.
- Currently, all api calls except for `/dataquery` have been converted to use the corresponding v1 endpoints (that still requires v0.5 synthetic timeseries). 
- Additionally, we are no longer using `assetSubtrees` or similar calls - this has been replaced with cursoring + paging through child assets (something to note is that we are still using the old limits here, as going above severely affects performance)

Things left to do:
- need to determine if we still want to support `assetSubtree` for events/annotations and assets/variables. I believe this is being used by people, and removing that support would affect backwards compatibility (it's very useful when used with template variables, eg `event{assetSubtrees=[$VAL_WELLS]}`). 
    - Supporting this would require additional logic to check if that filter is being used, and then constructing additional calls by fetching the subassets and then use those as part of the `parentId` filter parameter. 
    - Another option would be to remove that support, and instead implement cursoring here (currently isn't implemented). Again, not sure what effect this might have on performance, but I have had issues in the past with Grafana crashing when there are a ridiculous number of events being shown (something that would be a larger possibility if we allow cursoring)
- assets/search doesn't support query, so we need to do some parallel calls for the asset search dropdown to work as before
- determining what we want to do with limits?
- fixing tests + a lot more tests to make sure nothing is broken
- extra documentation for stuff that's been changed - especially relevant if we keep `assetSubtrees` in annotations/variables