### PR TITLE
fixing parser for special functions and regex groups

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -52,8 +52,9 @@ const parseSpecialFunctions = (
   templateSrv: TemplateSrv
 ) => {
   let newExpr = expr;
-  // look for sum(), max(), min(), or avg() with timeseries in it
-  const funcRegex = /(sum|max|min|avg)\(timeseries.*?\)/gi;
+  // look for sum(), max(), min(), or avg() with timeseries{} or timeseries{}[] in it
+  // this is not perfect, but should cover the vast majority of cases..
+  const funcRegex = /(sum|max|min|avg)\(timeseries{.*?}(?:\[.*?\])*?\)/gi;
   const funcRegexMatches = newExpr.match(funcRegex);
   if (funcRegexMatches) {
     for (const match of funcRegexMatches) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -54,7 +54,7 @@ const parseSpecialFunctions = (
   let newExpr = expr;
   // look for sum(), max(), min(), or avg() with timeseries{} or timeseries{}[] in it
   // this is not perfect, but should cover the vast majority of cases..
-  const funcRegex = /(sum|max|min|avg)\(timeseries{.*?}(?:\[.*?\])*?\)/gi;
+  const funcRegex = /(sum|max|min|avg)\(timeseries((?!timeseries{).)*?}(\[.*?\])?\)/gi;
   const funcRegexMatches = newExpr.match(funcRegex);
   if (funcRegexMatches) {
     for (const match of funcRegexMatches) {


### PR DESCRIPTION
Fixes the case where we have something like:
`Sum(timeseries{name=~"(Gas|Oil).*"}[avg])`

Previously the parser would get confused by the `)` from the regex group filter.