### PR TITLE
fix: self-explanatory tab names

### DIFF
--- a/src/components/queryEditor.tsx
+++ b/src/components/queryEditor.tsx
@@ -28,6 +28,7 @@ import {
   CogniteTargetObj,
   CogniteQueryBase,
   EventQuery,
+  TabTitles,
 } from '../types';
 import { failedResponseEvent, EventFields, responseWarningEvent } from '../constants';
 import '../css/query_editor.css';
@@ -456,7 +457,13 @@ export function QueryEditor(props: EditorProps) {
     <div>
       <TabsBar>
         {Object.values(Tabs).map((t) => (
-          <Tab css="" label={t} key={t} active={tab === t} onChangeTab={onSelectTab(t)} />
+          <Tab
+            css=""
+            label={TabTitles[t]}
+            key={t}
+            active={tab === t}
+            onChangeTab={onSelectTab(t)}
+          />
         ))}
       </TabsBar>
       <TabContent>

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export enum Tab {
 
 export const TabTitles = {
   [Tab.Timeseries]: 'Time series search',
-  [Tab.Asset]: 'Time series by asset',
+  [Tab.Asset]: 'Time series from asset',
   [Tab.Custom]: 'Time series custom query',
   [Tab.Event]: 'Events',
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,13 @@ export enum Tab {
   Event = 'Event',
 }
 
+export const TabTitles = {
+  [Tab.Timeseries]: 'Time series search',
+  [Tab.Asset]: 'Time series by asset',
+  [Tab.Custom]: 'Time series custom query',
+  [Tab.Event]: 'Events',
+};
+
 const defaultAssetQuery: AssetQuery = {
   includeSubtrees: false,
   target: '',


### PR DESCRIPTION
Got feedback that tab titles started to be a bit confusing.
How it was before: `timeseries`,`asset`,`custom`,`event`.
This doesn't make sense since first three tabs all working with timeseries.

How it is now:
<img width="798" alt="Screenshot 2021-03-12 at 15 39 19" src="https://user-images.githubusercontent.com/10908415/110947724-d0410600-8340-11eb-8b83-6aa6aad1ccb5.png">

Might need to improve it even more later.
