### PR TITLE
fix(custom-query): properly display pure text labels [CDF-8145]

### DIFF
--- a/src/__tests__/cdfDatasource.test.ts
+++ b/src/__tests__/cdfDatasource.test.ts
@@ -1,4 +1,9 @@
-import { datapoints2Tuples, promiser, reduceTimeseries } from '../cdfDatasource';
+import {
+  datapoints2Tuples,
+  promiser,
+  reduceTimeseries,
+  labelContainsVariableProps,
+} from '../cdfDatasource';
 import { getDataqueryResponse, getMeta } from './utils';
 
 describe('CDF datasource', () => {
@@ -73,6 +78,16 @@ describe('CDF datasource', () => {
           },
         ],
       });
+    });
+  });
+
+  describe('label contains {{}}', () => {
+    test('{{prop}}', () => {
+      expect(labelContainsVariableProps('anything {{prop}}')).toEqual(true);
+    });
+
+    test('no props', () => {
+      expect(labelContainsVariableProps('pure text')).toEqual(false);
     });
   });
 });

--- a/src/__tests__/datasource.test.ts
+++ b/src/__tests__/datasource.test.ts
@@ -26,22 +26,21 @@ const tsError = {
   },
 };
 const externalIdPrefix = 'Timeseries';
+const options: any = {
+  targets: [],
+  range: {
+    from: '1549336675000',
+    to: '1549338475000',
+  },
+  interval: '30s',
+  intervalMs: ms('30s'),
+  maxDataPoints: 760,
+  format: 'json',
+  panelId: 1,
+  dashboardId: 1,
+};
 
 describe('Datasource Query', () => {
-  const options: any = {
-    targets: [],
-    range: {
-      from: '1549336675000',
-      to: '1549338475000',
-    },
-    interval: '30s',
-    intervalMs: ms('30s'),
-    maxDataPoints: 760,
-    format: 'json',
-    panelId: 1,
-    dashboardId: 1,
-  };
-
   beforeEach(() => {
     jest.useFakeTimers();
   });
@@ -540,5 +539,27 @@ describe('Datasource Query', () => {
         `events{assetIds=[123,456], type="type_or_subtype", subtype="type_or_subtype"}`
       );
     });
+  });
+});
+
+describe('Given custom query with pure text label', () => {
+  beforeAll(async () => {
+    jest.clearAllMocks();
+    backendSrvMock.datasourceRequest = jest.fn().mockImplementation(async x => {
+      return getDataqueryResponse(x.data, externalIdPrefix, 0);
+    });
+  });
+
+  it('should return pure text label', async () => {
+    const targetA: QueryTargetLike = {
+      tab: Tab.Custom,
+      expr: 'ts{id=1}',
+      label: 'Pure text',
+    };
+    const result = await ds.query({
+      ...options,
+      targets: [targetA],
+    });
+    expect(result.data[0].target).toEqual('Pure text');
   });
 });


### PR DESCRIPTION
Custom query: display legend labels as a plain text instead of expression.
Example for query `ts{id=1} + ts{id=2} + 1`:
- user label `{{name}}` will result to `timeseries_name_1 + timeseries_name_2 + 1` label (as it used to work)
- user label `Cool custom name` will result to `Cool custom name` label (since no specific timeseries props referenced) 