### PR TITLE
fix(query-editor): unique input field ids per query

### DIFF
--- a/src/components/eventsTab.tsx
+++ b/src/components/eventsTab.tsx
@@ -22,7 +22,7 @@ const ActiveAtTimeRangeCheckbox = (props: SelectedProps) => {
   return (
     <div className="gf-form gf-form-inline">
       <InlineFormLabel
-        htmlFor='active-at-time-range'
+        htmlFor={`active-at-time-range-${query.refId}`}
         tooltip="Fetch active events in the provided time range. This is essentially the same as writing the following query: events{activeAtTime={min=$__from, max=$__to}} "
         width={7}
       >
@@ -30,7 +30,7 @@ const ActiveAtTimeRangeCheckbox = (props: SelectedProps) => {
       </InlineFormLabel>
       <InlineSwitch
         label='Active only'
-        id='active-at-time-range'
+        id={`active-at-time-range-${query.refId}`}
         value={query.eventQuery.activeAtTimeRange}
         onChange={({ currentTarget }) =>
           onQueryChange({
@@ -193,11 +193,11 @@ const SortByPicker = ({ query, onQueryChange }: SelectedProps ) => {
 const ActiveAggregateCheckbox = ({ query, onQueryChange }: SelectedProps) => {
   return (
     <div className="gf-form gf-form-inline">
-      <InlineFormLabel htmlFor='with-aggregate' tooltip="Fetch with Aggregate count " width={10}>
+      <InlineFormLabel htmlFor={`with-aggregate-${query.refId}`} tooltip="Fetch with Aggregate count " width={10}>
         With Aggregate
       </InlineFormLabel>
       <InlineSwitch
-        id='with-aggregate'
+        id={`with-aggregate-${query.refId}`}
         label='With Aggregate'
         value={query.eventQuery.aggregate?.withAggregate}
         onChange={({ currentTarget }) =>

--- a/src/components/queryEditor.tsx
+++ b/src/components/queryEditor.tsx
@@ -42,12 +42,12 @@ const LatestValueCheckbox = (props: SelectedProps) => {
   const { query, onQueryChange } = props;
   return (
     <div className="gf-form gf-form-inline">
-      <InlineFormLabel htmlFor='latest-value' tooltip="Fetch the latest data point in the provided time range" width={7}>
+      <InlineFormLabel htmlFor={`latest-value-${query.refId}`} tooltip="Fetch the latest data point in the provided time range" width={7}>
         Latest value
       </InlineFormLabel>
       <InlineSwitch
         label='Latest value'
-        id='latest-value'
+        id={`latest-value-${query.refId}`}
         value={query.latestValue}
         onChange={({ currentTarget }) => onQueryChange({ latestValue: currentTarget.checked })}
       />
@@ -59,12 +59,12 @@ const IncludeTimeseriesCheckbox = (props: SelectedProps) => {
   const { includeSubTimeseries } = query.assetQuery;
   return (
     <div className="gf-form">
-      <InlineFormLabel htmlFor='include-sub-timeseries' width={11} tooltip="Fetch time series linked to the asset">
+      <InlineFormLabel htmlFor={`include-sub-timeseries-${query.refId}`} width={11} tooltip="Fetch time series linked to the asset">
         Include sub-timeseries
       </InlineFormLabel>
       <InlineSwitch
         label='Include sub-timeseries'
-        id='include-sub-timeseries'
+        id={`include-sub-timeseries-${query.refId}`}
         value={includeSubTimeseries !== false}
         onChange={({ currentTarget }) => {
           const { checked } = currentTarget;
@@ -94,11 +94,11 @@ const IncludeSubAssetsCheckbox = (props: SelectedProps) => {
 
   return (
     <div className="gf-form">
-      <InlineFormLabel htmlFor='include-sub-assets' width={9}>Include sub-assets</InlineFormLabel>
+      <InlineFormLabel htmlFor={`include-sub-assets-${query.refId}`} width={9}>Include sub-assets</InlineFormLabel>
       <InlineSwitch
         label='Include sub-assets'
         value={includeSubtrees}
-        id='include-sub-assets'
+        id={`include-sub-assets-${query.refId}`}
         onChange={({ currentTarget }) => onIncludeSubtreesChange(currentTarget.checked)}
       />
     </div>
@@ -119,12 +119,12 @@ const IncludeRelationshipsCheckbox = (props: SelectedProps) => {
 
   return (
     <div className="gf-form">
-      <InlineFormLabel htmlFor='include-relationships' tooltip="Fetch time series related to the asset" width={12}>
+      <InlineFormLabel htmlFor={`include-relationships-${query.refId}`} tooltip="Fetch time series related to the asset" width={12}>
         Include relationships
       </InlineFormLabel>
       <InlineSwitch
         label='Include relationships'
-        id='include-relationships'
+        id={`include-relationships-${query.refId}`}
         value={withRelationships}
         onChange={({ currentTarget }) => onIncludeRelationshipsChange(currentTarget.checked)}
       />
@@ -181,12 +181,12 @@ function AssetTab(props: SelectedProps & { datasource: CogniteDatasource }) {
   return (
     <div className="gf-form-inline">
       <div className="gf-form">
-        <InlineFormLabel htmlFor={'asset-select-dropdown'} width={6}>Asset Tag</InlineFormLabel>
+        <InlineFormLabel htmlFor={`asset-select-dropdown-${query.refId}`} width={6}>Asset Tag</InlineFormLabel>
         <AsyncSelect
           loadOptions={(query) => datasource.getOptionsForDropdown(query, 'Asset')}
           value={current}
           defaultOptions
-          inputId='asset-select-dropdown'
+          inputId={`asset-select-dropdown-${query.refId}`}
           data-testid='asset-select-dropdown'
           placeholder="Search asset by name/description"
           className="cog-mr-4 width-20"


### PR DESCRIPTION
Introduced a regression in the latest version.

Since the same label is used now, when having multiple queries and by clicking any switch on the `Query X` would always change `Query A` instead.

To fix this we need to assign unique ids for each labelled field (based on query refId).

<img width="739" alt="Screenshot 2025-05-06 at 14 36 32" src="https://github.com/user-attachments/assets/d4a3164c-55c3-4df7-b0de-b34b051ce048" />
