### PR TITLE
Remove redundant dockerfile, fix documentation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,27 @@
+## Developing
+
+The easiest way to work on this datasource is by using [docker compose](./docker-compose.yaml) approach. 
+First, run the connector:
+
+```
+yarn dev
+```
+And then use another terminal to run the docker
+
+```
+yarn server
+```
+
+Alternatively, you to create a symbolic link
+in `data/plugins` that points to this directory and run Grafana instance separately.
+
+```shell
+cd /path/to/grafana/data/plugins
+ln -s /path/to/cognite-grafana-datasource cognitedata-datasource
+```
+
+## Building
+
+`yarn` followed by `yarn build` should work on systems with a shell.
+
+For debugging and development, use `yarn dev`, and for testing use `yarn test`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM grafana/grafana:7.5.17
-# Copy the plugin into the grafana plugin folder
-COPY ./dist /cognite-grafana-datasource
-
-COPY ./run-cdp.sh /run-cdp.sh
-
-ENTRYPOINT ["/run-cdp.sh"]

--- a/README.md
+++ b/README.md
@@ -26,41 +26,7 @@ To learn more about the connector please visit our [documentation](https://docs.
 
 If you find any bugs, or have any suggestions, please [visit support portal](https://support.cognite.com/).
 
----
 
-## Developing
+## Development
 
-The easiest way to work on this datasource is to create a symbolic link
-in `data/plugins` that points to this directory.
-
-```shell
-cd /path/to/grafana/data/plugins
-ln -s /path/to/cognite-grafana-datasource cognitedata-datasource
-```
-
-## Building
-
-`yarn` followed by `yarn build` should work on systems with a shell.
-
-For debugging and development, use `yarn dev`, and for testing use `yarn test`.
-
-## Docker
-
-The Grafana image is also hosted on Docker Hub as
-[cognite/grafana-cdf](https://hub.docker.com/r/cognite/grafana-cdf/) or [cognite/grafana-cdf-dev](https://hub.docker.com/r/cognite/grafana-cdf-dev/) and bundled with a Cognite Data Source. You may use it for development and testing purposes only.
-
-To run it, first create a Docker volume to store your dashboards
-and settings.
-
-`docker volume create grafana-storage`
-
-Run the Docker image using this volume:
-
-`docker run -d --name grafana -p 3000:3000 -v grafana-storage:/var/lib/grafana cognite/grafana-cdf`
-
-Now you can access Grafana at http://localhost:3000
-
-Standard username/password for logging in is admin/admin. See
-[http://docs.grafana.org/installation/docker/](http://docs.grafana.org/installation/docker/) for configuration details.
-
-For more help with Docker, see the [step-by-step guide](https://github.com/cognitedata/cognite-grafana-datasource/blob/master/instructions.md).
+See [here](./DEVELOPMENT.md)

--- a/run-cdp.sh
+++ b/run-cdp.sh
@@ -1,6 +1,0 @@
-#!/bin/bash -e
-
-mkdir -p /var/lib/grafana/plugins/cognite-grafana-datasource
-cp -r /cognite-grafana-datasource /var/lib/grafana/plugins/cognite-grafana-datasource/dist
-
-/run.sh


### PR DESCRIPTION

- Dockerfile is not maintained by us anymore, instead, we use one provided by Grafana
- Move documentation outside of the main readme (so it doesn't appear on grafana.com)