### PR TITLE
feat: custom query datapoints alignment

### DIFF
--- a/src/components/queryHelp.tsx
+++ b/src/components/queryHelp.tsx
@@ -25,7 +25,8 @@ export const customQueryHelp = (
       If you want to reference a specific time series, use:
       <br />
       <Code>{'ts{id=ID}'}</Code>, or{' '}
-      <Code>{`ts{id=ID, aggregate='AGGREGATE', granularity='GRANULARITY'}`}</Code>.<br />
+      <Code>{`ts{externalId='EXTERNAL_ID', aggregate='AGGREGATE', granularity='GRANULARITY', alignment=ALIGNMENT}`}</Code>
+      .<br />
       Example: <Code>{`sum(ts{metadata{type="TEMP"}}) - ts{id=12345678}`}</Code>
       <br />
       <br />
@@ -80,7 +81,7 @@ export const customQueryHelp = (
         className="query-keyword"
         href="https://docs.cognite.com/dev/concepts/resource_types/timeseries.html#synthetic-time-series"
       >
-        docs.cognite.com/api
+        docs.cognite.com/dev
       </a>
       .<br />
       <br />

--- a/src/parser/ts/index.ts
+++ b/src/parser/ts/index.ts
@@ -189,16 +189,6 @@ export const getReferencedTimeseries = (route: STSQuery): StringMap[] => {
   }));
 };
 
-export const hasAggregates = (expression: string): boolean => {
-  let hasAggregates = false;
-  walk(parse(expression), obj => {
-    if (isSTSReference(obj) && obj.query.some(isSTSAggregateFilter)) {
-      hasAggregates = true;
-    }
-  });
-  return hasAggregates;
-};
-
 export const flattenServerQueryFilters = (items: unknown[]): StringMap => {
   return items.filter(isSTSFilter).reduce((res, filter) => {
     let value: any;
@@ -416,7 +406,7 @@ const isOneOf = (value: string, ...arr: string[]) => {
 };
 
 const isSTSAggregateFilter = (query: STSFilter) => {
-  return isEqualsFilter(query) && isOneOf(query.path, 'granularity', 'aggregate');
+  return isEqualsFilter(query) && isOneOf(query.path, 'granularity', 'aggregate', 'alignment');
 };
 
 const isIdsFilter = (query: STSFilter): query is STSServerFilter => {


### PR DESCRIPTION
this supports `ts{alignment=....}` synthetic timeseries alignment feature together with filters.
previously it only worked if qeury was locked to a specific time series `ts{id=.., alignment=....}`