### PR TITLE
chore: remove deprecated gf-form-switch

### DIFF
--- a/playwright/fixtures/waitForQueriesToFinish.ts
+++ b/playwright/fixtures/waitForQueriesToFinish.ts
@@ -1,0 +1,26 @@
+import { expect } from '@grafana/plugin-e2e';
+
+const grafanaVersion = process.env.GRAFANA_VERSION ?? '11.0.0'
+const [majorVersion, minorVersion] = grafanaVersion.split('.').map(Number);
+
+// Workaround to get a "stable" panel state
+export const waitForQueriesToFinish = async (page) => {
+  const isGrafanaGte = (major: number, minor: number) => {
+    if (majorVersion > major) {
+      return true;
+    } else if (majorVersion === major && minorVersion >= minor) {
+      return true;
+    }
+    return false;
+  }
+
+  if (isGrafanaGte(11, 4)) {
+    const refreshButtonLocator = page.getByTestId('data-testid RefreshPicker run button');
+    await expect(refreshButtonLocator).toContainText('Refresh', { timeout: 15000 });
+  } else {
+    const loadingBarLocator = page.getByLabel('Panel loading bar');
+    await expect(loadingBarLocator).toHaveCount(0, { timeout: 15000 });
+  }
+
+  await page.waitForTimeout(1000); // otherwise the time range is the same, so the query might be cached
+}

--- a/src/components/commonEditors.tsx
+++ b/src/components/commonEditors.tsx
@@ -47,7 +47,7 @@ const AggregationEditor = (props: SelectedProps) => {
         options={aggregateOptions}
         menuPosition="fixed"
         value={query.aggregation}
-        className="cognite-dropdown width-10"
+        className="cog-mr-4 width-10"
       />
     </div>
   );

--- a/src/components/eventsTab.tsx
+++ b/src/components/eventsTab.tsx
@@ -4,10 +4,10 @@ import {
   CodeEditor,
   InlineFormLabel,
   LegacyForms,
-  Switch,
   Segment,
   Tooltip,
   Select,
+  InlineSwitch,
 } from '@grafana/ui';
 import jsonlint from 'jsonlint-mod';
 import { EventQuery, SelectedProps, EditorProps, EventsOrderDirection } from '../types';
@@ -22,24 +22,25 @@ const ActiveAtTimeRangeCheckbox = (props: SelectedProps) => {
   return (
     <div className="gf-form gf-form-inline">
       <InlineFormLabel
+        htmlFor='active-at-time-range'
         tooltip="Fetch active events in the provided time range. This is essentially the same as writing the following query: events{activeAtTime={min=$__from, max=$__to}} "
         width={7}
       >
         Active only
       </InlineFormLabel>
-      <div className="gf-form-switch">
-        <Switch
-          value={query.eventQuery.activeAtTimeRange}
-          onChange={({ currentTarget }) =>
-            onQueryChange({
-              eventQuery: {
-                ...query.eventQuery,
-                activeAtTimeRange: currentTarget.checked,
-              },
-            })
-          }
-        />
-      </div>
+      <InlineSwitch
+        label='Active only'
+        id='active-at-time-range'
+        value={query.eventQuery.activeAtTimeRange}
+        onChange={({ currentTarget }) =>
+          onQueryChange({
+            eventQuery: {
+              ...query.eventQuery,
+              activeAtTimeRange: currentTarget.checked,
+            },
+          })
+        }
+      />
     </div>
   );
 };
@@ -195,22 +196,20 @@ const ActiveAggregateCheckbox = ({ query, onQueryChange }: SelectedProps) => {
       <InlineFormLabel tooltip="Fetch with Aggregate count " width={10}>
         With Aggregate
       </InlineFormLabel>
-      <div className="gf-form-switch">
-        <Switch
-          value={query.eventQuery.aggregate?.withAggregate}
-          onChange={({ currentTarget }) =>
-            onQueryChange({
-              eventQuery: {
-                ...query.eventQuery,
-                aggregate: {
-                  ...query.eventQuery.aggregate,
-                  withAggregate: currentTarget.checked,
-                },
+      <InlineSwitch
+        value={query.eventQuery.aggregate?.withAggregate}
+        onChange={({ currentTarget }) =>
+          onQueryChange({
+            eventQuery: {
+              ...query.eventQuery,
+              aggregate: {
+                ...query.eventQuery.aggregate,
+                withAggregate: currentTarget.checked,
               },
-            })
-          }
-        />
-      </div>
+            },
+          })
+        }
+      />
     </div>
   );
 };

