### PR TITLE
fix: Bump go version to 1.21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v5
         with:
-          go-version: '1.19'
+          go-version: '1.21'
 
       - name: Install dependencies
         run: yarn install --immutable --prefer-offline


### PR DESCRIPTION
**Problem / User story**
The release flow seems to be failing

**Solution**
Try to bump the go lang to 1.21

**Affected Resource types**
Release

**Changes to datasource JSON model**
NA

**Has documentation been updated**
No

**Have tests been updated?**
No
**Screenshots and examples**
NA