### PR TITLE
Fix invalid screenshot relative paths

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -25,10 +25,10 @@
       }
     ],
     "screenshots": [
-      { "name": "Time series", "path": "/img/asset_ts.png" },
-      { "name": "Data models", "path": "/img/fdm.png" },
-      { "name": "Events", "path": "/img/events.png" },
-      { "name": "Custom query", "path": "/img/custom_query.png" }
+      { "name": "Time series", "path": "img/asset_ts.png" },
+      { "name": "Data models", "path": "img/fdm.png" },
+      { "name": "Events", "path": "img/events.png" },
+      { "name": "Custom query", "path": "img/custom_query.png" }
     ],
     "version": "%VERSION%",
     "updated": "%TODAY%"


### PR DESCRIPTION
validation failed:

```
detail: Write relative paths without leading '.' or '/'. e.g. Instead of './img/file.png' use 'img/file.png'
```
