### PR TITLE
FDM null value bugfix / items + variable support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This article documents the ongoing improvements we're making to the **Cognite Da
 - [Flexible Data Modelling](https://hub.cognite.com/groups/flexible-data-modeling-early-adopter-208) is now added as a preview feature. You need enable it on the data source settings. The plugin will visualize tables and time series which has been modelled in Cognite's new Flexible Data Model
 - [Extraction Pipelines](https://docs.cognite.com/cdf/integration/guides/interfaces/about_integrations) is added as a preview feature. You can now see the latest status of your extraction pipelines and runs inside Grafana.
 - Advanced filtering of events now also supports aggregates.
+- Variables created with an asset-query can now return `externalId` and `name` as value in addition to `id`. This is useful when using a variable inside FDM graphQl query.
 
 ## 2.6.0 - August 4th, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This article documents the ongoing improvements we're making to the **Cognite Data Source for Grafana**.
 
-## 3.0.0 - November 14th, 2022
+## 3.0.0 - November 21st, 2022
 - The connector dependencies has been updated and the connector now requires Grafana v8 or later.
 - [Flexible Data Modelling](https://hub.cognite.com/groups/flexible-data-modeling-early-adopter-208) is now added as a preview feature. You need enable it on the data source settings. The plugin will visualize tables and time series which has been modelled in Cognite's new Flexible Data Model
 - [Extraction Pipelines](https://docs.cognite.com/cdf/integration/guides/interfaces/about_integrations) is added as a preview feature. You can now see the latest status of your extraction pipelines and runs inside Grafana.

--- a/src/components/flexibleDataModellingTab.tsx
+++ b/src/components/flexibleDataModellingTab.tsx
@@ -35,7 +35,6 @@ export const FlexibleDataModellingTab = (
       });
     }
   };
-
   useEffect(() => {
     patchFlexibleDataModellingQuery({
       tsKeys: firstSelection.length ? typeNameList(firstSelection) : [],

--- a/src/components/flexibleDataModellingTab.tsx
+++ b/src/components/flexibleDataModellingTab.tsx
@@ -1,6 +1,12 @@
 import { CodeEditor, Field, HorizontalGroup, Select } from '@grafana/ui';
 import React, { useState, useEffect, useMemo } from 'react';
-import { FDMResponseToDropdown, getFirstSelection, reverseSortGet, typeNameList } from '../utils';
+import {
+  FDMResponseToDropdown,
+  getFirstSelection,
+  isValidQuery,
+  reverseSortGet,
+  typeNameList,
+} from '../utils';
 import { FlexibleDataModellingQuery, SelectedProps, EditorProps } from '../types';
 import CogniteDatasource from '../datasource';
 import { CommonEditors } from './commonEditors';
@@ -29,7 +35,7 @@ export const FlexibleDataModellingTab = (
     });
   };
   const updateGraphQuery = (graphQlQuery) => {
-    if (firstSelection.length) {
+    if (isValidQuery(graphQlQuery, query.refId)) {
       patchFlexibleDataModellingQuery({
         graphQlQuery,
       });

--- a/src/components/flexibleDataModellingTab.tsx
+++ b/src/components/flexibleDataModellingTab.tsx
@@ -68,6 +68,7 @@ export const FlexibleDataModellingTab = (
             onChange={(externalId) => {
               patchFlexibleDataModellingQuery({ externalId: externalId.value, version: undefined });
             }}
+            width={24}
           />
         </Field>
         <Field label="Version">

--- a/src/components/variableQueryEditor.tsx
+++ b/src/components/variableQueryEditor.tsx
@@ -74,7 +74,7 @@ export class CogniteVariableQueryEditor extends React.PureComponent<
   }
 
   handleQueryChange = (event) => {
-    this.setState((state) => ({ ...state, query: event.target.value, error: '' }));
+    this.setState({ query: event.target.value, error: '' });
   };
 
   handleBlur = () => {
@@ -92,11 +92,11 @@ export class CogniteVariableQueryEditor extends React.PureComponent<
   };
 
   handleValueTypeChange = (value) => {
-    this.setState((state) => ({
-      ...state,
+    this.setState({
       valueType: value,
-    }));
+    });
   };
+
   render() {
     const { query, error, valueType } = this.state;
 
@@ -120,6 +120,7 @@ export class CogniteVariableQueryEditor extends React.PureComponent<
             onChange={this.handleValueTypeChange}
             value={valueType}
             width={20}
+            onBlur={this.handleBlur}
           />
         </div>
         <div className="gf-form--grow">

--- a/src/components/variableQueryEditor.tsx
+++ b/src/components/variableQueryEditor.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { InlineFormLabel, Select, Switch } from '@grafana/ui';
 import { VariableQueryData, VariableQueryProps } from '../types';
 import { parse } from '../parser/events-assets';
+import { variableValueOptions } from '../constants';
 
 const help = (
   <pre>
@@ -115,10 +116,7 @@ export class CogniteVariableQueryEditor extends React.PureComponent<
             Value
           </InlineFormLabel>
           <Select
-            options={[
-              { value: 'id', label: 'Id' },
-              { value: 'externalId', label: 'ExternalId' },
-            ]}
+            options={variableValueOptions}
             onChange={this.handleValueTypeChange}
             value={valueType}
             width={20}

--- a/src/components/variableQueryEditor.tsx
+++ b/src/components/variableQueryEditor.tsx
@@ -112,7 +112,7 @@ export class CogniteVariableQueryEditor extends React.PureComponent<
             onBlur={this.handleBlur}
             placeholder="eg: assets{name='example', assetSubtreeIds=[{id=123456789, externalId='externalId'}]}"
           />
-          <InlineFormLabel tooltip="use Id or externalId" width={4}>
+          <InlineFormLabel tooltip="Value to populate when using the variable." width={4}>
             Value
           </InlineFormLabel>
           <Select

--- a/src/components/variableQueryEditor.tsx
+++ b/src/components/variableQueryEditor.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { InlineFormLabel, Select, Switch } from '@grafana/ui';
 import { VariableQueryData, VariableQueryProps } from '../types';
 import { parse } from '../parser/events-assets';
 
@@ -52,7 +53,6 @@ const help = (
     .
   </pre>
 );
-
 export class CogniteVariableQueryEditor extends React.PureComponent<
   VariableQueryProps,
   VariableQueryData
@@ -60,6 +60,10 @@ export class CogniteVariableQueryEditor extends React.PureComponent<
   defaults: VariableQueryData = {
     query: '',
     error: '',
+    valueType: {
+      value: 'id',
+      label: 'Id',
+    },
   };
 
   constructor(props: VariableQueryProps) {
@@ -69,26 +73,31 @@ export class CogniteVariableQueryEditor extends React.PureComponent<
   }
 
   handleQueryChange = (event) => {
-    this.setState({ query: event.target.value, error: '' });
+    this.setState((state) => ({ ...state, query: event.target.value, error: '' }));
   };
 
   handleBlur = () => {
     const { onChange, datasource } = this.props;
-    const { query } = this.state;
+    const { query, valueType } = this.state;
 
     try {
       const evaluatedQuery = datasource.replaceVariable(query);
       parse(evaluatedQuery);
-
-      onChange({ query }, query);
+      onChange({ query, valueType }, query);
     } catch ({ message }) {
       this.setState({ error: message });
-      onChange({ query: '' }, '');
+      onChange({ query: '', valueType }, '');
     }
   };
 
+  handleValueTypeChange = (value) => {
+    this.setState((state) => ({
+      ...state,
+      valueType: value,
+    }));
+  };
   render() {
-    const { query, error } = this.state;
+    const { query, error, valueType } = this.state;
 
     return (
       <div>
@@ -101,6 +110,18 @@ export class CogniteVariableQueryEditor extends React.PureComponent<
             onChange={this.handleQueryChange}
             onBlur={this.handleBlur}
             placeholder="eg: assets{name='example', assetSubtreeIds=[{id=123456789, externalId='externalId'}]}"
+          />
+          <InlineFormLabel tooltip="use Id or externalId" width={4}>
+            Value
+          </InlineFormLabel>
+          <Select
+            options={[
+              { value: 'id', label: 'Id' },
+              { value: 'externalId', label: 'ExternalId' },
+            ]}
+            onChange={this.handleValueTypeChange}
+            value={valueType}
+            width={20}
           />
         </div>
         <div className="gf-form--grow">

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -110,3 +110,9 @@ export const nodeField: any = {
     type: FieldType.string,
   },
 };
+
+export const variableValueOptions = [
+  { value: 'id', label: 'Id' },
+  { value: 'externalId', label: 'ExternalId' },
+  { value: 'name', label: 'Name' },
+];

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -321,7 +321,6 @@ export default class CogniteDatasource extends DataSourceApi<
 
     const filteredAssets = applyFilters(assets, filters);
     return filteredAssets.map((asset) => {
-      console.log(asset, asset[valueType?.value]);
       return {
         text: asset.name,
         value: asset[valueType?.value] || asset.id,

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -320,10 +320,10 @@ export default class CogniteDatasource extends DataSourceApi<
     });
 
     const filteredAssets = applyFilters(assets, filters);
-    return filteredAssets.map((obj) => {
+    return filteredAssets.map((asset) => {
       return {
-        text: obj.name,
-        value: valueType?.value ? obj[valueType?.value] : obj.id,
+        text: asset.name,
+        value: asset[valueType?.value] || asset.id,
       };
     });
   }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -321,6 +321,7 @@ export default class CogniteDatasource extends DataSourceApi<
 
     const filteredAssets = applyFilters(assets, filters);
     return filteredAssets.map((asset) => {
+      console.log(asset, asset[valueType?.value]);
       return {
         text: asset.name,
         value: asset[valueType?.value] || asset.id,

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -299,10 +299,9 @@ export default class CogniteDatasource extends DataSourceApi<
   /**
    * used by query editor to get metric suggestions (template variables)
    */
-  async metricFindQuery({ query }: VariableQueryData): Promise<MetricDescription[]> {
+  async metricFindQuery({ query, valueType }: VariableQueryData): Promise<MetricDescription[]> {
     let params: QueryCondition;
     let filters: ParsedFilter[];
-
     try {
       ({ params, filters } = parseQuery(this.replaceVariable(query)));
     } catch (e) {
@@ -321,10 +320,12 @@ export default class CogniteDatasource extends DataSourceApi<
     });
 
     const filteredAssets = applyFilters(assets, filters);
-    return filteredAssets.map(({ name, id }) => ({
-      text: name,
-      value: id,
-    }));
+    return filteredAssets.map((obj) => {
+      return {
+        text: obj.name,
+        value: valueType?.value ? obj[valueType?.value] : obj.id,
+      };
+    });
   }
 
   fetchSingleTimeseries = (id: IdEither) => {

--- a/src/datasources/FlexibleDataModellingDatasource.ts
+++ b/src/datasources/FlexibleDataModellingDatasource.ts
@@ -81,12 +81,19 @@ export class FlexibleDataModellingDatasource {
       const res = getData(edges);
       if (query.tsKeys.length) {
         const labels = [];
-        const targets = _.flatten(
-          _.map(edges, ({ node }) => _.filter(node, (_, key) => query.tsKeys.includes(key)))
-        ).map(({ externalId, name }) => {
-          if (name) labels.push(name);
-          return externalId;
-        });
+        const targets = _.map(
+          _.filter(
+            _.flatten(
+              _.map(edges, ({ node }) =>
+                _.filter(node, (value, key) => {
+                  if (_.has(value, 'name')) labels.push(value.name);
+                  return query.tsKeys.includes(key) && _.has(value, 'externalId');
+                })
+              )
+            )
+          ),
+          'externalId'
+        );
         const { data } = await this.timeseriesDatasource.query({
           ...options,
           targets: [

--- a/src/types.ts
+++ b/src/types.ts
@@ -448,6 +448,10 @@ export type TimeseriesFilterQuery = {
 export interface VariableQueryData {
   query: string;
   error?: string;
+  valueType?: {
+    label: string;
+    value: string;
+  };
 }
 
 export interface VariableQueryProps {

--- a/src/types.ts
+++ b/src/types.ts
@@ -470,6 +470,7 @@ export interface QueryWarning {
 export interface FDMQueryResponse {
   [x: string]: {
     edges?: { node?: { [x: string]: any } }[];
+    items?: any[];
   };
 }
 export interface FDMResponse {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,6 +50,16 @@ export function getRange(range: TimeRange): Tuple<number> {
   const timeTo = range.to.valueOf();
   return [timeFrom, timeTo];
 }
+export const isValidQuery = (query, refId) => {
+  try {
+    return gql`
+      ${query}
+    `;
+  } catch (e) {
+    handleError(e, refId);
+    return false;
+  }
+};
 const getFirstSelectionArr = (arr: ExecutableDefinitionNode) => arr?.selectionSet?.selections;
 export const getFirstSelection = (graphQuery, refId) => {
   try {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,6 +86,9 @@ const getNodeSelection = (selection) => {
     if (selection[0]?.name.value === 'node') {
       return selections;
     }
+    if (selection[0]?.name.value === 'items') {
+      return selections;
+    }
     return getNodeSelection(selections);
   }
   return [];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { isNil, omitBy, get, map, assignIn, sortBy, filter, find, uniq, head } from 'lodash';
+import _, { isNil, omitBy, get, map, assignIn, sortBy, filter, find, uniq, head } from 'lodash';
 import { TimeRange } from '@grafana/data';
 import { stringify } from 'query-string';
 import ms from 'ms';
@@ -76,7 +76,13 @@ export const FDMResponseToDropdown = (edges) => {
     values.push({ value: externalId, label: name });
     assignIn(names, { [externalId]: name });
   });
-  return { all, names, dataModelOptions: sortBy(values, ['label']) };
+  return {
+    all,
+    names,
+    dataModelOptions: sortBy(values, (value) => {
+      return _.lowerCase(value.label);
+    }),
+  };
 };
 export const reverseSortGet = (list, id) => sortBy(get(list, id)).reverse();
 const getNodeSelection = (selection) => {


### PR DESCRIPTION
**Problem / User story**
* The plugin would fail to fetch time series in case of some null values returned in some rows
* Alternative syntax of graphql supported to pull `items` instead of `node/edge` (added in FDM lately)
* Update variables to make it a config option to return externalId or name instead of internal id which makes it more usable with FDM

**Solution**
Check for null values + additiontal parsing

**Affected Resource types**
FDM, variables

**Changes to datasource JSON model**
N/A

**Has documentation been updated**
No

**Have tests been updated?**
No

**Screenshots and examples**
![image](https://user-images.githubusercontent.com/51971968/202400421-922443e4-3a23-4c64-b0aa-9617cfc8e303.png)

