### PR TITLE
Fix relative link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ If you find any bugs, or have any suggestions, please [visit support portal](htt
 
 ## Development
 
-See [here](./DEVELOPMENT.md)
+See [here](https://github.com/cognitedata/cognite-grafana-datasource/blob/master/DEVELOPMENT.md).


### PR DESCRIPTION
Currently the build errors with:
```
 ~/work/cognite-grafana-datasource/cognite-grafana-datasource
error: README.md: convert relative link to absolute: ./DEVELOPMENT.md
detail: README.md contains relative links. These links will not work on the Grafana plugin's catalog. Convert them to absolute links. (starting with https://)
warning: README.md: possible broken link: https://support.cognite.com/ (403 Forbidden)
detail: README.md might contain broken links. Check that all links are valid and publicly accessible.
Error: Process completed with exit code 1

```
