### PR TITLE
Convert event date fields from integer to date objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/cognite-grafana-datasource",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Cognite Data Fusion datasource",
   "repository": "https://github.com/cognitedata/cognite-grafana-datasource",
   "author": "Cognite AS",

--- a/src/cdf/types.ts
+++ b/src/cdf/types.ts
@@ -32,8 +32,8 @@ export interface TimeSeriesAggregateDatapoint {
 
 export interface CogniteEvent {
   id: number;
-  lastUpdatedTime: string;
-  createdTime: string;
+  lastUpdatedTime: number;
+  createdTime: number;
   externalId?: string;
   startTime?: number;
   endTime?: number;

--- a/src/datasources/EventsDatasource.spec.ts
+++ b/src/datasources/EventsDatasource.spec.ts
@@ -1,0 +1,66 @@
+import { CogniteEvent } from 'cdf/types';
+import { convertEventsDateFields } from './EventsDatasource';
+
+describe('convertEventsDateFields', () => {
+  it('should convert date fields to Date objects when start time is available', () => {
+    const events: CogniteEvent[] = [
+      {
+        id: 1,
+        createdTime: 1708415906649,
+        lastUpdatedTime: 1708415906786,
+        startTime: 1708415893288,
+      },
+    ];
+    const result = convertEventsDateFields(events as CogniteEvent[]);
+    expect(result[0].createdTime).toBeInstanceOf(Date);
+    expect(result[0].lastUpdatedTime).toBeInstanceOf(Date);
+    expect(result[0].startTime).toBeInstanceOf(Date);
+  });
+
+  it('should convert date fields to Date objects when end time is available', () => {
+    const events: CogniteEvent[] = [
+      {
+        id: 1,
+        createdTime: 1708415906649,
+        lastUpdatedTime: 1708415906786,
+        endTime: 1708415893288,
+      },
+    ];
+    const result = convertEventsDateFields(events as CogniteEvent[]);
+    expect(result[0].createdTime).toBeInstanceOf(Date);
+    expect(result[0].lastUpdatedTime).toBeInstanceOf(Date);
+    expect(result[0].endTime).toBeInstanceOf(Date);
+  });
+
+  it('should convert date fields to Date objects when both start and end time are available', () => {
+    const events: CogniteEvent[] = [
+      {
+        id: 1,
+        createdTime: 1708415906649,
+        lastUpdatedTime: 1708415906786,
+        startTime: 1708415893288,
+        endTime: 1708415893288,
+      },
+    ];
+    const result = convertEventsDateFields(events as CogniteEvent[]);
+    expect(result[0].createdTime).toBeInstanceOf(Date);
+    expect(result[0].lastUpdatedTime).toBeInstanceOf(Date);
+    expect(result[0].startTime).toBeInstanceOf(Date);
+    expect(result[0].endTime).toBeInstanceOf(Date);
+  });
+
+  it('should not convert date fields to Date objects when they are not available', () => {
+    const events: CogniteEvent[] = [
+      {
+        id: 1,
+        createdTime: 1708415906649,
+        lastUpdatedTime: 1708415906786,
+      },
+    ];
+    const result = convertEventsDateFields(events as CogniteEvent[]);
+    expect(result[0].createdTime).toBeInstanceOf(Date);
+    expect(result[0].lastUpdatedTime).toBeInstanceOf(Date);
+    expect(result[0].startTime).toBeUndefined();
+    expect(result[0].endTime).toBeUndefined();
+  });
+});

--- a/src/datasources/EventsDatasource.ts
+++ b/src/datasources/EventsDatasource.ts
@@ -27,6 +27,18 @@ const convertEventsToAnnotations = (events: CogniteEvent[], timeRangeEnd: number
   }))
 }
 
+export const convertEventsDateFields = (events: CogniteEvent[]) => {
+  return events.map(({ createdTime, lastUpdatedTime, startTime, endTime, ...rest }) => {
+    return {
+      ...rest,
+      createdTime: new Date(createdTime),
+      lastUpdatedTime: new Date(lastUpdatedTime),
+      ...(startTime && { startTime: new Date(startTime) }),
+      ...(endTime && { endTime: new Date(endTime) }),
+    }
+  });
+}
+
 export class EventsDatasource {
   constructor(private connector: Connector) { }
   async query(options: DataQueryRequest<CogniteQuery>): Promise<DataQueryResponse> {
@@ -66,7 +78,7 @@ export class EventsDatasource {
     return Promise.all(
       targets.map(async (target) => {
         const resEvents = await this.fetchEventsForTarget(target, timeRange);
-        const items = isAnnotationTarget(target) ? convertEventsToAnnotations(resEvents, timeRange[1]) : resEvents;
+        const items = isAnnotationTarget(target) ? convertEventsToAnnotations(resEvents, timeRange[1]) : convertEventsDateFields(resEvents);
         const df = convertItemsToDataFrame(items, target.eventQuery?.columns ?? [], "Events", target.refId);
         return df
       })


### PR DESCRIPTION
**Problem / User story**
Customers complaining that Event data's date fields are represented as integer values rather than in Date format.

**Solution**
Convert Event data's createdTime, lastUpdatedTime, startTime, endTime to Date object

**Affected Resource types**
What resource types has been involved in the change? Events

**Changes to datasource JSON model**
What has been updated in the JSON? Any fields added/removed, possible breaking changes? 
No

**Has documentation been updated**
Yes/No

**Have tests been updated?**
Yes

**Screenshots and examples**
Screenshots and example query if applicable
![Screenshot 2024-03-13 at 14 51 40](https://github.com/cognitedata/cognite-grafana-datasource/assets/14229342/e9556140-7a9a-48c3-937c-b15bb5e23e53)



