### PR TITLE
feat: time series latest value

### DIFF
--- a/src/__tests__/cdf.client.test.ts
+++ b/src/__tests__/cdf.client.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../cdf/client';
 import { getDataqueryResponse, getMeta } from './utils';
 
-describe('CDF datasource', () => {
+describe('CDF client', () => {
   describe('datapoints to tuples', () => {
     it('converts non aggregated values', () => {
       expect(

--- a/src/__tests__/datasource.test.ts
+++ b/src/__tests__/datasource.test.ts
@@ -89,6 +89,7 @@ describe('Datasource Query', () => {
       expect(results.succeded[0].metadata).toEqual({
         target: oldTarget,
         labels: [''],
+        type: 'data',
       });
       expect(results.succeded[0].result).toEqual(getDataqueryResponse({ items, aggregates }));
     });

--- a/src/__tests__/datasource.unit.test.ts
+++ b/src/__tests__/datasource.unit.test.ts
@@ -1,0 +1,71 @@
+import { Connector } from '../connector';
+import { defaultQuery, CogniteQuery } from '../types';
+import { getDataQueryRequestItems } from '../datasource';
+
+describe('getDataQueryRequestItems: generate cdf data points request items', () => {
+  const connector: Connector = ({
+    fetchData: jest.fn(),
+    fetchItems: jest.fn(),
+    fetchAndPaginate: jest.fn(),
+  } as unknown) as Connector;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('simple data points query', async () => {
+    const res = await getDataQueryRequestItems(
+      {
+        ...(defaultQuery as CogniteQuery),
+        targetRefType: 'externalId',
+        target: 'ext',
+      },
+      connector,
+      1000
+    );
+
+    expect(res.items).toEqual([
+      {
+        externalId: 'ext',
+      },
+    ]);
+  });
+
+  it('latest data point query', async () => {
+    const res = await getDataQueryRequestItems(
+      {
+        ...(defaultQuery as CogniteQuery),
+        latestValue: true,
+        before: 'now',
+        targetRefType: 'id',
+        target: 1,
+      },
+      connector,
+      1000
+    );
+
+    expect(res.items).toEqual([
+      {
+        before: 'now',
+        id: 1,
+      },
+    ]);
+  });
+
+  it('latest data point query with default "before"', async () => {
+    const { items } = await getDataQueryRequestItems(
+      {
+        ...(defaultQuery as CogniteQuery),
+        latestValue: true,
+        targetRefType: 'externalId',
+        target: 'ext',
+      },
+      connector,
+      1000
+    );
+
+    expect(items.length).toEqual(1);
+    expect(items[0].externalId).toEqual('ext');
+    expect(items[0].before).toBeLessThanOrEqual(Date.now());
+  });
+});

--- a/src/cdf/client.ts
+++ b/src/cdf/client.ts
@@ -22,7 +22,6 @@ import {
   Aggregates,
   Granularity,
   Tuple,
-  QueriesData,
   SuccessResponse,
   Responses,
   Result,
@@ -296,3 +295,12 @@ export const targetToIdEither = (obj: CogniteTargetObj) => {
         id: obj.target,
       };
 };
+
+export function getSingleTSQueryRequestItem(target: QueryTarget, type: DataQueryRequestType) {
+  const idEither = targetToIdEither(target);
+  if (type === 'data') {
+    return idEither;
+  }
+  const before = target.before || Date.now();
+  return { ...idEither, before };
+}

--- a/src/cdf/client.ts
+++ b/src/cdf/client.ts
@@ -270,8 +270,13 @@ export function getCalculationWarnings(items: Datapoint[]) {
   return Array.from(datapointsErrors).join('\n');
 }
 
-export function datapointsPath(isSynthetic: boolean) {
-  return `/timeseries/${isSynthetic ? 'synthetic/query' : 'data/list'}`;
+export function datapointsPath(type: 'data' | 'latest' | 'synthetic') {
+  const paths = {
+    synthetic: 'synthetic/query',
+    latest: 'data/latest',
+    data: 'data/list',
+  };
+  return `/timeseries/${paths[type]}`;
 }
 
 export const targetToIdEither = (obj: CogniteTargetObj) => {

--- a/src/components/queryEditor.tsx
+++ b/src/components/queryEditor.tsx
@@ -84,7 +84,7 @@ const AggregationEditor = (props: SelectedProps) => {
         options={aggregateOptions}
         menuPosition="fixed"
         value={query.aggregation}
-        className="width-10"
+        className="cognite-dropdown width-10"
       />
     </div>
   );
@@ -110,8 +110,8 @@ const LabelEditor = (props: SelectedProps) => {
 const LatestValueCheckbox = (props: SelectedProps) => {
   const { query, onQueryChange } = props;
   return (
-    <div className="gf-form-inline">
-      <InlineFormLabel tooltip="Fetch the latest data point only" width={9}>
+    <div className="gf-form gf-form-inline">
+      <InlineFormLabel tooltip="Fetch the latest data point in the provided time range" width={9}>
         Latest value
       </InlineFormLabel>
       <div className="gf-form-switch">
@@ -121,17 +121,6 @@ const LatestValueCheckbox = (props: SelectedProps) => {
           onChange={({ currentTarget }) => onQueryChange({ latestValue: currentTarget.checked })}
         />
       </div>
-      {query.latestValue && (
-        <FormField
-          label="Before"
-          labelWidth={6}
-          inputWidth={10}
-          onChange={({ target }) => onQueryChange({ before: target.value })}
-          value={query.before}
-          placeholder="now"
-          tooltip="Get data point before this time. The format is N[timeunit]-ago where timeunit is w,d,h,m,s. Example: '2d-ago' gets data that is up to 2 days old. You can also specify time in milliseconds since epoch. Use $__to to fetch the latest data point before the end of a selected time range."
-        />
-      )}
     </div>
   );
 };
@@ -212,7 +201,7 @@ function AssetTab(props: SelectedProps & { datasource: CogniteDatasource }) {
           value={current}
           defaultOptions
           placeholder="Search asset by name/description"
-          className="width-20"
+          className="cognite-dropdown width-20"
           allowCustomValue
           onChange={setCurrent}
         />
@@ -237,7 +226,11 @@ function TimeseriesTab(props: SelectedProps & { datasource: CogniteDatasource })
         }}
       />
       <LatestValueCheckbox {...{ query, onQueryChange }} />
-      {!query.latestValue && <CommonEditors {...{ query, onQueryChange }} />}
+      {query.latestValue ? (
+        <LabelEditor {...{ onQueryChange, query }} />
+      ) : (
+        <CommonEditors {...{ query, onQueryChange }} />
+      )}
     </div>
   );
 }

--- a/src/components/queryEditor.tsx
+++ b/src/components/queryEditor.tsx
@@ -110,7 +110,7 @@ const LabelEditor = (props: SelectedProps) => {
 const LatestValueCheckbox = (props: SelectedProps) => {
   const { query, onQueryChange } = props;
   return (
-    <div className="gf-form">
+    <div className="gf-form-inline">
       <InlineFormLabel width={9}>Latest value</InlineFormLabel>
       <div className="gf-form-switch">
         <Switch
@@ -119,6 +119,17 @@ const LatestValueCheckbox = (props: SelectedProps) => {
           onChange={({ currentTarget }) => onQueryChange({ latestValue: currentTarget.checked })}
         />
       </div>
+      {query.latestValue && (
+        <FormField
+          label="Before"
+          labelWidth={6}
+          inputWidth={10}
+          onChange={({ target }) => onQueryChange({ before: target.value })}
+          value={query.before}
+          placeholder="now"
+          tooltip="Get data points before this time. The format is N[timeunit]-ago where timeunit is w,d,h,m,s. Example: '2d-ago' gets data that is up to 2 days old. You can also specify time in milliseconds since epoch. Use $__to to fetch the latest data point before the end of selected time range."
+        />
+      )}
     </div>
   );
 };

--- a/src/components/queryEditor.tsx
+++ b/src/components/queryEditor.tsx
@@ -127,7 +127,7 @@ const LatestValueCheckbox = (props: SelectedProps) => {
           onChange={({ target }) => onQueryChange({ before: target.value })}
           value={query.before}
           placeholder="now"
-          tooltip="Get data points before this time. The format is N[timeunit]-ago where timeunit is w,d,h,m,s. Example: '2d-ago' gets data that is up to 2 days old. You can also specify time in milliseconds since epoch. Use $__to to fetch the latest data point before the end of selected time range."
+          tooltip="Get data points before this time. The format is N[timeunit]-ago where timeunit is w,d,h,m,s. Example: '2d-ago' gets data that is up to 2 days old. You can also specify time in milliseconds since epoch. Use $__to to fetch the latest data point before the end of a selected time range."
         />
       )}
     </div>

--- a/src/components/queryEditor.tsx
+++ b/src/components/queryEditor.tsx
@@ -111,7 +111,9 @@ const LatestValueCheckbox = (props: SelectedProps) => {
   const { query, onQueryChange } = props;
   return (
     <div className="gf-form-inline">
-      <InlineFormLabel width={9}>Latest value</InlineFormLabel>
+      <InlineFormLabel tooltip="Fetch the latest data point only" width={9}>
+        Latest value
+      </InlineFormLabel>
       <div className="gf-form-switch">
         <Switch
           css=""
@@ -127,7 +129,7 @@ const LatestValueCheckbox = (props: SelectedProps) => {
           onChange={({ target }) => onQueryChange({ before: target.value })}
           value={query.before}
           placeholder="now"
-          tooltip="Get data points before this time. The format is N[timeunit]-ago where timeunit is w,d,h,m,s. Example: '2d-ago' gets data that is up to 2 days old. You can also specify time in milliseconds since epoch. Use $__to to fetch the latest data point before the end of a selected time range."
+          tooltip="Get data point before this time. The format is N[timeunit]-ago where timeunit is w,d,h,m,s. Example: '2d-ago' gets data that is up to 2 days old. You can also specify time in milliseconds since epoch. Use $__to to fetch the latest data point before the end of a selected time range."
         />
       )}
     </div>

--- a/src/components/queryEditor.tsx
+++ b/src/components/queryEditor.tsx
@@ -107,6 +107,22 @@ const LabelEditor = (props: SelectedProps) => {
   );
 };
 
+const LatestValueCheckbox = (props: SelectedProps) => {
+  const { query, onQueryChange } = props;
+  return (
+    <div className="gf-form">
+      <InlineFormLabel width={9}>Latest value</InlineFormLabel>
+      <div className="gf-form-switch">
+        <Switch
+          css=""
+          value={query.latestValue}
+          onChange={({ currentTarget }) => onQueryChange({ latestValue: currentTarget.checked })}
+        />
+      </div>
+    </div>
+  );
+};
+
 const CommonEditors = ({ onQueryChange, query }: SelectedProps) => (
   <div className="gf-form-inline">
     <AggregationEditor {...{ onQueryChange, query }} />
@@ -207,8 +223,8 @@ function TimeseriesTab(props: SelectedProps & { datasource: CogniteDatasource })
           searchResource: (query) => datasource.getOptionsForDropdown(query, Tabs.Timeseries),
         }}
       />
-      {/* {current.description && <pre>{current.description}</pre>} */}
-      <CommonEditors {...{ query, onQueryChange }} />
+      <LatestValueCheckbox {...{ query, onQueryChange }} />
+      {!query.latestValue && <CommonEditors {...{ query, onQueryChange }} />}
     </div>
   );
 }

--- a/src/components/resourceSelect.tsx
+++ b/src/components/resourceSelect.tsx
@@ -85,7 +85,7 @@ export function ResourceSelect(props: {
         defaultOptions
         value={current.value ? current : null}
         placeholder={`Search ${resourceType.toLowerCase()} by name/description`}
-        className="width-20"
+        className="cognite-dropdown width-20"
         onChange={onDropdown}
       />
       <FormField

--- a/src/css/query_editor.css
+++ b/src/css/query_editor.css
@@ -36,8 +36,8 @@ pre code {
   line-height: 2;
 }
 
-.cognite-timeseries-list-checkbox {
-  margin-right: 10px;
+.cognite-dropdown {
+  margin-right: 4px;
 }
 
 .gf-dropdown-wrapper {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -179,14 +179,13 @@ export default class CogniteDatasource extends DataSourceApi<
   private getSingleTSQueryRequestItem(
     target: QueryTarget,
     type: DataQueryRequestType,
-    options: QueryOptions
+    { scopedVars }: QueryOptions
   ) {
     const idEither = targetToIdEither(target);
-    const beforeStr = target.before || 'now';
     if (type === 'data') {
       return idEither;
     }
-    const before = this.replaceVariable(beforeStr, options.scopedVars);
+    const before = target.before ? this.replaceVariable(target.before, scopedVars) : Date.now();
     return { ...idEither, before };
   }
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -21,7 +21,7 @@ import {
   stringifyError,
   fetchSingleAsset,
   fetchSingleTimeseries,
-  getSingleTSQueryRequestItem,
+  targetToIdEither,
 } from './cdf/client';
 import {
   AssetsFilterRequestParams,
@@ -64,7 +64,6 @@ import {
   Tuple,
   VariableQueryData,
   QueriesDataItem,
-  DataQueryRequestType,
 } from './types';
 import { applyFilters, getRequestId, toGranularityWithLowerBound } from './utils';
 
@@ -178,14 +177,12 @@ export default class CogniteDatasource extends DataSourceApi<
   }
 
   private replaceVariablesInTarget(target: QueryTarget, scopedVars: ScopedVars): QueryTarget {
-    const { expr, assetQuery, before, label } = target;
+    const { expr, assetQuery, label } = target;
 
-    const [
-      beforeTemplated,
-      exprTemplated,
-      labelTemplated,
-      assetTargetTemplated,
-    ] = this.replaceVariablesArr([before, expr, label, assetQuery?.target], scopedVars);
+    const [exprTemplated, labelTemplated, assetTargetTemplated] = this.replaceVariablesArr(
+      [expr, label, assetQuery?.target],
+      scopedVars
+    );
 
     const templatedAssetQuery = assetQuery && {
       assetQuery: {
@@ -199,7 +196,6 @@ export default class CogniteDatasource extends DataSourceApi<
       ...templatedAssetQuery,
       expr: exprTemplated,
       label: labelTemplated,
-      before: beforeTemplated,
     };
   }
 
@@ -469,7 +465,7 @@ export async function getDataQueryRequestItems(
     default:
     case undefined:
     case Tab.Timeseries: {
-      items = [getSingleTSQueryRequestItem(target, type)];
+      items = [targetToIdEither(target)];
       break;
     }
     case Tab.Asset: {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -64,6 +64,7 @@ import {
   VariableQueryData,
   QueriesData,
   QueriesDataItem,
+  DataQueryRequestType,
 } from './types';
 import { applyFilters, getRequestId, toGranularityWithLowerBound } from './utils';
 
@@ -179,9 +180,9 @@ export default class CogniteDatasource extends DataSourceApi<
     target: QueryTarget,
     options: QueryOptions
   ): Promise<QueriesDataItem> {
-    const { tab, target: tsId, assetQuery, expr, latestValue } = target;
+    const { tab, expr, latestValue, before } = target;
     let items: DataQueryRequestItem[];
-    let type: 'data' | 'latest' | 'synthetic';
+    let type: DataQueryRequestType;
     switch (tab) {
       default:
       case undefined:
@@ -191,7 +192,13 @@ export default class CogniteDatasource extends DataSourceApi<
           items = [targetToIdEither(target)];
         } else {
           type = 'latest';
-          items = [{ ...targetToIdEither(target), before: options.range.to.valueOf() }];
+          const beforeStr = before ? this.replaceVariable(before, options.scopedVars) : 'now';
+          items = [
+            {
+              ...targetToIdEither(target),
+              before: beforeStr,
+            },
+          ];
         }
         break;
       }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -176,6 +176,10 @@ export default class CogniteDatasource extends DataSourceApi<
     return concurrent(requests, queryProxy);
   }
 
+  /**
+   * Resolves Grafana variables in QueryTarget object (props: label, expr, assetQuery.target)
+   * E.g. {..., label: 'date: ${__from:date:YYYY-MM}'} -> {..., label: 'date: 2020-07'}
+   */
   private replaceVariablesInTarget(target: QueryTarget, scopedVars: ScopedVars): QueryTarget {
     const { expr, assetQuery, label } = target;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,7 +64,6 @@ export interface CogniteQueryBase extends DataQuery {
   aggregation: string;
   granularity: string;
   latestValue: boolean;
-  before?: string;
   error: string;
   label: string;
   tab: Tab;

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,7 @@ export type CogniteQuery = CogniteQueryBase & CogniteTargetObj;
 export interface CogniteQueryBase extends DataQuery {
   aggregation: string;
   granularity: string;
+  latestValue: boolean;
   error: string;
   label: string;
   tab: Tab;
@@ -194,6 +195,7 @@ export type DataQueryRequestItem = {
   expression?: string;
   start?: string | number;
   end?: string | number;
+  before?: string | number;
   limit?: number;
   granularity?: string;
   aggregates?: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -184,12 +184,19 @@ export type DataQueryError = {
   };
 };
 
-export type QueriesData = {
+export type QueriesDataItem = {
+  type: 'data' | 'latest' | 'synthetic';
   items: DataQueryRequestItem[];
   target: QueryTarget;
-}[];
+};
 
-export type ResponseMetadata = { labels: string[]; target: QueryTarget };
+export type QueriesData = QueriesDataItem[];
+
+export type ResponseMetadata = {
+  labels: string[];
+  target: QueryTarget;
+  type: 'data' | 'latest' | 'synthetic';
+};
 
 export type DataQueryRequestItem = {
   expression?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ const defaultAssetQuery: AssetQuery = {
 
 export const defaultQuery: Partial<CogniteQuery> = {
   target: '',
+  latestValue: false,
   aggregation: 'average',
   granularity: '',
   label: '',
@@ -192,8 +193,6 @@ export type QueriesDataItem = {
   items: DataQueryRequestItem[];
   target: QueryTarget;
 };
-
-export type QueriesData = QueriesDataItem[];
 
 export type ResponseMetadata = {
   labels: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ export interface CogniteQueryBase extends DataQuery {
   aggregation: string;
   granularity: string;
   latestValue: boolean;
+  before?: string;
   error: string;
   label: string;
   tab: Tab;
@@ -184,8 +185,10 @@ export type DataQueryError = {
   };
 };
 
+export type DataQueryRequestType = 'data' | 'latest' | 'synthetic';
+
 export type QueriesDataItem = {
-  type: 'data' | 'latest' | 'synthetic';
+  type: DataQueryRequestType;
   items: DataQueryRequestItem[];
   target: QueryTarget;
 };
@@ -195,7 +198,7 @@ export type QueriesData = QueriesDataItem[];
 export type ResponseMetadata = {
   labels: string[];
   target: QueryTarget;
-  type: 'data' | 'latest' | 'synthetic';
+  type: DataQueryRequestType;
 };
 
 export type DataQueryRequestItem = {


### PR DESCRIPTION
Enables "latest data point" feature in "timeseries" tab

<img width="1279" alt="Screenshot 2021-01-11 at 10 12 46" src="https://user-images.githubusercontent.com/10908415/104162836-a5e0d400-53f5-11eb-881e-803ab7f2e590.png">


*REFACTOR:*
Due to the code being too inconveniet for unit testing, I rewrote some logic around variable replacing.
Now all the `variable.replace(str, ...)` login is moved in one place, it happens before any other business logic.