--- a/src/components/eventsTab.tsx
+++ b/src/components/eventsTab.tsx
@@ -121,7 +121,7 @@ const OrderDirectionEditor = (
         options={options}
         menuPosition="fixed"
         value={direction}
-        className="cognite-dropdown width-10"
+        className="cog-mr-4 width-10"
       />
     </div>
   );

--- a/src/components/eventsTab.tsx
+++ b/src/components/eventsTab.tsx
@@ -193,10 +193,12 @@ const SortByPicker = ({ query, onQueryChange }: SelectedProps ) => {
 const ActiveAggregateCheckbox = ({ query, onQueryChange }: SelectedProps) => {
   return (
     <div className="gf-form gf-form-inline">
-      <InlineFormLabel tooltip="Fetch with Aggregate count " width={10}>
+      <InlineFormLabel htmlFor='with-aggregate' tooltip="Fetch with Aggregate count " width={10}>
         With Aggregate
       </InlineFormLabel>
       <InlineSwitch
+        id='with-aggregate'
+        label='With Aggregate'
         value={query.eventQuery.aggregate?.withAggregate}
         onChange={({ currentTarget }) =>
           onQueryChange({

--- a/src/components/queryEditor.tsx
+++ b/src/components/queryEditor.tsx
@@ -1,17 +1,16 @@
 import defaults from 'lodash/defaults';
 import React, { useState, useEffect } from 'react';
 import {
-  LegacyForms,
   Tab,
   TabsBar,
   TabContent,
   InlineFormLabel,
-  Switch,
   AsyncSelect,
   Button,
   InlineField,
   InlineFieldRow,
-  Input
+  Input,
+  InlineSwitch
 } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { CustomQueryHelp } from './queryHelp';
@@ -39,21 +38,19 @@ import { CommonEditors, LabelEditor } from './commonEditors';
 import { EventsTab } from './eventsTab';
 import { eventBusService } from '../appEventHandler';
 
-const { FormField } = LegacyForms;
-
 const LatestValueCheckbox = (props: SelectedProps) => {
   const { query, onQueryChange } = props;
   return (
     <div className="gf-form gf-form-inline">
-      <InlineFormLabel tooltip="Fetch the latest data point in the provided time range" width={7}>
+      <InlineFormLabel htmlFor='latest-value' tooltip="Fetch the latest data point in the provided time range" width={7}>
         Latest value
       </InlineFormLabel>
-      <div className="gf-form-switch">
-        <Switch
-          value={query.latestValue}
-          onChange={({ currentTarget }) => onQueryChange({ latestValue: currentTarget.checked })}
-        />
-      </div>
+      <InlineSwitch
+        label='Latest value'
+        id='latest-value'
+        value={query.latestValue}
+        onChange={({ currentTarget }) => onQueryChange({ latestValue: currentTarget.checked })}
+      />
     </div>
   );
 };
@@ -62,23 +59,23 @@ const IncludeTimeseriesCheckbox = (props: SelectedProps) => {
   const { includeSubTimeseries } = query.assetQuery;
   return (
     <div className="gf-form">
-      <InlineFormLabel width={11} tooltip="Fetch time series linked to the asset">
+      <InlineFormLabel htmlFor='include-sub-timeseries' width={11} tooltip="Fetch time series linked to the asset">
         Include sub-timeseries
       </InlineFormLabel>
-      <div className="gf-form-switch">
-        <Switch
-          value={includeSubTimeseries !== false}
-          onChange={({ currentTarget }) => {
-            const { checked } = currentTarget;
-            onQueryChange({
-              assetQuery: {
-                ...query.assetQuery,
-                includeSubTimeseries: checked,
-              },
-            });
-          }}
-        />
-      </div>
+      <InlineSwitch
+        label='Include sub-timeseries'
+        id='include-sub-timeseries'
+        value={includeSubTimeseries !== false}
+        onChange={({ currentTarget }) => {
+          const { checked } = currentTarget;
+          onQueryChange({
+            assetQuery: {
+              ...query.assetQuery,
+              includeSubTimeseries: checked,
+            },
+          });
+        }}
+      />
     </div>
   );
 };
@@ -97,13 +94,13 @@ const IncludeSubAssetsCheckbox = (props: SelectedProps) => {
 
   return (
     <div className="gf-form">
-      <InlineFormLabel width={9}>Include sub-assets</InlineFormLabel>
-      <div className="gf-form-switch">
-        <Switch
-          value={includeSubtrees}
-          onChange={({ currentTarget }) => onIncludeSubtreesChange(currentTarget.checked)}
-        />
-      </div>
+      <InlineFormLabel htmlFor='include-sub-assets' width={9}>Include sub-assets</InlineFormLabel>
+      <InlineSwitch
+        label='Include sub-assets'
+        value={includeSubtrees}
+        id='include-sub-assets'
+        onChange={({ currentTarget }) => onIncludeSubtreesChange(currentTarget.checked)}
+      />
     </div>
   );
 };
@@ -122,15 +119,15 @@ const IncludeRelationshipsCheckbox = (props: SelectedProps) => {
 
   return (
     <div className="gf-form">
-      <InlineFormLabel tooltip="Fetch time series related to the asset" width={12}>
+      <InlineFormLabel htmlFor='include-relationships' tooltip="Fetch time series related to the asset" width={12}>
         Include relationships
       </InlineFormLabel>
-      <div className="gf-form-switch">
-        <Switch
-          value={withRelationships}
-          onChange={({ currentTarget }) => onIncludeRelationshipsChange(currentTarget.checked)}
-        />
-      </div>
+      <InlineSwitch
+        label='Include relationships'
+        id='include-relationships'
+        value={withRelationships}
+        onChange={({ currentTarget }) => onIncludeRelationshipsChange(currentTarget.checked)}
+      />
     </div>
   );
 };
@@ -184,11 +181,13 @@ function AssetTab(props: SelectedProps & { datasource: CogniteDatasource }) {
   return (
     <div className="gf-form-inline">
       <div className="gf-form">
-        <InlineFormLabel width={6}>Asset Tag</InlineFormLabel>
+        <InlineFormLabel htmlFor={'asset-select-dropdown'} width={6}>Asset Tag</InlineFormLabel>
         <AsyncSelect
           loadOptions={(query) => datasource.getOptionsForDropdown(query, 'Asset')}
           value={current}
           defaultOptions
+          inputId='asset-select-dropdown'
+          data-testid='asset-select-dropdown'
           placeholder="Search asset by name/description"
           className="cognite-dropdown width-20"
           allowCustomValue

--- a/src/components/queryEditor.tsx
+++ b/src/components/queryEditor.tsx
@@ -189,7 +189,7 @@ function AssetTab(props: SelectedProps & { datasource: CogniteDatasource }) {
           inputId='asset-select-dropdown'
           data-testid='asset-select-dropdown'
           placeholder="Search asset by name/description"
-          className="cognite-dropdown width-20"
+          className="cog-mr-4 width-20"
           allowCustomValue
           onChange={setCurrent}
         />

--- a/src/components/resourceSelect.tsx
+++ b/src/components/resourceSelect.tsx
@@ -89,7 +89,7 @@ export function ResourceSelect(props: {
         defaultOptions
         value={current.value ? current : null}
         placeholder={`Search ${resourceType.toLowerCase()} by name/description`}
-        className="cognite-dropdown width-20"
+        className="cog-mr-4 width-20"
         onChange={onDropdown}
       />
       <FormField

--- a/src/components/resourceSelect.tsx
+++ b/src/components/resourceSelect.tsx
@@ -49,6 +49,9 @@ export function ResourceSelect(props: {
   };
 
   const fetchDropdownResource = async (id: IdEither) => {
+    if (('externalId' in id && !id.externalId) || ('id' in id && !id.id)) {
+      return null;
+    }
     try {
       const [res] = await fetchSingleResource(id);
       return res;

--- a/src/components/templatesTab.tsx
+++ b/src/components/templatesTab.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Select, AsyncSelect, Field, Input, HorizontalGroup, CodeEditor } from '@grafana/ui';
+import { Select, AsyncSelect, Field, Input, CodeEditor, Stack } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import CogniteDatasource from '../datasource';
 import { EditorProps, SelectedProps, TemplateQuery } from '../types';
@@ -55,7 +55,7 @@ export function TemplatesTab(
   }, [templateQuery]);
   return (
     <>
-      <HorizontalGroup>
+      <Stack>
         <Field label="Template Group" description="Select template group">
           <AsyncSelect
             loadOptions={loadTemplateGroupsOptions}
@@ -73,7 +73,7 @@ export function TemplatesTab(
             onBlur={triggerQuery}
           />
         </Field>
-      </HorizontalGroup>
+      </Stack>
       <Field label="Query" description="GraphQL query">
         <CodeEditor
           value={templateQuery.graphQlQuery ?? ''}
@@ -85,7 +85,7 @@ export function TemplatesTab(
           showLineNumbers
         />
       </Field>
-      <HorizontalGroup>
+      <Stack>
         <Field label="Data Path" description="Path to the data">
           <Input
             value={templateQuery.dataPath}
@@ -109,7 +109,7 @@ export function TemplatesTab(
             onBlur={triggerQuery}
           />
         </Field>
-      </HorizontalGroup>
+      </Stack>
     </>
   );
 }

--- a/src/css/query_editor.css
+++ b/src/css/query_editor.css
@@ -10,14 +10,6 @@
   min-width: 20rem;
 }
 
-.gf-form-select-wrapper select.gf-form-input {
-  height: 2.64rem;
-}
-
-.gf-form-select-wrapper--caret-indent.gf-form-select-wrapper::after {
-  right: 0.775rem;
-}
-
 .gf-tabs-cognite.active:before,
 .gf-tabs-cognite.active:focus:before,
 .gf-tabs-cognite.active:hover:before {
@@ -33,21 +25,10 @@ pre code,
   line-height: 2;
 }
 
-.cognite-dropdown {
+.cog-mr-4 {
   margin-right: 4px;
 }
 
-.gf-dropdown-wrapper {
-  min-width: 200px;
-}
-
-.gf-field-switch {
-  margin: 0 0 0 8px;
-}
-
-.gf-field-switch > div:last-child {
-  margin: 8px 0 0 16px;
-}
 .preview-label {
   align-self: center;
   background: #ffdc7f;

--- a/src/css/query_editor.css
+++ b/src/css/query_editor.css
@@ -33,8 +33,7 @@ pre code,
   line-height: 2;
 }
 
-.cognite-dropdown,
-.gf-form-switch {
+.cognite-dropdown {
   margin-right: 4px;
 }
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -44,7 +44,7 @@ import {
   ExtractionPipelinesDatasource,
 } from './datasources';
 import AnnotationsQueryEditor from 'components/annotationsQueryEditor';
-import { lastValueFrom, Observable, from, map } from 'rxjs';
+import { lastValueFrom, Observable, from, map, of } from 'rxjs';
 
 export default class CogniteDatasource extends DataSourceWithBackend<
   CogniteQuery,
@@ -124,7 +124,7 @@ export default class CogniteDatasource extends DataSourceWithBackend<
   }
 
   // Queries the backend by using `super.query`
-   queryBackend(
+  queryBackend(
     backendTargets: QueryTarget[],
     options: DataQueryRequest<CogniteQuery>
   ): Observable<DataQueryResponse> {
@@ -231,6 +231,10 @@ export default class CogniteDatasource extends DataSourceWithBackend<
 
   // A utility function to merge multiple observables into one
   mergeObservables(observables: Array<Observable<DataQueryResponse>>): Observable<DataQueryResponse> {
+    if (observables.length === 0) {
+      return of({ data: [] });
+    }
+    
     return new Observable((subscriber) => {
       let allData: any[] = [];
       let allErrors: DataQueryError[] = [];

--- a/src/parser/ts/parser.unit.test.ts
+++ b/src/parser/ts/parser.unit.test.ts
@@ -543,8 +543,8 @@ describe('parse unary "-" operator', () => {
       expect(parse(query)).toEqual(expected);
       const endTime = Date.now(); 
       const timeDiff = endTime - startTime; 
-      // in case you have to bump the limit up from 20ms, make sure you know what you are doing :)
-      expect(timeDiff).toBeLessThan(20);
+      // in case you have to bump the limit up from 50ms, make sure you know what you are doing :)
+      expect(timeDiff).toBeLessThan(50);
     })
   );
 

--- a/tests/queryEditor.spec.ts
+++ b/tests/queryEditor.spec.ts
@@ -1,0 +1,70 @@
+import { test as base, expect, PluginFixture, PluginOptions } from '@grafana/plugin-e2e';
+import { readProvisionedDataSource } from '../playwright/fixtures/readProvisionedDataSource';
+
+const test = base.extend<PluginFixture, PluginOptions>({ readProvisionedDataSource });
+
+const expectedTs = [
+  '59.9139-10.7522-current.clouds',
+  '59.9139-10.7522-current.feels_like',
+  '59.9139-10.7522-current.humidity',
+  '59.9139-10.7522-current.pressure',
+  '59.9139-10.7522-current.temp',
+  '59.9139-10.7522-current.wind_speed',
+  '59.9139-10.7522-current.visibility',
+  '59.9139-10.7522-current.uvi'
+].sort();
+
+test('Panel with asset subtree queries rendered OK', async ({ selectors, readProvisionedDataSource, gotoDashboardPage, readProvisionedDashboard, page }) => {
+  const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
+  const dashboard = await readProvisionedDashboard({ fileName: 'weather-station.json' });
+  const dashboardPage = await gotoDashboardPage(dashboard);
+
+  const panelEditPage = await dashboardPage.addPanel();
+  await panelEditPage.datasource.set(ds.name);
+  
+  const editorRow = panelEditPage.getQueryEditorRow("A");
+
+  await editorRow.getByText('Time series from asset').click();
+
+  const combobox = await editorRow.getByRole('combobox', { name: 'Asset Tag' });
+  await combobox.click();
+
+  const option = selectors.components.Select.option;
+  await panelEditPage.getByGrafanaSelector(option).filter({ hasText: 'Locations' }).click();
+
+  const includeSubAssets = await editorRow.getByLabel('Include sub-assets').nth(1);
+  await includeSubAssets.check({ force: true });
+  await expect(includeSubAssets).toBeChecked();
+
+  const includeTs = await editorRow.getByLabel('Include sub-timeseries').nth(1);
+  await expect(includeTs).toBeChecked();
+
+  const latestValue = await editorRow.getByLabel('Latest value').nth(1);
+  await latestValue.check({ force: true });
+  await expect(latestValue).toBeChecked();
+
+  await expect(panelEditPage.refreshPanel(
+    {
+      waitForResponsePredicateCallback: async (response) => {
+        
+        const isTsData = response.request().url().endsWith('/timeseries/data/latest');
+        const is200 = response.status() === 200;
+        
+        if (isTsData && is200) {
+          const json = await response.json();
+          const externalIds = json.items?.map(({ externalId }) => externalId).sort();
+          const isEqualArr = JSON.stringify(externalIds) === JSON.stringify(expectedTs);
+          return isEqualArr;
+        }
+
+        return false;
+      }
+    }
+  )).toBeOK();
+
+  const buttons = await page.getByRole('button', { name: /59.9139-10.7522.*/ });
+  for (const expectedTsName of expectedTs) {
+    const button = buttons.locator(`text='${expectedTsName}'`);
+    await expect(button).toBeVisible();
+  }
+});


### PR DESCRIPTION
**Problem / User story**
some css styles are about to be removed: https://github.com/cognitedata/cognite-grafana-datasource/issues/384
In our case it's `gf-form-switch` which used for `Switch` component.

**Solution**
- `Switch` is replaced with `InlineSwitch` which is essencially the same.
- additionally fixed the empty `Observable` response when there no valid queries (otherwise it's failing e2e test, due to infinite loading). This bug was introduced when recently when we started using observables.

**Have tests been updated?**
- yes, added e2e test that with the switches (timeseries from asset query)
- added a fixture to wait for the panel to finish loading

**Screenshots and examples**

<img width="640" alt="Screenshot 2025-04-11 at 15 04 13" src="https://github.com/user-attachments/assets/1703d8db-6f00-4d15-8a92-d244c1788c12" />
