### PR TITLE
Forward errors to Grafana UI

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -131,8 +131,12 @@ export default class CogniteDatasource extends DataSourceApi<
         showWarnings(succeded);
         responseData = [...reduceTimeseries(succeded, timeRange), ...eventResults];
       } catch (error) {
-        /* eslint-disable-next-line no-console  */
-        console.error(error); // TODO: use app-events or something
+        return {
+          data: [],
+          error: {
+            message: error,
+          },
+        };
       }
     }
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -134,7 +134,7 @@ export default class CogniteDatasource extends DataSourceApi<
         return {
           data: [],
           error: {
-            message: error,
+            message: error?.message ?? error,
           },
         };
       }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -10,6 +10,7 @@ import {
   TableData,
   TimeSeries,
   AppEvent,
+  DataQueryResponse,
 } from '@grafana/data';
 import { BackendSrv, getBackendSrv, getTemplateSrv, SystemJS, TemplateSrv } from '@grafana/runtime';
 import { partition } from 'lodash';
@@ -64,7 +65,6 @@ import {
   MetricDescription,
   Ok,
   QueryOptions,
-  QueryResponse,
   QueryTarget,
   ResponseMetadata,
   Responses,
@@ -114,7 +114,7 @@ export default class CogniteDatasource extends DataSourceApi<
   /**
    * used by panels to get timeseries data
    */
-  async query(options: DataQueryRequest<CogniteQuery>): Promise<QueryResponse> {
+  async query(options: DataQueryRequest<CogniteQuery>): Promise<DataQueryResponse> {
     const queryTargets = filterEmptyQueryTargets(options.targets).map((t) =>
       this.replaceVariablesInTarget(t, options.scopedVars)
     );


### PR DESCRIPTION
This makes errors visible in the corner as the image below shows, which how I expect errors in a datasource to be shown.

<img width="1125" alt="image" src="https://user-images.githubusercontent.com/1014854/153422482-b485af76-d6d3-4090-adbb-46746c98b060.png">

