### PR TITLE
Change confusing label for API host

### DIFF
--- a/src/components/configEditor.tsx
+++ b/src/components/configEditor.tsx
@@ -118,7 +118,7 @@ export function ConfigEditor(props: ConfigEditorProps) {
 
         <div className="gf-form gf-form-inline">
           <FormField
-            label="API URL"
+            label="API Host"
             labelWidth={10}
             inputWidth={21}
             onChange={onJsonStringValueChange('cogniteApiUrl')}


### PR DESCRIPTION
**Problem / User story**
We have seen many times that a user insert the URL for API into the config setting named "API URL", even though the sample text (api.cognitedata.com) isn't an URL. 

**Solution**
Rename label from API URL to API Host

**Has documentation been updated**
No

