### PR TITLE
fix: variable input in assets tab

### DIFF
--- a/src/components/queryEditor.tsx
+++ b/src/components/queryEditor.tsx
@@ -149,9 +149,14 @@ function AssetTab(props: SelectedProps & { datasource: CogniteDatasource }) {
     value: query.assetQuery.target,
   });
 
-  const fetchAndSetDropdownLabel = async (id: number) => {
-    const [res] = await datasource.fetchSingleAsset({ id });
-    setCurrent(resource2DropdownOption(res));
+  const fetchAndSetDropdownLabel = async (idInput: string) => {
+    const id = Number(idInput);
+    if (Number.isNaN(id)) {
+      setCurrent({ label: idInput, value: idInput });
+    } else {
+      const [res] = await datasource.fetchSingleAsset({ id });
+      setCurrent(resource2DropdownOption(res));
+    }
   };
 
   useEffect(() => {
@@ -165,7 +170,7 @@ function AssetTab(props: SelectedProps & { datasource: CogniteDatasource }) {
 
   useEffect(() => {
     if (current.value && !current.label) {
-      fetchAndSetDropdownLabel(+current.value);
+      fetchAndSetDropdownLabel(current.value);
     }
   }, [current.value]);
 
@@ -179,6 +184,7 @@ function AssetTab(props: SelectedProps & { datasource: CogniteDatasource }) {
           defaultOptions
           placeholder="Search asset by name/description"
           className="width-20"
+          allowCustomValue
           onChange={setCurrent}
         />
       </div>


### PR DESCRIPTION
We lost some capabilities with the recent update.
Not possible to see/input $variables in asset tab. 

Before the fix:
<img width="836" alt="Screenshot 2020-11-23 at 10 06 46" src="https://user-images.githubusercontent.com/10908415/99945478-faac8a80-2d74-11eb-9105-cc986192cbc0.png">

After:
<img width="873" alt="Screenshot 2020-11-23 at 10 06 30" src="https://user-images.githubusercontent.com/10908415/99945494-013b0200-2d75-11eb-8ea3-8b22c4d36ded.png">
