### PR TITLE
Fix custom labels on string time series

### DIFF
--- a/src/cdf/client.ts
+++ b/src/cdf/client.ts
@@ -131,7 +131,7 @@ async function getTimeseriesLabel(
 ): Promise<string> {
   let resLabel = label;
   if (label && labelContainsVariableProps(label)) {
-    const [ts] = await getTimeseries({ items: [id] }, connector);
+    const [ts] = await getTimeseries({ items: [id] }, connector, false);
     resLabel = getLabelWithInjectedProps(label, ts);
   }
   return resLabel;


### PR DESCRIPTION
**Problem / User story**
Users can't assign labels to string timeseries. Seems like there was a regression at some point in past.

**Has documentation been updated**
No

**Have tests been updated?**
No

**Screenshots and examples**
![Screenshot 2023-08-14 at 13 52 40](https://github.com/cognitedata/cognite-grafana-datasource/assets/10908415/627686ab-e3d6-4751-acd8-814fab248a49)

