### PR TITLE
chore: migrate CD to use access policy token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,6 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    env:
-      GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }} # Requires a Grafana API key from Grafana.com.
     permissions:
       id-token: write
       contents: write
@@ -19,5 +17,5 @@ jobs:
 
       - uses: grafana/plugin-actions/build-plugin@main
         with:
-          grafana_token: ${{ secrets.GRAFANA_API_KEY }}
+          policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
           attestation: true


### PR DESCRIPTION
this is the new way to sign the plugins, the other thing (API key) is deprecated