### PR TITLE
fix: scientific notation for numbers in custom query

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/src/parser/*/grammar.ts linguist-generated=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This article documents the ongoing improvements we're making to the **Cognite
 Data Source for Grafana**.
 
+## 4.1.1 - February 14th, 2024
+
+### Bug fixes
+
+- Fixed an issue with the custum query where floats with more than 7 digits after decimal point where not supported
+
 ## 4.1.0 - February 7th, 2024
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Data Source for Grafana**.
 
 ### Bug fixes
 
-- Fixed an issue with the custom query where floats with more than 7 digits after the decimal point were not supported
+- Fixed an issue with the custom query where floats with more than 7 digits after the decimal point were causing syntax error
 
 ## 4.1.0 - February 7th, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Data Source for Grafana**.
 
 ### Bug fixes
 
-- Fixed an issue with the custum query where floats with more than 7 digits after decimal point where not supported
+- Fixed an issue with the custom query where floats with more than 7 digits after the decimal point were not supported
 
 ## 4.1.0 - February 7th, 2024
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/cognite-grafana-datasource",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Cognite Data Fusion datasource",
   "repository": "https://github.com/cognitedata/cognite-grafana-datasource",
   "author": "Cognite AS",

--- a/src/parser/common.ne
+++ b/src/parser/common.ne
@@ -15,6 +15,7 @@ prop_name -> [A-Za-z0-9_]:+ {% join %}
 
 # number
 number -> decimal {% id %}
+  | jsonfloat {% id %}
 
 # strings
 dqstring -> "\"" dstrchar:* "\"" {% d => d[1].join("") %}

--- a/src/parser/events-assets/grammar.ts
+++ b/src/parser/events-assets/grammar.ts
@@ -1,8 +1,7 @@
-// Generated automatically by nearley, version 2.19.7
+// Generated automatically by nearley, version 2.20.1
 // http://github.com/Hardmath123/nearley
 // Bypasses TS6133. Allow declared but unused functions.
 // @ts-ignore
-
 /* eslint-disable */
 function id(d: any[]): any {
   return d[0];
@@ -56,7 +55,7 @@ interface NearleyLexer {
   reset: (chunk: string, info: any) => void;
   next: () => NearleyToken | undefined;
   save: () => any;
-  formatError: (token: NearleyToken) => string;
+  formatError: (token: never) => string;
   has: (tokenType: string) => boolean;
 }
 
@@ -251,6 +250,7 @@ const grammar: Grammar = {
     },
     { name: 'prop_name', symbols: ['prop_name$ebnf$1'], postprocess: join },
     { name: 'number', symbols: ['decimal'], postprocess: id },
+    { name: 'number', symbols: ['jsonfloat'], postprocess: id },
     { name: 'dqstring$ebnf$1', symbols: [] },
     {
       name: 'dqstring$ebnf$1',

--- a/src/parser/ts/grammar.ts
+++ b/src/parser/ts/grammar.ts
@@ -1,4 +1,4 @@
-// Generated automatically by nearley, version 2.19.7
+// Generated automatically by nearley, version 2.20.1
 // http://github.com/Hardmath123/nearley
 // Bypasses TS6133. Allow declared but unused functions.
 // @ts-ignore
@@ -112,7 +112,7 @@ interface NearleyLexer {
   reset: (chunk: string, info: any) => void;
   next: () => NearleyToken | undefined;
   save: () => any;
-  formatError: (token: NearleyToken) => string;
+  formatError: (token: never) => string;
   has: (tokenType: string) => boolean;
 }
 
@@ -307,6 +307,7 @@ const grammar: Grammar = {
     },
     { name: 'prop_name', symbols: ['prop_name$ebnf$1'], postprocess: join },
     { name: 'number', symbols: ['decimal'], postprocess: id },
+    { name: 'number', symbols: ['jsonfloat'], postprocess: id },
     { name: 'dqstring$ebnf$1', symbols: [] },
     {
       name: 'dqstring$ebnf$1',

--- a/src/parser/ts/parser.unit.test.ts
+++ b/src/parser/ts/parser.unit.test.ts
@@ -178,6 +178,16 @@ describe('nearley parser', () => {
     expect(res).toEqual([STS([Filter('id', 1)]), Operator('-'), STS([Filter('a', 2)])]);
   });
 
+  it('number scientific notation', () => {
+    const res = parse(`10e-100 - ts{id=1}`);
+    expect(res).toEqual([Constant(10e-100), Operator('-'), STS([Filter('id', 1)])]);
+  });
+
+  it('number supports 20 digits after comma', () => {
+    const res = parse(`0.00000000000000007203 - ts{id=1}`);
+    expect(res).toEqual([Constant(0.00000000000000007203), Operator('-'), STS([Filter('id', 1)])]);
+  });
+
   it('function with arithmetics and filters', () => {
     const res = parse(`sin(ts{assetSubtreeIds=[{id=1}], aggregate="average"} / 10)`);
     expect(res).toEqual(


### PR DESCRIPTION
**Problem / User story**
In custom queries, we observe that the decimal numbers convert to scientific notation when it is more than 7 decimal places and the query fails.

**Solution**
Use standard grammar from nearley to parse float numbers (supports scientific notation as well as a side effect).


<img width="812" alt="Screenshot 2024-02-12 at 09 57 00" src="https://github.com/cognitedata/cognite-grafana-datasource/assets/10908415/491e317e-44e6-4b70-b8ff-13305c76468b">