### PR TITLE
fix: array sts server filters

### DIFF
--- a/src/parser/ts/grammar.ne
+++ b/src/parser/ts/grammar.ne
@@ -1,11 +1,11 @@
 @preprocessor typescript
 
-
 @builtin "number.ne"
 @builtin "string.ne"
 
 @{%
-const join = ([d]) => d.join('');
+const join = ([d]) => joinArr(d);
+const joinArr = (d) => d.join('');
 const formatQuery = ([type, query]) => ({type, query});
 const extractPair = d => {
   return {
@@ -103,8 +103,6 @@ const extractFunction = ([func, br, args, BR]) => {
   return { func }
 }
 
-const extractVariable = ([_, d]) => "$" + d;
-
 const emptyObject = () => ({});
 const emptyArray = () => ([]);
 %}
@@ -166,8 +164,11 @@ value ->
   | "false" {% () => false %}
   | "null" {% () => null %}
 
-variable -> "$" prop_name {% extractVariable %}
-  | "[[" prop_name "]]" {% extractVariable %}
+variable -> "$" prop_name {% joinArr %}
+  | "[[" prop_name "]]" {% joinArr %}
+  | "$" advanced_variable {% joinArr %}
+  
+advanced_variable -> "{" prop_name ":" prop_name "}" {% joinArr %}
 
 operator -> _ "+" _ {% extractOperator %}
   | _ "-" _ {% extractOperator %}

--- a/src/parser/ts/grammar.ts
+++ b/src/parser/ts/grammar.ts
@@ -4,7 +4,8 @@
 // @ts-ignore
 function id(d: any[]): any { return d[0]; }
 
-const join = ([d]) => d.join('');
+const join = ([d]) => joinArr(d);
+const joinArr = (d) => d.join('');
 const formatQuery = ([type, query]) => ({type, query});
 const extractPair = d => {
   return {
@@ -101,8 +102,6 @@ const extractFunction = ([func, br, args, BR]) => {
   }
   return { func }
 }
-
-const extractVariable = ([_, d]) => "$" + d;
 
 const emptyObject = () => ({});
 const emptyArray = () => ([]);
@@ -320,10 +319,12 @@ const grammar: Grammar = {
     {"name": "value", "symbols": ["value$string$2"], "postprocess": () => false},
     {"name": "value$string$3", "symbols": [{"literal":"n"}, {"literal":"u"}, {"literal":"l"}, {"literal":"l"}], "postprocess": (d) => d.join('')},
     {"name": "value", "symbols": ["value$string$3"], "postprocess": () => null},
-    {"name": "variable", "symbols": [{"literal":"$"}, "prop_name"], "postprocess": extractVariable},
+    {"name": "variable", "symbols": [{"literal":"$"}, "prop_name"], "postprocess": joinArr},
     {"name": "variable$string$1", "symbols": [{"literal":"["}, {"literal":"["}], "postprocess": (d) => d.join('')},
     {"name": "variable$string$2", "symbols": [{"literal":"]"}, {"literal":"]"}], "postprocess": (d) => d.join('')},
-    {"name": "variable", "symbols": ["variable$string$1", "prop_name", "variable$string$2"], "postprocess": extractVariable},
+    {"name": "variable", "symbols": ["variable$string$1", "prop_name", "variable$string$2"], "postprocess": joinArr},
+    {"name": "variable", "symbols": [{"literal":"$"}, "advanced_variable"], "postprocess": joinArr},
+    {"name": "advanced_variable", "symbols": [{"literal":"{"}, "prop_name", {"literal":":"}, "prop_name", {"literal":"}"}], "postprocess": joinArr},
     {"name": "operator", "symbols": ["_", {"literal":"+"}, "_"], "postprocess": extractOperator},
     {"name": "operator", "symbols": ["_", {"literal":"-"}, "_"], "postprocess": extractOperator},
     {"name": "operator", "symbols": ["_", {"literal":"/"}, "_"], "postprocess": extractOperator},

--- a/src/parser/ts/parser.unit.test.ts
+++ b/src/parser/ts/parser.unit.test.ts
@@ -68,6 +68,16 @@ describe('get timeseries filters from parsed data', () => {
       expect(getServerFilters(testSeries)).toStrictEqual([{}, { name: 'value' }]);
     });
 
+    it('array filter', () => {
+      const nested = [STS([Filter('assetIds', [123])])];
+      expect(getServerFilters(nested)).toStrictEqual([{ assetIds: [123] }]);
+    });
+
+    it('array nested filter', () => {
+      const nested = [STS([Filter('assetIds', [Filter('id', 1)])])];
+      expect(getServerFilters(nested)).toStrictEqual([{ assetIds: [{ id: 1 }] }]);
+    });
+
     it('nested', () => {
       const nested = [STS([Filter('a', [Filter('b', 'c', '!~')])])];
       expect(getServerFilters(nested)).toStrictEqual([{}]);

--- a/src/parser/ts/parser.unit.test.ts
+++ b/src/parser/ts/parser.unit.test.ts
@@ -202,7 +202,12 @@ describe('nearley parser', () => {
 
   it('template variables', () => {
     const res = parse(`ts{id=[[asset]]}`);
-    expect(res).toEqual(STS([Filter('id', '$asset')]));
+    expect(res).toEqual(STS([Filter('id', '[[asset]]')]));
+  });
+
+  it('advanced template variable', () => {
+    const res = parse('ts{id=${asset:json}}');
+    expect(res).toEqual(STS([Filter('id', '${asset:json}')]));
   });
 });
 


### PR DESCRIPTION
basically new tests should be self explanatory
there was one bug, that didn't allow doing any array filtering.
also as a bonus added support for advanced grafana variables. (it allows variable formatting)