### PR TITLE
chore: require grafana 7.0.6

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -29,7 +29,7 @@
   },
 
   "dependencies": {
-    "grafanaVersion": "7.0.6",
+    "grafanaDependency": "7.0.6",
     "plugins": []
   },
 


### PR DESCRIPTION
`grafanaVersion` is deprecated now, `grafanaDependency` is requred by the new rules.
grafanaDependency basically makes sure it won't be run on grafana 6.