### PR TITLE
fix(deprecated-apis): remove backendSrv.datasourceRequest

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   "dependencies": {
     "@emotion/css": "^11.1.3",
     "@grafana/data": "^10.1.2",
-    "@grafana/runtime": "^10.1.2",
+    "@grafana/runtime": "^10.3.1",
     "@grafana/schema": "^10.1.2",
     "@grafana/ui": "^10.1.2",
     "deepdash": "^4.5.4",

--- a/src/__mocks__/@grafana/runtime.ts
+++ b/src/__mocks__/@grafana/runtime.ts
@@ -1,6 +1,6 @@
 export const getBackendSrv = () =>
   ({
-    datasourceRequest: jest.fn(),
+    fetch: jest.fn(),
   } as any);
 
 const variables = [

--- a/src/__tests__/dropdown.test.ts
+++ b/src/__tests__/dropdown.test.ts
@@ -4,8 +4,9 @@ import { Tab } from '../types';
 
 jest.mock('@grafana/runtime');
 type Mock = jest.Mock;
-const ds = getMockedDataSource();
-const { backendSrv } = ds;
+
+const fetcher = { fetch: jest.fn() };
+const ds = getMockedDataSource(fetcher);
 
 function getTimeseriesResponse(items) {
   return {
@@ -62,15 +63,15 @@ describe('Dropdown Options Query', () => {
   describe('Given an empty request for asset options', () => {
     let result;
     beforeAll(async () => {
-      backendSrv.datasourceRequest = jest
+      fetcher.fetch = jest
         .fn()
         .mockImplementation(() => Promise.resolve(assetsResponse));
       result = await ds.getOptionsForDropdown('', Tab.Asset);
     });
 
     it('should generate the correct request', () => {
-      expect(backendSrv.datasourceRequest).toBeCalledTimes(1);
-      expect((backendSrv.datasourceRequest as Mock).mock.calls[0][0]).toMatchSnapshot();
+      expect(fetcher.fetch).toBeCalledTimes(1);
+      expect((fetcher.fetch as Mock).mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('should return all assets', () => {
@@ -85,13 +86,13 @@ describe('Dropdown Options Query', () => {
       item.externalId.startsWith('asset')
     );
     beforeAll(async () => {
-      backendSrv.datasourceRequest = jest.fn().mockImplementation(() => Promise.resolve(response));
+      fetcher.fetch = jest.fn().mockImplementation(() => Promise.resolve(response));
       result = await ds.getOptionsForDropdown('asset', Tab.Asset);
     });
 
     it('should generate the correct request', () => {
-      expect(backendSrv.datasourceRequest).toBeCalledTimes(1);
-      expect((backendSrv.datasourceRequest as Mock).mock.calls[0][0]).toMatchSnapshot();
+      expect(fetcher.fetch).toBeCalledTimes(1);
+      expect((fetcher.fetch as Mock).mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('should return the assets with asset in their name', () => {
@@ -109,13 +110,13 @@ describe('Dropdown Options Query', () => {
       metadata: '{"key1":"value1"}',
     };
     beforeAll(async () => {
-      backendSrv.datasourceRequest = jest.fn().mockImplementation(() => Promise.resolve(response));
+      fetcher.fetch = jest.fn().mockImplementation(() => Promise.resolve(response));
       result = await ds.getOptionsForDropdown('asset', Tab.Asset, optionsObj);
     });
 
     it('should generate the correct request', () => {
-      expect(backendSrv.datasourceRequest).toBeCalledTimes(1);
-      expect((backendSrv.datasourceRequest as Mock).mock.calls[0][0]).toMatchSnapshot();
+      expect(fetcher.fetch).toBeCalledTimes(1);
+      expect((fetcher.fetch as Mock).mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('should return the assets with asset in their name and metadata.key1 = value1', () => {
@@ -126,15 +127,15 @@ describe('Dropdown Options Query', () => {
   describe('Given an empty request for timeseries options', () => {
     let result;
     beforeAll(async () => {
-      backendSrv.datasourceRequest = jest
+      fetcher.fetch = jest
         .fn()
         .mockImplementation(() => Promise.resolve(tsResponse));
       result = await ds.getOptionsForDropdown('', Tab.Timeseries);
     });
 
     it('should generate the correct request', () => {
-      expect(backendSrv.datasourceRequest).toBeCalledTimes(1);
-      expect((backendSrv.datasourceRequest as Mock).mock.calls[0][0]).toMatchSnapshot();
+      expect(fetcher.fetch).toBeCalledTimes(1);
+      expect((fetcher.fetch as Mock).mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('should return all timeseries', () => {
@@ -149,13 +150,13 @@ describe('Dropdown Options Query', () => {
       (item) => item.description && item.description.startsWith('test')
     );
     beforeAll(async () => {
-      backendSrv.datasourceRequest = jest.fn().mockImplementation(() => Promise.resolve(response));
+      fetcher.fetch = jest.fn().mockImplementation(() => Promise.resolve(response));
       result = await ds.getOptionsForDropdown('Timeseries', Tab.Timeseries);
     });
 
     it('should generate the correct request', () => {
-      expect(backendSrv.datasourceRequest).toBeCalledTimes(1);
-      expect((backendSrv.datasourceRequest as Mock).mock.calls[0][0]).toMatchSnapshot();
+      expect(fetcher.fetch).toBeCalledTimes(1);
+      expect((fetcher.fetch as Mock).mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('should return timeseries with Timeseries in their name', () => {

--- a/src/__tests__/extractionPipelinesDatasource.test.ts
+++ b/src/__tests__/extractionPipelinesDatasource.test.ts
@@ -13,8 +13,8 @@ jest.mock('@grafana/data');
 const appEvents = eventBusService;
 
 const { ExtractionPipelines } = Tab;
-const ds = getMockedDataSource();
-const { backendSrv } = ds;
+const fetcher = { fetch: jest.fn() };
+const ds = getMockedDataSource(fetcher);
 const options: any = {
   targets: [],
   range: {
@@ -101,14 +101,14 @@ describe('extraction pipelines', () => {
   });
   describe('getExtractionPipelinesDropdowns', () => {
     beforeEach(async () => {
-      backendSrv.datasourceRequest = jest
+      fetcher.fetch = jest
         .fn()
         .mockImplementationOnce(() => Promise.resolve({ data: extpipesRes }))
         .mockResolvedValueOnce((x) => Promise.resolve(x.data));
       results = await ds.extractionPipelinesDatasource.getExtractionPipelinesDropdowns('a');
     });
     it('it is called 1 times', () => {
-      expect(backendSrv.datasourceRequest).toBeCalledTimes(1);
+      expect(fetcher.fetch).toBeCalledTimes(1);
     });
     it('returns response data', () => {
       expect(results).toEqual(extpipesRes.items);
@@ -156,7 +156,7 @@ describe('extraction pipelines', () => {
               },
             },
           ];
-          backendSrv.datasourceRequest = jest
+          fetcher.fetch = jest
             .fn()
             .mockImplementationOnce(() => Promise.resolve({ data: extpipesRes }))
             .mockImplementationOnce(() => Promise.resolve({ data: extpipesRunsListRes1 }))
@@ -194,7 +194,7 @@ describe('extraction pipelines', () => {
               },
             },
           ];
-          backendSrv.datasourceRequest = jest
+          fetcher.fetch = jest
             .fn()
             .mockImplementationOnce(() => Promise.resolve({ data: extpipesByIdRes }))
             .mockImplementationOnce(() => Promise.resolve({ data: extpipesRunsListRes1 }))
@@ -236,7 +236,7 @@ describe('extraction pipelines', () => {
               },
             },
           ];
-          backendSrv.datasourceRequest = jest
+          fetcher.fetch = jest
             .fn()
             .mockImplementationOnce(() => Promise.resolve({ data: extpipesRunsListRes1 }))
             .mockImplementationOnce(() => Promise.resolve({ data: extpipesRunsListRes2 }))

--- a/src/__tests__/login.test.ts
+++ b/src/__tests__/login.test.ts
@@ -4,8 +4,8 @@ jest.mock('@grafana/runtime');
 type Mock = jest.Mock;
 
 describe('Login with OAuth2', () => {
-  const ds = getMockedDataSource({ oauthPassThru: true });
-  const { backendSrv } = ds;
+  const fetcher = { fetch: jest.fn() };
+  const ds = getMockedDataSource(fetcher, { oauthPassThru: true });
 
   function makeLoginResponse(loggedIn: boolean, project: string) {
     return Promise.resolve({
@@ -21,13 +21,13 @@ describe('Login with OAuth2', () => {
     let result;
 
     beforeAll(async () => {
-      backendSrv.datasourceRequest = jest.fn().mockReturnValue(response);
+      fetcher.fetch = jest.fn().mockReturnValue(response);
       result = await ds.testDatasource();
     });
 
     it('should send a correct request', async () => {
-      expect(backendSrv.datasourceRequest).toBeCalledTimes(1);
-      expect((backendSrv.datasourceRequest as Mock).mock.calls[0][0]).toMatchSnapshot();
+      expect(fetcher.fetch).toBeCalledTimes(1);
+      expect((fetcher.fetch as Mock).mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('should log the user in', async () => {
@@ -39,7 +39,7 @@ describe('Login with OAuth2', () => {
     const response = makeLoginResponse(true, 'WrongProject');
 
     it('should display an error message', async () => {
-      backendSrv.datasourceRequest = jest.fn().mockReturnValue(response);
+      fetcher.fetch = jest.fn().mockReturnValue(response);
       expect(await ds.testDatasource()).toMatchSnapshot();
     });
   });
@@ -48,7 +48,7 @@ describe('Login with OAuth2', () => {
     const response = makeLoginResponse(false, 'string');
 
     it('should display an error message', async () => {
-      backendSrv.datasourceRequest = jest.fn().mockReturnValue(response);
+      fetcher.fetch = jest.fn().mockReturnValue(response);
       expect(await ds.testDatasource()).toMatchSnapshot();
     });
   });

--- a/src/__tests__/metrics.test.ts
+++ b/src/__tests__/metrics.test.ts
@@ -4,8 +4,8 @@ import { VariableQueryData } from '../types';
 
 jest.mock('@grafana/runtime');
 type Mock = jest.Mock;
-const ds = getMockedDataSource();
-const { backendSrv } = ds;
+const fetcher = { fetch: jest.fn() };
+const ds = getMockedDataSource(fetcher);
 
 const assetsResponse = {
   data: {
@@ -35,7 +35,7 @@ describe('Metrics Query', () => {
       const result = await ds.metricFindQuery(variableQuery);
 
       expect(result).toEqual([]);
-      expect(backendSrv.datasourceRequest).not.toBeCalled();
+      expect(fetcher.fetch).not.toBeCalled();
     });
   });
 
@@ -45,7 +45,7 @@ describe('Metrics Query', () => {
       query: 'assets{}',
     };
     beforeAll(async () => {
-      backendSrv.datasourceRequest = jest
+      fetcher.fetch = jest
         .fn()
         .mockImplementation(() => Promise.resolve(assetsResponse));
       result = await ds.metricFindQuery(variableQuery);
@@ -56,8 +56,8 @@ describe('Metrics Query', () => {
     });
 
     it('should generate the correct request', () => {
-      expect(backendSrv.datasourceRequest).toBeCalledTimes(1);
-      expect((backendSrv.datasourceRequest as Mock).mock.calls[0][0]).toMatchSnapshot();
+      expect(fetcher.fetch).toBeCalledTimes(1);
+      expect((fetcher.fetch as Mock).mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('should return all assets', () => {
@@ -75,13 +75,13 @@ describe('Metrics Query', () => {
     response.data.items = assetsResponse.data.items.filter((item) => item.id === id);
 
     beforeAll(async () => {
-      backendSrv.datasourceRequest = jest.fn().mockImplementation(() => Promise.resolve(response));
+      fetcher.fetch = jest.fn().mockImplementation(() => Promise.resolve(response));
       result = await ds.metricFindQuery(variableQuery);
     });
 
     it('should generate the correct request', () => {
-      expect(backendSrv.datasourceRequest).toBeCalledTimes(1);
-      expect((backendSrv.datasourceRequest as Mock).mock.calls[0][0]).toMatchSnapshot();
+      expect(fetcher.fetch).toBeCalledTimes(1);
+      expect((fetcher.fetch as Mock).mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('should return the correct assets', () => {
@@ -99,15 +99,15 @@ describe('Metrics Query', () => {
     };
 
     beforeAll(async () => {
-      backendSrv.datasourceRequest = jest
+      fetcher.fetch = jest
         .fn()
         .mockImplementation(() => Promise.resolve(assetsResponse));
       result = await ds.metricFindQuery(variableQuery);
     });
 
     it('should generate the correct request', () => {
-      expect(backendSrv.datasourceRequest).toBeCalledTimes(1);
-      expect((backendSrv.datasourceRequest as Mock).mock.calls[0][0]).toMatchSnapshot();
+      expect(fetcher.fetch).toBeCalledTimes(1);
+      expect((fetcher.fetch as Mock).mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('should return the correct assets', () => {
@@ -125,15 +125,15 @@ describe('Metrics Query', () => {
     };
 
     beforeAll(async () => {
-      backendSrv.datasourceRequest = jest
+      fetcher.fetch = jest
         .fn()
         .mockImplementation(() => Promise.resolve(assetsResponse));
       result = await ds.metricFindQuery(variableQuery);
     });
 
     it('should generate the correct request', () => {
-      expect(backendSrv.datasourceRequest).toBeCalledTimes(1);
-      expect((backendSrv.datasourceRequest as Mock).mock.calls[0][0]).toMatchSnapshot();
+      expect(fetcher.fetch).toBeCalledTimes(1);
+      expect((fetcher.fetch as Mock).mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('should return the correct assets', () => {
@@ -148,7 +148,7 @@ describe('Metrics Query', () => {
     it('should return an empty array', async () => {
       const result = await ds.metricFindQuery(variableQuery);
       expect(result).toEqual([]);
-      expect(backendSrv.datasourceRequest).not.toBeCalled();
+      expect(fetcher.fetch).not.toBeCalled();
     });
   });
 
@@ -159,14 +159,14 @@ describe('Metrics Query', () => {
       };
       const result = await ds.metricFindQuery(variableQuery);
       expect(result).toEqual([]);
-      expect(backendSrv.datasourceRequest).not.toBeCalled();
+      expect(fetcher.fetch).not.toBeCalled();
     });
     it('should throw an error if filter regexp is wrong', async () => {
       const variableQuery: VariableQueryData = {
         query: "assets{name=~'*.foo'}",
       };
       expect(ds.metricFindQuery(variableQuery)).rejects.toMatchSnapshot();
-      expect(backendSrv.datasourceRequest).toBeCalledTimes(1);
+      expect(fetcher.fetch).toBeCalledTimes(1);
     });
   });
 
@@ -176,15 +176,15 @@ describe('Metrics Query', () => {
     };
 
     beforeAll(async () => {
-      backendSrv.datasourceRequest = jest
+      fetcher.fetch = jest
         .fn()
         .mockImplementation(() => Promise.resolve(assetsResponse));
       await ds.metricFindQuery(variableQuery);
     });
 
     it('should generate the correct request', () => {
-      expect(backendSrv.datasourceRequest).toBeCalledTimes(1);
-      expect((backendSrv.datasourceRequest as Mock).mock.calls[0][0]).toMatchSnapshot();
+      expect(fetcher.fetch).toBeCalledTimes(1);
+      expect((fetcher.fetch as Mock).mock.calls[0][0]).toMatchSnapshot();
     });
   });
 });

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -67,7 +67,7 @@ export default class CogniteDatasource extends DataSourceApi<
   timeseriesDatasource: TimeseriesDatasource;
   flexibleDataModellingDatasource: FlexibleDataModellingDatasource;
 
-  constructor(instanceSettings: DataSourceInstanceSettings<CogniteDataSourceOptions>, fetcher?: Fetcher) {
+  constructor(instanceSettings: DataSourceInstanceSettings<CogniteDataSourceOptions>) {
     super(instanceSettings);
 
     const defaultFetcher = {
@@ -92,10 +92,10 @@ export default class CogniteDatasource extends DataSourceApi<
     this.templateSrv = getTemplateSrv();
     this.url = url;
     this.project = cogniteProject ?? defaultProject;
-    this.connector = new Connector(
+    const connector = new Connector(
       this.project,
       url,
-      fetcher ?? defaultFetcher,
+      defaultFetcher,
       oauthPassThru,
       oauthClientCreds,
       enableTemplates,
@@ -103,6 +103,11 @@ export default class CogniteDatasource extends DataSourceApi<
       enableFlexibleDataModelling,
       enableExtractionPipelines
     );
+    this.initSources(connector);
+  }
+  
+  initSources (connector: Connector) {
+    this.connector = connector;
     this.templatesDatasource = new TemplatesDatasource(this.connector);
     this.timeseriesDatasource = new TimeseriesDatasource(this.connector);
     this.eventsDatasource = new EventsDatasource(this.connector);

--- a/src/test_utils.ts
+++ b/src/test_utils.ts
@@ -3,6 +3,7 @@ import { DataSourceInstanceSettings } from '@grafana/data';
 import _ from 'lodash';
 import CogniteDatasource from './datasource';
 import { CDFDataQueryRequest, QueryTarget, CogniteDataSourceOptions } from './types';
+import { Connector, Fetcher } from 'connector';
 
 export function getDataqueryResponse(
   { items, aggregates }: CDFDataQueryRequest,
@@ -51,11 +52,11 @@ const instanceSettings = ({ oauthPassThru }) =>
     withCredentials: false,
   } as unknown as DataSourceInstanceSettings<CogniteDataSourceOptions>);
 
-export const getMockedDataSource = (options = { oauthPassThru: false }) =>
-  new CogniteDatasource(instanceSettings(options));
+export const getMockedDataSource = (fetcher: Fetcher, options = { oauthPassThru: false }) =>
+  new CogniteDatasource(instanceSettings(options), fetcher);
 
-export const getDataSourceWithMocks = (options?: any) => {
-  const ds = getMockedDataSource(options);
+export const getDataSourceWithMocks = (fetcher: Fetcher, options?: any) => {
+  const ds = getMockedDataSource(fetcher, options);
   return { ds, backendSrv: ds.backendSrv, templateSrv: ds.templateSrv };
 };
 

--- a/src/test_utils.ts
+++ b/src/test_utils.ts
@@ -52,8 +52,13 @@ const instanceSettings = ({ oauthPassThru }) =>
     withCredentials: false,
   } as unknown as DataSourceInstanceSettings<CogniteDataSourceOptions>);
 
-export const getMockedDataSource = (fetcher: Fetcher, options = { oauthPassThru: false }) =>
-  new CogniteDatasource(instanceSettings(options), fetcher);
+export const getMockedDataSource = (fetcher: Fetcher, options = { oauthPassThru: false }) => {
+  const instanceProps = instanceSettings(options)
+  const ds = new CogniteDatasource(instanceProps);
+  const connector = new Connector(instanceProps.jsonData.cogniteProject, instanceProps.url, fetcher, options.oauthPassThru);
+  ds.initSources(connector);
+  return ds;
+}
 
 export const getDataSourceWithMocks = (fetcher: Fetcher, options?: any) => {
   const ds = getMockedDataSource(fetcher, options);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,6 +1205,13 @@
   dependencies:
     "@floating-ui/utils" "^0.1.3"
 
+"@floating-ui/core@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.0.tgz#fa41b87812a16bf123122bf945946bae3fdf7fc1"
+  integrity sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==
+  dependencies:
+    "@floating-ui/utils" "^0.2.1"
+
 "@floating-ui/dom@^1.0.1":
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.5.3.tgz#54e50efcb432c06c23cd33de2b575102005436fa"
@@ -1213,10 +1220,39 @@
     "@floating-ui/core" "^1.4.2"
     "@floating-ui/utils" "^0.1.3"
 
-"@floating-ui/utils@^0.1.3":
+"@floating-ui/dom@^1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.1.tgz#d552e8444f77f2d88534372369b3771dc3a2fa5d"
+  integrity sha512-iA8qE43/H5iGozC3W0YSnVSW42Vh522yyM1gj+BqRwVsTNOyr231PsXDaV04yT39PsO0QL2QpbI/M0ZaLUQgRQ==
+  dependencies:
+    "@floating-ui/core" "^1.6.0"
+    "@floating-ui/utils" "^0.2.1"
+
+"@floating-ui/react-dom@^2.0.3":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.0.8.tgz#afc24f9756d1b433e1fe0d047c24bd4d9cefaa5d"
+  integrity sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==
+  dependencies:
+    "@floating-ui/dom" "^1.6.1"
+
+"@floating-ui/react@0.26.4":
+  version "0.26.4"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.26.4.tgz#7626667d2dabc80e2696b500df7f1a348d7ec7a8"
+  integrity sha512-pRiEz+SiPyfTcckAtLkEf3KJ/sUbB4X4fWMcDm27HT2kfAq+dH+hMc2VoOkNaGpDE35a2PKo688ugWeHaToL3g==
+  dependencies:
+    "@floating-ui/react-dom" "^2.0.3"
+    "@floating-ui/utils" "^0.1.5"
+    tabbable "^6.0.1"
+
+"@floating-ui/utils@^0.1.3", "@floating-ui/utils@^0.1.5":
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.6.tgz#22958c042e10b67463997bd6ea7115fe28cbcaf9"
   integrity sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==
+
+"@floating-ui/utils@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.1.tgz#16308cea045f0fc777b6ff20a9f25474dd8293d2"
+  integrity sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==
 
 "@formatjs/ecma402-abstract@1.17.2":
   version "1.17.2"
@@ -1288,6 +1324,37 @@
     uplot "1.6.26"
     xss "^1.0.14"
 
+"@grafana/data@10.3.1":
+  version "10.3.1"
+  resolved "https://registry.yarnpkg.com/@grafana/data/-/data-10.3.1.tgz#9858d49b608485daad948b3012816762025c4924"
+  integrity sha512-Sok3UVhaXmSLaGyehx8gsCh6jVI+8GH4UiMtvGN2mDvN7ogTOdyBHVqxiYMFwkWrzPOJ0d8dJyG1qwRRr7M8LQ==
+  dependencies:
+    "@braintree/sanitize-url" "6.0.2"
+    "@grafana/schema" "10.3.1"
+    "@types/d3-interpolate" "^3.0.0"
+    "@types/string-hash" "1.1.1"
+    d3-interpolate "3.0.1"
+    date-fns "2.30.0"
+    dompurify "^2.4.3"
+    eventemitter3 "5.0.1"
+    fast_array_intersect "1.1.0"
+    history "4.10.1"
+    lodash "4.17.21"
+    marked "5.1.1"
+    marked-mangle "1.1.0"
+    moment "2.29.4"
+    moment-timezone "0.5.43"
+    ol "7.4.0"
+    papaparse "5.4.1"
+    react-use "17.4.0"
+    regenerator-runtime "0.14.0"
+    rxjs "7.8.1"
+    string-hash "^1.1.3"
+    tinycolor2 "1.6.0"
+    tslib "2.6.0"
+    uplot "1.6.28"
+    xss "^1.0.14"
+
 "@grafana/e2e-selectors@10.2.0":
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/@grafana/e2e-selectors/-/e2e-selectors-10.2.0.tgz#12110b75376cfeeeeb33d8bb57fca2b4119febb7"
@@ -1296,6 +1363,15 @@
     "@grafana/tsconfig" "^1.2.0-rc1"
     tslib "2.6.0"
     typescript "4.8.4"
+
+"@grafana/e2e-selectors@10.3.1":
+  version "10.3.1"
+  resolved "https://registry.yarnpkg.com/@grafana/e2e-selectors/-/e2e-selectors-10.3.1.tgz#b13676250ee5d80a7f65a58269f0c3a2d63397be"
+  integrity sha512-+qWAXViafuJYH7rN54iQmt7nbCWcA+FTpMGlzfezCdXAwcU3NiIvo4PD5kxR7nYcm1+s5G5pTZ00DQHxO5vBRw==
+  dependencies:
+    "@grafana/tsconfig" "^1.2.0-rc1"
+    tslib "2.6.0"
+    typescript "5.2.2"
 
 "@grafana/eslint-config@^6.0.0":
   version "6.0.1"
@@ -1321,6 +1397,14 @@
     "@opentelemetry/otlp-transformer" "^0.41.2"
     murmurhash-js "^1.0.0"
 
+"@grafana/faro-core@^1.3.7":
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/@grafana/faro-core/-/faro-core-1.3.7.tgz#d0fa9e4513ea74a5defc5568dfa24fa6abe35665"
+  integrity sha512-QSQBTa32zCAGAQ/fsooNYspvINrCXWoS3NRg7r7/C6ToFOGgcZNIdRoPqCr/sZK9NcICSIoNV6ulGph8gjogYA==
+  dependencies:
+    "@opentelemetry/api" "^1.7.0"
+    "@opentelemetry/otlp-transformer" "^0.45.1"
+
 "@grafana/faro-web-sdk@1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@grafana/faro-web-sdk/-/faro-web-sdk-1.2.1.tgz#4818884bba26f07ebe563084fc0e4eed4108ef8d"
@@ -1330,15 +1414,24 @@
     ua-parser-js "^1.0.32"
     web-vitals "^3.1.1"
 
-"@grafana/runtime@^10.1.2":
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/@grafana/runtime/-/runtime-10.2.0.tgz#7c8e1ab6f1d443dabd1de5205292b4e17732ab50"
-  integrity sha512-onhUvhzjYgBabGogJJk7uDJ4NfoPwfUXyxnnLANxP3MyLfe5M86ypYWztqXOARmX8dlm30TUEe4N+/evNyjHJw==
+"@grafana/faro-web-sdk@^1.3.5":
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/@grafana/faro-web-sdk/-/faro-web-sdk-1.3.7.tgz#3c850a47501d943e0470f87da3d6fe8ed8b27a71"
+  integrity sha512-D85pCkgPqfKY/Mz1hZnQGT1Yb63lJUlnxdnMGuto2xxb4UzQSyoKY1vnPhBvJvdYQMMvaiEC/DcvsLILzPvaSA==
   dependencies:
-    "@grafana/data" "10.2.0"
-    "@grafana/e2e-selectors" "10.2.0"
-    "@grafana/faro-web-sdk" "1.2.1"
-    "@grafana/ui" "10.2.0"
+    "@grafana/faro-core" "^1.3.7"
+    ua-parser-js "^1.0.32"
+    web-vitals "^3.1.1"
+
+"@grafana/runtime@^10.3.1":
+  version "10.3.1"
+  resolved "https://registry.yarnpkg.com/@grafana/runtime/-/runtime-10.3.1.tgz#2bf1fd46a0004a2da634a753255bf8f12429e3bf"
+  integrity sha512-i+KHVgr4ztFOvNeDxd/cRQrmLBmpspworetUiTT5k/yNSWF4pOGfhKULfiPFQrRtvXonPwgx92YnyUzLB2+MSQ==
+  dependencies:
+    "@grafana/data" "10.3.1"
+    "@grafana/e2e-selectors" "10.3.1"
+    "@grafana/faro-web-sdk" "^1.3.5"
+    "@grafana/ui" "10.3.1"
     history "4.10.1"
     lodash "4.17.21"
     rxjs "7.8.1"
@@ -1353,12 +1446,89 @@
   dependencies:
     tslib "2.6.0"
 
+"@grafana/schema@10.3.1":
+  version "10.3.1"
+  resolved "https://registry.yarnpkg.com/@grafana/schema/-/schema-10.3.1.tgz#c8b43c064b13dfb02e0a4fc604593d370a412845"
+  integrity sha512-newt0qGm3ZNQxOFApYBzyTLh0HTslWEfkp+DiKLK/W0Fyxl+RlSYf99gh7gv+/QlIa0wpQRaGIknSlI85Ho7yA==
+  dependencies:
+    tslib "2.6.0"
+
 "@grafana/tsconfig@^1.2.0-rc1":
   version "1.2.0-rc1"
   resolved "https://registry.yarnpkg.com/@grafana/tsconfig/-/tsconfig-1.2.0-rc1.tgz#10973c978ec95b0ea637511254b5f478bce04de7"
   integrity sha512-+SgQeBQ1pT6D/E3/dEdADqTrlgdIGuexUZ8EU+8KxQFKUeFeU7/3z/ayI2q/wpJ/Kr6WxBBNlrST6aOKia19Ag==
 
-"@grafana/ui@10.2.0", "@grafana/ui@^10.1.2":
+"@grafana/ui@10.3.1":
+  version "10.3.1"
+  resolved "https://registry.yarnpkg.com/@grafana/ui/-/ui-10.3.1.tgz#385c005096485544c1b1505a60c2aba026ea78d6"
+  integrity sha512-dH+HqtTy1Jl3ymelzF/qHCmwCE+b5+CIyWPMSH6YVf+9xzkNOoX11g2WkCFUxhM7LUB0yaXzN9/0bIpN4wwsGQ==
+  dependencies:
+    "@emotion/css" "11.11.2"
+    "@emotion/react" "11.11.1"
+    "@floating-ui/react" "0.26.4"
+    "@grafana/data" "10.3.1"
+    "@grafana/e2e-selectors" "10.3.1"
+    "@grafana/faro-web-sdk" "^1.3.5"
+    "@grafana/schema" "10.3.1"
+    "@leeoniya/ufuzzy" "1.0.13"
+    "@monaco-editor/react" "4.6.0"
+    "@popperjs/core" "2.11.8"
+    "@react-aria/button" "3.8.0"
+    "@react-aria/dialog" "3.5.3"
+    "@react-aria/focus" "3.13.0"
+    "@react-aria/menu" "3.10.0"
+    "@react-aria/overlays" "3.15.0"
+    "@react-aria/utils" "3.18.0"
+    "@react-stately/menu" "3.5.3"
+    ansicolor "1.1.100"
+    calculate-size "1.1.1"
+    classnames "2.3.2"
+    d3 "7.8.5"
+    date-fns "2.30.0"
+    hoist-non-react-statics "3.3.2"
+    i18next "^22.0.0"
+    i18next-browser-languagedetector "^7.0.2"
+    immutable "4.3.1"
+    is-hotkey "0.2.0"
+    jquery "3.7.0"
+    lodash "4.17.21"
+    micro-memoize "^4.1.2"
+    moment "2.29.4"
+    monaco-editor "0.34.0"
+    ol "7.4.0"
+    prismjs "1.29.0"
+    rc-cascader "3.20.0"
+    rc-drawer "6.5.2"
+    rc-slider "10.3.1"
+    rc-time-picker "^3.7.3"
+    rc-tooltip "6.1.1"
+    react-beautiful-dnd "13.1.1"
+    react-calendar "4.6.0"
+    react-colorful "5.6.1"
+    react-custom-scrollbars-2 "4.5.0"
+    react-dropzone "14.2.3"
+    react-highlight-words "0.20.0"
+    react-hook-form "^7.49.2"
+    react-i18next "^12.0.0"
+    react-inlinesvg "3.0.2"
+    react-loading-skeleton "3.3.1"
+    react-popper "2.3.0"
+    react-router-dom "5.3.3"
+    react-select "5.7.4"
+    react-table "7.8.0"
+    react-transition-group "4.4.5"
+    react-use "17.4.0"
+    react-window "1.8.9"
+    rxjs "7.8.1"
+    slate "0.47.9"
+    slate-plain-serializer "0.7.13"
+    slate-react "0.22.10"
+    tinycolor2 "1.6.0"
+    tslib "2.6.0"
+    uplot "1.6.28"
+    uuid "9.0.0"
+
+"@grafana/ui@^10.1.2":
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/@grafana/ui/-/ui-10.2.0.tgz#99920ee490d52c014b28d61ca0d9d86294a15f41"
   integrity sha512-RzvR053LVV8qYRrfFPMjzEeABwahVOeyQPXmU5vmYccPolQYXbc8wp149wjTf5xdUygqQunRADI6sAqgRpVrdA==
@@ -1761,6 +1931,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@leeoniya/ufuzzy@1.0.13":
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/@leeoniya/ufuzzy/-/ufuzzy-1.0.13.tgz#d4812e339ee82589513f9d937f3da29044325b6d"
+  integrity sha512-w7cOuME1F8e4TOrSAGQWPczj60eIcQiU31X1RU65yiZBz1zpDWfynVJUw8d2QzhkUsEObAV0nN4RTIqxpCvJGg==
+
 "@leeoniya/ufuzzy@1.0.8":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@leeoniya/ufuzzy/-/ufuzzy-1.0.8.tgz#6a01b561749df84ff28637051865fdde3cbfc3a9"
@@ -1837,6 +2012,13 @@
   dependencies:
     "@opentelemetry/api" "^1.0.0"
 
+"@opentelemetry/api-logs@0.45.1":
+  version "0.45.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.45.1.tgz#9e4f2c652dcce798c5627939b22304c2b5ce19c5"
+  integrity sha512-zVGq/k70l+kB/Wuv3O/zhptP2hvDhEbhDu9EtHde1iWZJf3FedeYS/nWVcMBkkyPAjS/JKNk86WN4CBQLGUuOw==
+  dependencies:
+    "@opentelemetry/api" "^1.0.0"
+
 "@opentelemetry/api-metrics@^0.33.0":
   version "0.33.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api-metrics/-/api-metrics-0.33.0.tgz#753d355289b7811ad254d6e5b0193bd1b9f23ab0"
@@ -1849,12 +2031,24 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.6.0.tgz#de2c6823203d6f319511898bb5de7e70f5267e19"
   integrity sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g==
 
+"@opentelemetry/api@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.7.0.tgz#b139c81999c23e3c8d3c0a7234480e945920fc40"
+  integrity sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==
+
 "@opentelemetry/core@1.15.2":
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-1.15.2.tgz#5b170bf223a2333884bbc2d29d95812cdbda7c9f"
   integrity sha512-+gBv15ta96WqkHZaPpcDHiaz0utiiHZVfm2YOYSqFGrUaJpPkMoSuLBB58YFQGi6Rsb9EHos84X6X5+9JspmLw==
   dependencies:
     "@opentelemetry/semantic-conventions" "1.15.2"
+
+"@opentelemetry/core@1.18.1":
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-1.18.1.tgz#d2e45f6bd6be4f00d20d18d4f1b230ec33805ae9"
+  integrity sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==
+  dependencies:
+    "@opentelemetry/semantic-conventions" "1.18.1"
 
 "@opentelemetry/otlp-transformer@^0.41.2":
   version "0.41.2"
@@ -1868,6 +2062,18 @@
     "@opentelemetry/sdk-metrics" "1.15.2"
     "@opentelemetry/sdk-trace-base" "1.15.2"
 
+"@opentelemetry/otlp-transformer@^0.45.1":
+  version "0.45.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-transformer/-/otlp-transformer-0.45.1.tgz#8f6590b93f177510983bea3055e5a3f3d30faad2"
+  integrity sha512-FhIHgfC0b0XtoBrS5ISfva939yWffNl47ypXR8I7Ru+dunlySpmf2TLocKHYLHGcWiuoeSNO5O4dZCmSKOtpXw==
+  dependencies:
+    "@opentelemetry/api-logs" "0.45.1"
+    "@opentelemetry/core" "1.18.1"
+    "@opentelemetry/resources" "1.18.1"
+    "@opentelemetry/sdk-logs" "0.45.1"
+    "@opentelemetry/sdk-metrics" "1.18.1"
+    "@opentelemetry/sdk-trace-base" "1.18.1"
+
 "@opentelemetry/resources@1.15.2":
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-1.15.2.tgz#0c9e26cb65652a1402834a3c030cce6028d6dd9d"
@@ -1875,6 +2081,14 @@
   dependencies:
     "@opentelemetry/core" "1.15.2"
     "@opentelemetry/semantic-conventions" "1.15.2"
+
+"@opentelemetry/resources@1.18.1":
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-1.18.1.tgz#e27bdc4715bccc8cd4a72d4aca3995ad0a496fe7"
+  integrity sha512-JjbcQLYMttXcIabflLRuaw5oof5gToYV9fuXbcsoOeQ0BlbwUn6DAZi++PNsSz2jjPeASfDls10iaO/8BRIPRA==
+  dependencies:
+    "@opentelemetry/core" "1.18.1"
+    "@opentelemetry/semantic-conventions" "1.18.1"
 
 "@opentelemetry/sdk-logs@0.41.2":
   version "0.41.2"
@@ -1884,6 +2098,14 @@
     "@opentelemetry/core" "1.15.2"
     "@opentelemetry/resources" "1.15.2"
 
+"@opentelemetry/sdk-logs@0.45.1":
+  version "0.45.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-logs/-/sdk-logs-0.45.1.tgz#d59a99147ab15eb36757932517dfc9a10e1645e9"
+  integrity sha512-z0RRgW4LeKEKnhXS4F/HnqB6+7gsy63YK47F4XAJYHs4s1KKg8XnQ2RkbuL31i/a9nXkylttYtvsT50CGr487g==
+  dependencies:
+    "@opentelemetry/core" "1.18.1"
+    "@opentelemetry/resources" "1.18.1"
+
 "@opentelemetry/sdk-metrics@1.15.2":
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-metrics/-/sdk-metrics-1.15.2.tgz#eadd0a049de9cd860e1e0d49eea01156469c4b60"
@@ -1891,6 +2113,15 @@
   dependencies:
     "@opentelemetry/core" "1.15.2"
     "@opentelemetry/resources" "1.15.2"
+    lodash.merge "^4.6.2"
+
+"@opentelemetry/sdk-metrics@1.18.1":
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-metrics/-/sdk-metrics-1.18.1.tgz#1dd334744a1e5d2eec27e9e9765c73cd2f43aef3"
+  integrity sha512-TEFgeNFhdULBYiCoHbz31Y4PDsfjjxRp8Wmdp6ybLQZPqMNEb+dRq+XN8Xw3ivIgTaf9gYsomgV5ensX99RuEQ==
+  dependencies:
+    "@opentelemetry/core" "1.18.1"
+    "@opentelemetry/resources" "1.18.1"
     lodash.merge "^4.6.2"
 
 "@opentelemetry/sdk-trace-base@1.15.2":
@@ -1902,10 +2133,24 @@
     "@opentelemetry/resources" "1.15.2"
     "@opentelemetry/semantic-conventions" "1.15.2"
 
+"@opentelemetry/sdk-trace-base@1.18.1":
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.18.1.tgz#256605d90b202002d5672305c66dbcf377132379"
+  integrity sha512-tRHfDxN5dO+nop78EWJpzZwHsN1ewrZRVVwo03VJa3JQZxToRDH29/+MB24+yoa+IArerdr7INFJiX/iN4gjqg==
+  dependencies:
+    "@opentelemetry/core" "1.18.1"
+    "@opentelemetry/resources" "1.18.1"
+    "@opentelemetry/semantic-conventions" "1.18.1"
+
 "@opentelemetry/semantic-conventions@1.15.2":
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.2.tgz#3bafb5de3e20e841dff6cb3c66f4d6e9694c4241"
   integrity sha512-CjbOKwk2s+3xPIMcd5UNYQzsf+v94RczbdNix9/kQh38WiQkM90sUOi3if8eyHFgiBjBjhwXrA7W3ydiSQP9mw==
+
+"@opentelemetry/semantic-conventions@1.18.1":
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz#8e47caf57a84b1dcc1722b2025693348cdf443b4"
+  integrity sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==
 
 "@petamoriken/float16@^3.4.7":
   version "3.8.4"
@@ -1942,6 +2187,18 @@
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/@rc-component/trigger/-/trigger-1.18.0.tgz#e23778f74fd32cb12e45c760809f610762c3035b"
   integrity sha512-vloGnWpeTmt7DBw0OHnG9poQ8h1WFh0hebq6fpgVjGYSxm6JU8rLH+kNwVNNvhL6Rg5He4ESjOk6O7uF9dJhxA==
+  dependencies:
+    "@babel/runtime" "^7.23.2"
+    "@rc-component/portal" "^1.1.0"
+    classnames "^2.3.2"
+    rc-motion "^2.0.0"
+    rc-resize-observer "^1.3.1"
+    rc-util "^5.38.0"
+
+"@rc-component/trigger@^1.17.0":
+  version "1.18.3"
+  resolved "https://registry.yarnpkg.com/@rc-component/trigger/-/trigger-1.18.3.tgz#b323b9e33f2700ca8d24a96f21401ab7b0eafdcd"
+  integrity sha512-Ksr25pXreYe1gX6ayZ1jLrOrl9OAUHUqnuhEx6MeHnNa1zVM5Y2Aj3Q35UrER0ns8D2cJYtmJtVli+i+4eKrvA==
   dependencies:
     "@babel/runtime" "^7.23.2"
     "@rc-component/portal" "^1.1.0"
@@ -3702,6 +3959,11 @@ clsx@^1.1.1, clsx@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+
+clsx@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.0.tgz#e851283bcb5c80ee7608db18487433f7b23f77cb"
+  integrity sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==
 
 co@^4.6.0:
   version "4.6.0"
@@ -7745,6 +8007,18 @@ rc-cascader@3.18.1:
     rc-tree "~5.7.0"
     rc-util "^5.35.0"
 
+rc-cascader@3.20.0:
+  version "3.20.0"
+  resolved "https://registry.yarnpkg.com/rc-cascader/-/rc-cascader-3.20.0.tgz#b270f9d84ed83417ee7309ef5e56e415f1586076"
+  integrity sha512-lkT9EEwOcYdjZ/jvhLoXGzprK1sijT3/Tp4BLxQQcHDZkkOzzwYQC9HgmKoJz0K7CukMfgvO9KqHeBdgE+pELw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    array-tree-filter "^2.1.0"
+    classnames "^2.3.1"
+    rc-select "~14.10.0"
+    rc-tree "~5.8.1"
+    rc-util "^5.37.0"
+
 rc-drawer@6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/rc-drawer/-/rc-drawer-6.5.2.tgz#49c1f279261992f6d4653d32a03b14acd436d610"
@@ -7784,6 +8058,19 @@ rc-resize-observer@^1.0.0, rc-resize-observer@^1.3.1:
     classnames "^2.2.1"
     rc-util "^5.38.0"
     resize-observer-polyfill "^1.5.1"
+
+rc-select@~14.10.0:
+  version "14.10.0"
+  resolved "https://registry.yarnpkg.com/rc-select/-/rc-select-14.10.0.tgz#5f60e61ed7c9a83c8591616b1174a1c4ab2de0cd"
+  integrity sha512-TsIJTYafTTapCA32LLNpx/AD6ntepR1TG8jEVx35NiAAWCPymhUfuca8kRcUNd3WIGVMDcMKn9kkphoxEz+6Ag==
+  dependencies:
+    "@babel/runtime" "^7.10.1"
+    "@rc-component/trigger" "^1.5.0"
+    classnames "2.x"
+    rc-motion "^2.0.1"
+    rc-overflow "^1.3.1"
+    rc-util "^5.16.1"
+    rc-virtual-list "^3.5.2"
 
 rc-select@~14.9.0:
   version "14.9.2"
@@ -7828,10 +8115,30 @@ rc-tooltip@6.0.1:
     "@rc-component/trigger" "^1.0.4"
     classnames "^2.3.1"
 
+rc-tooltip@6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/rc-tooltip/-/rc-tooltip-6.1.1.tgz#8f3bf2b7008f091977da19aa4617a48cefed3d10"
+  integrity sha512-YoxL0Ev4htsX37qgN23eKr0L5PIRpZaLVL9GX6aJ4x6UEnwgXZYUNCAEHfKlKT3eD1felDq3ob4+Cn9lprLDBw==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    "@rc-component/trigger" "^1.17.0"
+    classnames "^2.3.1"
+
 rc-tree@~5.7.0:
   version "5.7.12"
   resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-5.7.12.tgz#6910e551390963708936c2cbf925f9deff4a6d76"
   integrity sha512-LXA5nY2hG5koIAlHW5sgXgLpOMz+bFRbnZZ+cCg0tQs4Wv1AmY7EDi1SK7iFXhslYockbqUerQan82jljoaItg==
+  dependencies:
+    "@babel/runtime" "^7.10.1"
+    classnames "2.x"
+    rc-motion "^2.0.1"
+    rc-util "^5.16.1"
+    rc-virtual-list "^3.5.1"
+
+rc-tree@~5.8.1:
+  version "5.8.5"
+  resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-5.8.5.tgz#f714a383be27bd87366cf32f7f85b2af1fbae6b6"
+  integrity sha512-PRfcZtVDNkR7oh26RuNe1hpw11c1wfgzwmPFL0lnxGnYefe9lDAO6cg5wJKIAwyXFVt5zHgpjYmaz0CPy1ZtKg==
   dependencies:
     "@babel/runtime" "^7.10.1"
     classnames "2.x"
@@ -7905,6 +8212,17 @@ react-calendar@4.3.0:
     get-user-locale "^2.2.1"
     prop-types "^15.6.0"
 
+react-calendar@4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/react-calendar/-/react-calendar-4.6.0.tgz#2410895ba5f257f931815ffa74af06ff7a56d2e3"
+  integrity sha512-GJ6ZipKMQmlK666t+0hgmecu6WHydEnMWJjKdEkUxW6F471hiM5DkbWXkfr8wlAg9tc9feNCBhXw3SqsPOm01A==
+  dependencies:
+    "@wojtekmaj/date-utils" "^1.1.3"
+    clsx "^2.0.0"
+    get-user-locale "^2.2.1"
+    prop-types "^15.6.0"
+    tiny-warning "^1.0.0"
+
 react-colorful@5.6.1:
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-5.6.1.tgz#7dc2aed2d7c72fac89694e834d179e32f3da563b"
@@ -7960,6 +8278,11 @@ react-hook-form@7.5.3:
   version "7.5.3"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.5.3.tgz#9a624fa14ec153b154891c5ebddae02ec5c2e40f"
   integrity sha512-5T0mfJ4kCPKljd7t3Rgp7lML4Y2+kaZIeMdN6Zo/J7gBQ+WkrDBHOftdOtz4X+7/eqHGak5yL5evNpYdA9abVA==
+
+react-hook-form@^7.49.2:
+  version "7.50.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.50.0.tgz#379802d85c7b78e0056229c53607946d34f99a36"
+  integrity sha512-AOhuzM3RdP09ZCnq+Z0yvKGHK25yiOX5phwxjV9L7U6HMla10ezkBnvQ+Pk4GTuDfsC5P2zza3k8mawFwFLVuQ==
 
 react-i18next@^12.0.0:
   version "12.3.1"
@@ -8203,15 +8526,15 @@ regenerator-runtime@0.13.11:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
+regenerator-runtime@0.14.0, regenerator-runtime@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz#5e19d68eb12d486f797e15a3c6a918f7cec5eb45"
+  integrity sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==
+
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
-
-regenerator-runtime@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz#5e19d68eb12d486f797e15a3c6a918f7cec5eb45"
-  integrity sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==
 
 regenerator-transform@^0.15.2:
   version "0.15.2"
@@ -9026,6 +9349,11 @@ systemjs@6.14.2:
   resolved "https://registry.yarnpkg.com/systemjs/-/systemjs-6.14.2.tgz#e289f959f8c8b407403bd39c6abaa16f2c13f316"
   integrity sha512-1TlOwvKWdXxAY9vba+huLu99zrQURDWA8pUTYsRIYDZYQbGyK+pyEP4h4dlySsqo7ozyJBmYD20F+iUHhAltEg==
 
+tabbable@^6.0.1:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.2.0.tgz#732fb62bc0175cfcec257330be187dcfba1f3b97"
+  integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==
+
 table@^6.0.9:
   version "6.8.1"
   resolved "https://registry.yarnpkg.com/table/-/table-6.8.1.tgz#ea2b71359fe03b017a5fbc296204471158080bdf"
@@ -9332,6 +9660,11 @@ typescript@4.8.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
   integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
 
+typescript@5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+
 typescript@~5.1.0:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
@@ -9412,6 +9745,11 @@ uplot@1.6.26:
   version "1.6.26"
   resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.26.tgz#a6012fd141ad4a71741c75af0c71283d0ade45a7"
   integrity sha512-qN0mveL6UsP40TnHzHAJkUQvpfA3y8zSLXtXKVlJo/sLfj2+vjan/Z3g81MCZjy/hEDUFNtnLftPmETDA4s7Rg==
+
+uplot@1.6.28:
+  version "1.6.28"
+  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.28.tgz#bce4fe5e65e4d3e7f2c2288ad580b4fffbbc68cc"
+  integrity sha512-6AQ/Hu2ZvwF1P6PtIELdWKFml8Vvf3PUqrkVndL4A1+s/0loHwXfsk3yMwy4WGkRAt0MAMpf0uKLa9h0Yt3miw==
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
**Problem / User story**
- introduced Fetcher, a simple type with a `fetch()` method, to encapsulate an HTTP client
- since we are mocking the fetcher in the tests, I made it possible to supply a custom one into the initSources method
- resolved incompatibility issue where `@grafana/runtime@^10.3.1` type didn't play well with the ~10.2 (by just updating the dependency)
- resolved deprecation warning in which backendSrv.datasourceRequest should be replaced with backendSrv.fetch, ref https://community.grafana.com/t/how-to-migrate-from-backendsrv-datasourcerequest-to-backendsrv-fetch/58770