### PR TITLE
chore: revert the major version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 This article documents the ongoing improvements we're making to the **Cognite
 Data Source for Grafana**.
 
-## 5.0.0 - Oct 24th, 2024
+## 4.2.1 - November 28th, 2024
 
 ### Bug fixes
 
-- **Breaking** Upgrade plugin dependencies to fix CVEs  (requires Grafana v11)
+- Upgrade plugin dependencies to fix CVEs
 
 ## 4.2.0 - June 17th, 2024
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/cognite-grafana-datasource",
-  "version": "5.0.0",
+  "version": "4.2.1",
   "description": "Cognite Data Fusion datasource",
   "repository": "https://github.com/cognitedata/cognite-grafana-datasource",
   "author": "Cognite AS",

--- a/src/datasources/TemplatesDatasource.ts
+++ b/src/datasources/TemplatesDatasource.ts
@@ -75,11 +75,6 @@ export class TemplatesDatasource {
       throw `Your data path did not exist! Data Path: '${dataPath}''`;
     }
 
-    if (resultsData.errors) {
-      // There can still be errors even if there is data
-      console.log('Got GraphQL errors:', resultsData.error);
-    }
-
     return Array.isArray(data) ? data : [data];
   }
 

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -35,7 +35,7 @@
   },
 
   "dependencies": {
-    "grafanaDependency": ">=11.0.0",
+    "grafanaDependency": ">=10.0.0",
     "plugins": []
   },
 


### PR DESCRIPTION
it seems like the latest changes we have done aren't breaking for Grafana 10.
Moving back to v4.
also, remove the redundant `console.log`