### PR TITLE
fix: default values of aggregates in STS

### DIFF
--- a/src/__tests__/__snapshots__/datasource.test.ts.snap
+++ b/src/__tests__/__snapshots__/datasource.test.ts.snap
@@ -258,7 +258,7 @@ Object {
         "id": 123,
       },
     ],
-    "limit": 100000,
+    "limit": 10000,
     "start": 1549336675000,
   },
   "method": "POST",
@@ -379,7 +379,7 @@ Object {
       Object {
         "end": 1549338475000,
         "expression": "ts{externalId=\\"Timeseries1\\"}",
-        "limit": 100000,
+        "limit": 10000,
         "start": 1549336675000,
       },
     ],
@@ -465,20 +465,20 @@ Object {
     "items": Array [
       Object {
         "end": 1549338475000,
-        "expression": "ts{id=1} + pi()",
-        "limit": 33333,
+        "expression": "ts{id=1, aggregate=\\"none\\", granularity=\\"30s\\"} + pi()",
+        "limit": 3333,
         "start": 1549336675000,
       },
       Object {
         "end": 1549338475000,
-        "expression": "ts{id=2} + pi()",
-        "limit": 33333,
+        "expression": "ts{id=2, aggregate=\\"none\\", granularity=\\"30s\\"} + pi()",
+        "limit": 3333,
         "start": 1549336675000,
       },
       Object {
         "end": 1549338475000,
-        "expression": "ts{id=3} + pi()",
-        "limit": 33333,
+        "expression": "ts{id=3, aggregate=\\"none\\", granularity=\\"30s\\"} + pi()",
+        "limit": 3333,
         "start": 1549336675000,
       },
     ],
@@ -495,19 +495,19 @@ Object {
     "items": Array [
       Object {
         "end": 1549338475000,
-        "expression": "ts{id=1} * ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\"} - ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\", granularity=\\"10m\\"}",
+        "expression": "ts{id=1, aggregate=\\"none\\", granularity=\\"30s\\"} * ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\", granularity=\\"30s\\"} - ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\", granularity=\\"10m\\"}",
         "limit": 3333,
         "start": 1549336675000,
       },
       Object {
         "end": 1549338475000,
-        "expression": "ts{id=2} * ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\"} - ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\", granularity=\\"10m\\"}",
+        "expression": "ts{id=2, aggregate=\\"none\\", granularity=\\"30s\\"} * ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\", granularity=\\"30s\\"} - ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\", granularity=\\"10m\\"}",
         "limit": 3333,
         "start": 1549336675000,
       },
       Object {
         "end": 1549338475000,
-        "expression": "ts{id=3} * ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\"} - ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\", granularity=\\"10m\\"}",
+        "expression": "ts{id=3, aggregate=\\"none\\", granularity=\\"30s\\"} * ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\", granularity=\\"30s\\"} - ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\", granularity=\\"10m\\"}",
         "limit": 3333,
         "start": 1549336675000,
       },

--- a/src/__tests__/__snapshots__/datasource.test.ts.snap
+++ b/src/__tests__/__snapshots__/datasource.test.ts.snap
@@ -258,7 +258,7 @@ Object {
         "id": 123,
       },
     ],
-    "limit": 10000,
+    "limit": 100000,
     "start": 1549336675000,
   },
   "method": "POST",

--- a/src/__tests__/__snapshots__/datasource.test.ts.snap
+++ b/src/__tests__/__snapshots__/datasource.test.ts.snap
@@ -465,19 +465,19 @@ Object {
     "items": Array [
       Object {
         "end": 1549338475000,
-        "expression": "ts{id=1, aggregate=\\"none\\", granularity=\\"30s\\"} + pi()",
+        "expression": "ts{id=1} + pi()",
         "limit": 3333,
         "start": 1549336675000,
       },
       Object {
         "end": 1549338475000,
-        "expression": "ts{id=2, aggregate=\\"none\\", granularity=\\"30s\\"} + pi()",
+        "expression": "ts{id=2} + pi()",
         "limit": 3333,
         "start": 1549336675000,
       },
       Object {
         "end": 1549338475000,
-        "expression": "ts{id=3, aggregate=\\"none\\", granularity=\\"30s\\"} + pi()",
+        "expression": "ts{id=3} + pi()",
         "limit": 3333,
         "start": 1549336675000,
       },
@@ -495,19 +495,19 @@ Object {
     "items": Array [
       Object {
         "end": 1549338475000,
-        "expression": "ts{id=1, aggregate=\\"none\\", granularity=\\"30s\\"} * ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\", granularity=\\"30s\\"} - ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\", granularity=\\"10m\\"}",
+        "expression": "ts{id=1} * ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\"} - ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\", granularity=\\"10m\\"}",
         "limit": 3333,
         "start": 1549336675000,
       },
       Object {
         "end": 1549338475000,
-        "expression": "ts{id=2, aggregate=\\"none\\", granularity=\\"30s\\"} * ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\", granularity=\\"30s\\"} - ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\", granularity=\\"10m\\"}",
+        "expression": "ts{id=2} * ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\"} - ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\", granularity=\\"10m\\"}",
         "limit": 3333,
         "start": 1549336675000,
       },
       Object {
         "end": 1549338475000,
-        "expression": "ts{id=3, aggregate=\\"none\\", granularity=\\"30s\\"} * ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\", granularity=\\"30s\\"} - ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\", granularity=\\"10m\\"}",
+        "expression": "ts{id=3} * ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\"} - ts{externalId=\\"Timeseries1\\", aggregate=\\"average\\", granularity=\\"10m\\"}",
         "limit": 3333,
         "start": 1549336675000,
       },

--- a/src/cdfDatasource.ts
+++ b/src/cdfDatasource.ts
@@ -28,7 +28,7 @@ import { getLabelsForExpression } from './parser/ts';
 import { getRange } from './datasource';
 import { TimeSeries } from '@grafana/ui';
 import { appEvents } from 'grafana/app/core/core';
-import { datapointsLimit, failedResponseEvent, CacheTime, DATAPOINTS_LIMIT_WARNING } from './constants';
+import { failedResponseEvent, CacheTime, DATAPOINTS_LIMIT_WARNING } from './constants';
 
 const { Asset, Custom, Timeseries } = Tab;
 
@@ -52,7 +52,7 @@ export function formQueryForItems(
       granularity: granularity || ms2String(options.intervalMs),
     };
   }
-  const limit = calculateDPLimitPerQuery(items.length);
+  const limit = calculateDPLimitPerQuery(items.length, isAggregated);
   return {
     ...aggregations,
     end,
@@ -62,8 +62,8 @@ export function formQueryForItems(
   };
 }
 
-function calculateDPLimitPerQuery(queriesNumber: number) {
-  return Math.floor(datapointsLimit / Math.min(queriesNumber, 100));
+function calculateDPLimitPerQuery(queriesNumber: number, hasAggregates: boolean = true) {
+  return Math.floor((hasAggregates ? 10_000 : 100_000) / Math.min(queriesNumber, 100));
 }
 
 export function formQueriesForTargets(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,4 +13,3 @@ export const CacheTime = {
   TimeseriesByIds: '61m',
   Default: '11s',
 };
-export const datapointsLimit = 10_000;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,3 +13,4 @@ export const CacheTime = {
   TimeseriesByIds: '61m',
   Default: '11s',
 };
+export const datapointsLimit = 10_000;

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -151,7 +151,7 @@ export default class CogniteDatasource {
       }
       case Tab.Custom: {
         const templatedExpr = this.replaceVariable(expr, options.scopedVars);
-        return formQueriesForExpression(templatedExpr, target, this.connector);
+        return formQueriesForExpression(templatedExpr, target, this.connector, options);
       }
     }
   }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -151,7 +151,7 @@ export default class CogniteDatasource {
       }
       case Tab.Custom: {
         const templatedExpr = this.replaceVariable(expr, options.scopedVars);
-        return formQueriesForExpression(templatedExpr, target, this.connector, options);
+        return formQueriesForExpression(templatedExpr, target, this.connector, options.interval);
       }
     }
   }

--- a/src/parser/ts/index.ts
+++ b/src/parser/ts/index.ts
@@ -22,10 +22,10 @@ export const formQueriesForExpression = async (
   expression: string,
   target: QueryTarget,
   connector: Connector,
-  options: QueryOptions
+  defaultInterval: string
 ): Promise<DataQueryRequestItem[]> => {
   const rawParsed = parse(expression);
-  const defaultGranularity = target.granularity || options.interval;
+  const defaultGranularity = target.granularity || defaultInterval;
   const defaultAggregation = target.aggregation;
   const parsed =
     defaultAggregation === 'none'

--- a/src/parser/ts/index.ts
+++ b/src/parser/ts/index.ts
@@ -27,10 +27,13 @@ export const formQueriesForExpression = async (
   const rawParsed = parse(expression);
   const defaultGranularity = target.granularity || options.interval;
   const defaultAggregation = target.aggregation;
-  const parsed = injectAggregatesToParsed(rawParsed, {
-    aggregate: defaultAggregation,
-    granularity: defaultGranularity,
-  });
+  const parsed =
+    defaultAggregation === 'none'
+      ? rawParsed
+      : injectAggregatesToParsed(rawParsed, {
+          aggregate: defaultAggregation,
+          granularity: defaultGranularity,
+        });
   const serverFilters = getServerFilters(parsed);
   if (!serverFilters.length) {
     return [{ expression }];

--- a/src/parser/ts/index.ts
+++ b/src/parser/ts/index.ts
@@ -56,8 +56,7 @@ const NoTimeseriesFound = (filter: StringMap, expr: string) => {
 };
 
 /**
- * Injects default values of aggregate and granularity (if it is not provided).
- * Mutates <query> properties array with default aggregate or granularity values.
+ * Injects default values of aggregate and granularity (if it is not provided).s
  * @param parsedData: synthetic timeseries parsed data
  * @param target: {aggregation, granularity}
  * @param defaultInterval – interval that comes from grafana options

--- a/src/parser/ts/parser.unit.test.ts
+++ b/src/parser/ts/parser.unit.test.ts
@@ -499,13 +499,13 @@ describe('check if default aggregation and granularity will be added', () => {
   const defaultInterval = '6h';
   it('should add default aggregate and granularity', () => {
     const stsWithoutAggregation = STS([Filter('name', 'name')]);
-    const withoutAggregates = enrichWithDefaultAggregates(
+    const withAggregates = enrichWithDefaultAggregates(
       stsWithoutAggregation,
       defaults,
       defaultInterval
     );
 
-    expect(withoutAggregates).toEqual(
+    expect(withAggregates).toEqual(
       STS([Filter('name', 'name'), Filter('aggregate', 'average'), Filter('granularity', '1h')])
     );
   });

--- a/src/parser/ts/parser.unit.test.ts
+++ b/src/parser/ts/parser.unit.test.ts
@@ -536,4 +536,10 @@ describe('check if default aggregation and granularity will be added', () => {
 
     expect(withAggregatesAndGranularity).toEqual(stsWithAggregateAndGranularity);
   });
+  it('should not add default values in case of default aggregate is none', () => {
+    const sts = STS([Filter('name', 'name')]);
+    const stsWithInjected = injectAggregatesToParsed(sts, { aggregate: 'none', granularity: '2h' });
+
+    expect(sts).toEqual(sts);
+  });
 });

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -128,11 +128,24 @@
         </span>
       </info-popover>
     </div>
+    <div class="gf-form">
+      <label class="gf-form-label query-keyword fix-query-keyword">Aggregation</label>
+      <select class="gf-form-input" ng-model="ctrl.target.aggregation" ng-init="ctrl.getInitAggregate()" ng-change="ctrl.refreshData()">
+        <option ng-repeat="fn in ctrl.customTabAggregation" value="{{fn.value}}">{{fn.name}}</option>
+      </select>
+    </div>
+    <div class="gf-form" ng-if="ctrl.target.aggregation && ctrl.target.aggregation !== 'none'">
+      <label class="gf-form-label query-keyword fix-query-keyword">Granularity</label>
+      <input type="text" class="gf-form-input width-8" ng-model="ctrl.target.granularity" ng-blur="ctrl.refreshData()" placeholder="default"/>
+      <info-popover mode="right-absolute">
+        The granularity of the aggregate values. Valid entries are: 'day' (or 'd'), 'hour' (or 'h'), 'minute' (or 'm'), 'second' (or 's'). Example: 12h.
+      </info-popover>
+    </div>
   </div>
-  <div class="gf-form" ng-init>
-      <label class="gf-form-label query-keyword fix-query-keyword width-8">Filter</label>
-      <input type="text" class="gf-form-input custom-query width-auto" ng-model="ctrl.target.expr" ng-change="ctrl.onChangeQuery()" ng-blur="ctrl.refreshData()" placeholder=""/>
-      <info-popover mode="right-absolute" ng-click="showHelp = !showHelp">Click for help</info-popover>
+  <div class="gf-form gf-form--grow" ng-init>
+    <label class="gf-form-label query-keyword fix-query-keyword width-8">Query</label>
+    <input type="text" class="gf-form-input custom-query width-auto" ng-model="ctrl.target.expr" ng-change="ctrl.onChangeQuery()" ng-blur="ctrl.refreshData()" placeholder=""/>
+    <info-popover mode="right-absolute" ng-click="showHelp = !showHelp">Click for help</info-popover>
   </div>
   <div class="gf-form--grow" ng-show="showHelp">
       <pre>

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -27,6 +27,7 @@ export class CogniteQueryCtrl extends QueryCtrl {
     { value: 'totalVariation', name: 'Total Variation' },
   ];
   customTabAggregation = [
+    { value: 'none', name: 'None' },
     { value: 'average', name: 'Average' },
     { value: 'interpolation', name: 'Interpolation' },
     { value: 'stepInterpolation', name: 'Step Interpolation' },

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -26,6 +26,11 @@ export class CogniteQueryCtrl extends QueryCtrl {
     { value: 'discreteVariance', name: 'Discrete Variance' },
     { value: 'totalVariation', name: 'Total Variation' },
   ];
+  customTabAggregation = [
+    { value: 'average', name: 'Average' },
+    { value: 'interpolation', name: 'Interpolation' },
+    { value: 'stepInterpolation', name: 'Step Interpolation' },
+  ];
   tabs = [
     {
       value: Tab.Timeseries,
@@ -117,6 +122,13 @@ export class CogniteQueryCtrl extends QueryCtrl {
       return `Custom Query: ${this.target.expr} ${this.target.error}`;
     }
     return '';
+  }
+
+  getInitAggregate() {
+    if (_.findIndex(this.customTabAggregation, ['value', this.target.aggregation]) === -1) {
+      this.target.aggregation = this.customTabAggregation[0].value;
+      this.refresh();
+    }
   }
 
   $onDestroy() {


### PR DESCRIPTION
Add default values of aggregation and granularity for synthetic timeseries if they are not provided.