### PR TITLE
fix: expand description with a docs links

### DIFF
--- a/src/partials/annotations.editor.html
+++ b/src/partials/annotations.editor.html
@@ -22,10 +22,10 @@
     </div>
     <div class="gf-form--grow" ng-show="showHelpQuery">
       <pre>
-Query for events uses the 'events/list' endpoint. For request parameters <code class="query-keyword">'='</code> sign is used.
+Annotation query uses the <a class="query-keyword" href="https://docs.cognite.com/api/v1/#operation/advancedListEvents" target="_blank">events/list</a> endpoint for data fetching. <code class="query-keyword">'='</code> sign is used to provide parameters for the request.
   Format: <code class="query-keyword">events{param=number, ...}</code>
   Example: <code class="query-keyword">events{type='WORKORDER', assetSubtreeIds=[{id=12}, {externalId='external'}]}</code>
-  Filtering available by adding <code class="query-keyword">'=~'</code>, <code class="query-keyword">'!~'</code> and <code class="query-keyword">'!='</code> signs to filtered props. Applying few filters for query acts as logic AND
+  Results filtering is available by adding <code class="query-keyword">'=~'</code>, <code class="query-keyword">'!~'</code> and <code class="query-keyword">'!='</code> signs to filtered props. Applying few filters for query acts as logic AND
   Format:
     <code class="query-keyword">'=~'</code> – regex equality, means that provided regexp is used to match defined prop and matched value will be included
     <code class="query-keyword">'!~'</code> – regex inequality, means that provided regexp is used to match defined prop and matched value will be excluded

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -153,15 +153,20 @@
   Format: <code class="query-keyword">ts{options}</code><br>
   Options are of the form: <code class="query-keyword">PROPERTY COMPARATOR VALUE</code><br>
   Comparator can be either
-    =  (strict equality),
-    != (strict inequality),
-    =~ (regex equality),
-    !~ (regex inequality)<br>
+    <code class="query-keyword">=</code> (strict equality),
+    <code class="query-keyword">!=</code> (strict inequality),
+    <code class="query-keyword">=~</code> (regex equality),
+    <code class="query-keyword">!~</code> (regex inequality)<br>
   If you want to reference a specific timeseries, use <code class="query-keyword">ts{id=ID}</code>, or <code class="query-keyword">ts{id=ID, aggregate=AGGREGATE, granularity=GRANULARITY}</code>.
   Example:  <code class="query-keyword">sum(ts{metadata{type="TEMP"}}) - ts{id=12345678}</code>
 
   Templated variables can also be used with <code class="query-keyword">$variable</code>.
-  Example: <code class="query-keyword">ts{assetIds=[$asset], metadata={key1=~'.*test.*'}, isStep=1, granularity='12h', aggregate='average}</code> <br>
+  Example: <code class="query-keyword">ts{assetIds=[$asset], metadata={key1=~'.*test.*'}, isStep=1, granularity='12h', aggregate='average}</code>
+
+  In case of multi-value variable, return value can be formatted. To format variable value use <code class="query-keyword">${variable:[formatter]}</code>.
+  Example: <code class="query-keyword">ts{assetIds=[${asset:csv}], granularity='12h', aggregate='average}</code> <br>
+  Check <a class="query-keyword" href="https://grafana.com/docs/grafana/latest/reference/templating/#advanced-formatting-options" target="_blank">Grafana documentation</a> to get list of available formatters.
+
   Synthetic timeseries functions can also be applied on one or multiple timeseries.
   Example: <code class="query-keyword">(ts{name=~'.*temp.*', aggregate='average'} - 32) * 5/9</code>
             <code class="query-keyword">ts{} + sin(ts{granularity='24h', aggregate='average'})</code><br>
@@ -173,7 +178,7 @@
             <code class="query-keyword">pow(ts{} - avg(ts{}), 2)</code>
               ↪ yields the squared deviation of each timeseries from the average <br>
   There is a support for some advanced functions, like <code class="query-keyword">round</code>, <code class="query-keyword">on_error</code> and <code class="query-keyword">map</code>.
-  The documentation on how to use them can be found on <a href="https://docs.cognite.com/api">docs.cognite.com/api</a><br>
+  The documentation on how to use them can be found on <a class="query-keyword" href="https://docs.cognite.com/api">docs.cognite.com/api</a>
     </pre>
   </div>
 </script>

--- a/src/variable_query_ctrl.tsx
+++ b/src/variable_query_ctrl.tsx
@@ -4,8 +4,8 @@ import { parse } from './parser/events-assets';
 
 const help = (
   <pre>
-    Query for assets uses the '/assets/list' endpoint. For request parameters{' '}
-    <code className="query-keyword">'='</code> sign is used.
+    Variable query uses the <a className="query-keyword" href="https://docs.cognite.com/api/v1/#operation/listAssets" target="_blank">assets/list</a> endpoint for data fetching.{' '}
+    <code className="query-keyword">'='</code> sign is used to provide parameters for the request.
     <br />
     Format: <code className="query-keyword">{`assets{param=value,...}`}</code>
     <br />
@@ -13,10 +13,10 @@ const help = (
     <code className="query-keyword">{`assets{assetSubtreeIds=[{id=123}, {externalId='external'}]`}</code>
     <br />
     <br />
-    Filtering through the results also possible by adding{' '}
+    Results filtering is also possible by adding{' '}
     <code className="query-keyword">'=~'</code>, <code className="query-keyword">'!~'</code> and{' '}
     <code className="query-keyword">'!='</code> signs to props. Applying few filters for query acts
-    as AND
+    as logic AND
     <br />
     Format:
     <br />


### PR DESCRIPTION
add links to documentation in help sections of:
- synthetic TS query field
- annotations
- variables