### PR TITLE
Release 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This article documents the ongoing improvements we're making to the **Cognite Data Source for Grafana**.
 
+
+## 2.1.1 - November 23, 2020
+
+### Bug fixes:
+- Support variables in `time series by asset` query.
+In version 2.1.0 `$variable` used as an `Asset tag` worked for earlier created dashboards, but it was impossible to create a new panel with the same capability.
+
+
 ## 2.1.0 - November 19, 2020
 
 * The data source requires Grafana version `7.0.6` or above.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/cognite-grafana-datasource",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Cognite Data Fusion datasource",
   "repository": "https://github.com/cognitedata/cognite-grafana-datasource",
   "author": "Cognite AS",

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -29,7 +29,7 @@
   },
 
   "dependencies": {
-    "grafanaDependency": "7.0.6",
+    "grafanaDependency": ">=7.0.6",
     "plugins": []
   },
 


### PR DESCRIPTION
Release patch for assets tab v2.1.1


>  The grafanaDependency in plugin.json is a semver string that defines on what versions of Grafana the plugin can be installed on. Currently, the plugin lists grafanaDependency to be “7.0.6”, which means it can only by installed by those who are running _exactly_ 7.0.6. 

this was fixed manually in DB on Grafana side, but needs to fixed before the next release