### PR TITLE
chore(events-query): replace legacy UI components

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,5 +1,12 @@
 ## Developing
 
+### Prerequisites
+- [Node.js](https://nodejs.org/en/download/)
+- [Yarn](https://yarnpkg.com/getting-started/install)
+- [Docker](https://docs.docker.com/get-docker/)
+- [Go](https://golang.org/doc/install)
+- [Mage](https://magefile.org/)
+
 The easiest way to work on this datasource is by using [docker compose](./docker-compose.yaml) approach. 
 First, run the connector:
 

--- a/provisioning/dashboards/weather-station.json
+++ b/provisioning/dashboards/weather-station.json
@@ -40,10 +40,6 @@
           "type": "cognitedata-datasource",
           "uid": "42"
         },
-        "fieldConfig": {
-          "defaults": {},
-          "overrides": []
-        },
         "gridPos": {
           "h": 8,
           "w": 12,
@@ -116,6 +112,101 @@
         "fieldConfig": {
           "defaults": {
             "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "inspect": false
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": 3,
+        "options": {
+          "cellHeight": "sm",
+          "footer": {
+            "countRows": false,
+            "fields": "",
+            "reducer": [
+              "sum"
+            ],
+            "show": false
+          },
+          "showHeader": true
+        },
+        "pluginVersion": "10.2.9",
+        "targets": [
+          {
+            "aggregation": "average",
+            "datasource": {
+              "type": "cognitedata-datasource",
+              "uid": "42"
+            },
+            "eventQuery": {
+              "activeAtTimeRange": true,
+              "advancedFilter": "",
+              "aggregate": {
+                "name": "uniqueValues",
+                "properties": [],
+                "withAggregate": false
+              },
+              "columns": [
+                "externalId",
+                "description",
+                "startTime",
+                "endTime"
+              ],
+              "expr": "events{}",
+              "sort": [
+                {
+                  "order": "asc",
+                  "property": "startTime"
+                }
+              ]
+            },
+            "expr": "",
+            "granularity": "",
+            "label": "",
+            "latestValue": false,
+            "refId": "A",
+            "tab": "Event",
+            "target": ""
+          }
+        ],
+        "title": "Events table",
+        "type": "table"
+      },
+      {
+        "datasource": {
+          "type": "cognitedata-datasource",
+          "uid": "42"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
               "mode": "palette-classic"
             },
             "custom": {
@@ -125,7 +216,6 @@
               "axisLabel": "",
               "axisPlacement": "auto",
               "barAlignment": 0,
-              "barWidthFactor": 0.6,
               "drawStyle": "line",
               "fillOpacity": 0,
               "gradientMode": "none",
@@ -173,7 +263,7 @@
           "h": 9,
           "w": 24,
           "x": 0,
-          "y": 0
+          "y": 8
         },
         "id": 1,
         "options": {

--- a/src/components/eventsTab.tsx
+++ b/src/components/eventsTab.tsx
@@ -14,6 +14,7 @@ import {
   Input,
   InlineSegmentGroup,
   Icon,
+  Field,
 } from '@grafana/ui';
 import jsonlint from 'jsonlint-mod';
 import { EventQuery, SelectedProps, EditorProps, EventsOrderDirection } from '../types';
@@ -334,18 +335,17 @@ const AdvancedEventFilter = (props) => {
           </>
         </Label>
         {showHelp && <EventAdvancedFilterHelp onDismiss={() => setShowHelp(false)} />}
-        <InlineFieldRow aria-labelledby={`advanced-filter-${query.refId}`}>
+        <Field aria-labelledby={`advanced-filter-${query.refId}`}>
           <CodeEditor
             value={query.eventQuery.advancedFilter ?? ''}
             language="json"
             height={200}
-            width="80rem"
             showLineNumbers
             showMiniMap
             onBlur={onChange}
             onSave={onChange}
           />
-        </InlineFieldRow>
+        </Field>
       </FieldSet>
       <ActiveAggregateCheckbox {...{ query, onQueryChange }} />
       {query.eventQuery.aggregate?.withAggregate && (

--- a/src/components/eventsTab.tsx
+++ b/src/components/eventsTab.tsx
@@ -1,13 +1,19 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState, ChangeEvent } from 'react';
 import {
   Button,
   CodeEditor,
   InlineFormLabel,
-  LegacyForms,
+  Label,
+  InlineField,
+  InlineFieldRow,
+  FieldSet,
   Segment,
   Tooltip,
   Select,
   InlineSwitch,
+  Input,
+  InlineSegmentGroup,
+  Icon,
 } from '@grafana/ui';
 import jsonlint from 'jsonlint-mod';
 import { EventQuery, SelectedProps, EditorProps, EventsOrderDirection } from '../types';
@@ -16,11 +22,10 @@ import CogniteDatasource from '../datasource';
 import { EventQueryHelp, EventAdvancedFilterHelp } from './queryHelp';
 import { InlineButton } from './inlineButton';
 
-const { FormField } = LegacyForms;
 const ActiveAtTimeRangeCheckbox = (props: SelectedProps) => {
   const { query, onQueryChange } = props;
   return (
-    <div className="gf-form gf-form-inline">
+    <InlineFieldRow>
       <InlineFormLabel
         htmlFor={`active-at-time-range-${query.refId}`}
         tooltip="Fetch active events in the provided time range. This is essentially the same as writing the following query: events{activeAtTime={min=$__from, max=$__to}} "
@@ -41,7 +46,7 @@ const ActiveAtTimeRangeCheckbox = (props: SelectedProps) => {
           })
         }
       />
-    </div>
+    </InlineFieldRow>
   );
 };
 const ColumnsPicker = ({ query, onQueryChange }: SelectedProps) => {
@@ -64,16 +69,16 @@ const ColumnsPicker = ({ query, onQueryChange }: SelectedProps) => {
   };
 
   return (
-    <div className="gf-form">
+    <InlineFieldRow>
       <InlineFormLabel
         tooltip="Choose which columns to display. To access metadata property, use 'metadata.propertyName'"
         width={7}
       >
         Columns
       </InlineFormLabel>
-      <div className="gf-form" style={{ flexWrap: 'wrap' }}>
+      <InlineSegmentGroup>
         {columns.map((val, key) => (
-          <>
+          <React.Fragment key={key}>
             <Segment
               value={val}
               options={options}
@@ -92,7 +97,7 @@ const ColumnsPicker = ({ query, onQueryChange }: SelectedProps) => {
               }}
               iconName="times"
             />
-          </>
+          </React.Fragment>
         ))}
         <InlineButton
           onClick={() => {
@@ -102,8 +107,8 @@ const ColumnsPicker = ({ query, onQueryChange }: SelectedProps) => {
           }}
           iconName="plus-circle"
         />
-      </div>
-    </div>
+      </InlineSegmentGroup>
+    </InlineFieldRow>
   );
 };
 
@@ -111,10 +116,9 @@ const OrderDirectionEditor = (
   { onChange, direction = "asc" }:
   { direction: EventsOrderDirection, onChange: (val: EventsOrderDirection) => void }
 ) => {
-  const options = [{ label: "ascending", value: "asc" }, { label: "descending", value: "desc" }]
-  
+  const options = [{ label: "ascending", value: "asc" }, { label: "descending", value: "desc" }];
   return (
-    <div className="gf-form">
+    <InlineFieldRow>
       <InlineFormLabel width={6}>Order</InlineFormLabel>
       <Select
         onChange={({ value }) => onChange(value as  EventsOrderDirection)}
@@ -123,7 +127,7 @@ const OrderDirectionEditor = (
         value={direction}
         className="cog-mr-4 width-10"
       />
-    </div>
+    </InlineFieldRow>
   );
 };
 
@@ -142,16 +146,16 @@ const SortByPicker = ({ query, onQueryChange }: SelectedProps ) => {
   };
 
   return (
-    <div className="gf-form">
+    <InlineFieldRow>
       <InlineFormLabel
         tooltip="Property to sort on. To access metadata property, use 'metadata.propertyName'"
         width={7}
       >
         Sort by
       </InlineFormLabel>
-      <div className="gf-form" style={{ flexWrap: 'wrap' }}>
+      <InlineSegmentGroup>
         {sort.map((val, key) => (
-          <>
+          <React.Fragment key={key}>
             <Segment
               value={val.property}
               options={options}
@@ -175,7 +179,7 @@ const SortByPicker = ({ query, onQueryChange }: SelectedProps ) => {
               }}
               iconName="times"
             />
-          </>
+          </React.Fragment>
         ))}
         {sort?.length < 2 ? <InlineButton
           onClick={() => {
@@ -185,14 +189,14 @@ const SortByPicker = ({ query, onQueryChange }: SelectedProps ) => {
           }}
           iconName="plus-circle"
         /> : null}
-      </div>
-    </div>
+      </InlineSegmentGroup>
+    </InlineFieldRow>
   );
 };
 
 const ActiveAggregateCheckbox = ({ query, onQueryChange }: SelectedProps) => {
   return (
-    <div className="gf-form gf-form-inline">
+    <InlineFieldRow>
       <InlineFormLabel htmlFor={`with-aggregate-${query.refId}`} tooltip="Fetch with Aggregate count " width={10}>
         With Aggregate
       </InlineFormLabel>
@@ -212,7 +216,7 @@ const ActiveAggregateCheckbox = ({ query, onQueryChange }: SelectedProps) => {
           })
         }
       />
-    </div>
+    </InlineFieldRow>
   );
 };
 const FieldsTypeColumnsPicker = ({ query, onQueryChange }: SelectedProps) => {
@@ -241,13 +245,13 @@ const FieldsTypeColumnsPicker = ({ query, onQueryChange }: SelectedProps) => {
     });
   };
   return (
-    <div className="gf-form">
+    <InlineFieldRow>
       <InlineFormLabel tooltip="Choose which fields properties" width={10}>
         Field properties
       </InlineFormLabel>
-      <div className="gf-form" style={{ flexWrap: 'wrap' }}>
+      <InlineSegmentGroup>
         {properties.map(({ property }, key) => (
-          <>
+          <React.Fragment key={key}>
             <Segment
               value={property}
               options={options}
@@ -272,7 +276,7 @@ const FieldsTypeColumnsPicker = ({ query, onQueryChange }: SelectedProps) => {
               }}
               iconName="times"
             />
-          </>
+          </React.Fragment>
         ))}
         <InlineButton
           onClick={() => {
@@ -285,8 +289,8 @@ const FieldsTypeColumnsPicker = ({ query, onQueryChange }: SelectedProps) => {
           }}
           iconName="plus-circle"
         />
-      </div>
-    </div>
+      </InlineSegmentGroup>
+    </InlineFieldRow>
   );
 };
 const AdvancedEventFilter = (props) => {
@@ -316,33 +320,37 @@ const AdvancedEventFilter = (props) => {
 
   return (
     <>
-      <div className="gf-form gf-form--grow">
-        <Tooltip content="click here for more information">
-          <Button
-            variant="secondary"
-            icon="question-circle"
-            onClick={() => setShowHelp(!showHelp)}
+      <FieldSet style={{ marginBottom: 8 }}>
+        <Label
+          title='Advanced filter'
+          htmlFor={`advanced-filter-${query.refId}`}
+          style={{ margin: 10 }}
+        >
+          <>
+            Advanced filter
+            <Tooltip content="click here for more information">
+              <Icon style={{ margin: 5 }} name="question-circle" onClick={() => setShowHelp(!showHelp)} />
+            </Tooltip>
+          </>
+        </Label>
+        {showHelp && <EventAdvancedFilterHelp onDismiss={() => setShowHelp(false)} />}
+        <InlineFieldRow aria-labelledby={`advanced-filter-${query.refId}`}>
+          <CodeEditor
+            value={query.eventQuery.advancedFilter ?? ''}
+            language="json"
+            height={200}
+            width="80rem"
+            showLineNumbers
+            showMiniMap
+            onBlur={onChange}
+            onSave={onChange}
           />
-        </Tooltip>
-        <span className="gf-form-label query-keyword fix-query-keyword width-8">
-          Advanced Query
-        </span>
-        <CodeEditor
-          value={query.eventQuery.advancedFilter ?? ''}
-          language="json"
-          height={200}
-          width="80rem"
-          showLineNumbers
-          showMiniMap
-          onBlur={onChange}
-          onSave={onChange}
-        />
-      </div>
+        </InlineFieldRow>
+      </FieldSet>
       <ActiveAggregateCheckbox {...{ query, onQueryChange }} />
       {query.eventQuery.aggregate?.withAggregate && (
         <FieldsTypeColumnsPicker {...{ query, onQueryChange }} />
       )}
-      {showHelp && <EventAdvancedFilterHelp onDismiss={() => setShowHelp(false)} />}
     </>
   );
 };
@@ -355,27 +363,31 @@ export function EventsTab(
 
   return (
     <>
-      <div className="gf-form">
-        <FormField
+      <InlineFieldRow>
+        <InlineField
           label="Query"
-          labelWidth={7}
-          inputWidth={30}
-          className="custom-query"
-          onChange={({ target }) => setValue(target.value)}
-          placeholder="events{}"
-          onBlur={() =>
-            onQueryChange({
-              eventQuery: {
-                ...query.eventQuery,
-                expr: value,
-              },
-            })
-          }
-          value={value}
+          labelWidth={14}
           tooltip="Click [?] button for help."
-        />
+        >
+          <Input
+            value={value}
+            id={`event-query-${query.refId}`}
+            width={30}
+            placeholder="events{}"
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setValue(e.target.value)}
+            onBlur={() =>
+              onQueryChange({
+                eventQuery: {
+                  ...query.eventQuery,
+                  expr: value,
+                },
+              })
+            }
+            className="custom-query"
+          />
+        </InlineField>
         <Button variant="secondary" icon="question-circle" onClick={() => setShowHelp(!showHelp)} />
-      </div>
+      </InlineFieldRow>
       <ActiveAtTimeRangeCheckbox {...{ query, onQueryChange }} />
       <ColumnsPicker {...{ query, onQueryChange }} />
       <SortByPicker {...{ query, onQueryChange }} />

--- a/src/components/queryHelp.tsx
+++ b/src/components/queryHelp.tsx
@@ -186,7 +186,7 @@ const HelpAlertPanel = ({ onDismiss, title, children }: HelpParams) => (
 
 export const EventAdvancedFilterHelp = ({ onDismiss }: Pick<HelpParams, 'onDismiss'>) => (
   <HelpAlertPanel title="Event advanced filter query syntax help" onDismiss={onDismiss}>
-    <a href="https://pr-ark-codegen-1444.specs.preview.cogniteapp.com/v1.json.html#operation/advancedListEvents">
+    <a href="https://api-docs.cognite.com/20230101/tag/Events/operation/advancedListEvents">
       Click here for Advanced filter documentation
     </a>
   </HelpAlertPanel>

--- a/tests/queryEditor.spec.ts
+++ b/tests/queryEditor.spec.ts
@@ -162,8 +162,21 @@ test('"Event query" as table is OK', async ({ page, gotoDashboardPage, readProvi
   await waitForQueriesToFinish(page, grafanaVersion);
   await expect(panelEditPage.refreshPanel({ waitForResponsePredicateCallback: isCdfResponse('/events/list') })).toBeOK();
 
+  // Check if the table contains the expected events
+  // Since we filtered the events by prefix, we can check if the table contains the events that start with "test_event (1"
+  // and do not contain the events that start with "test_event (2..9"
+  const ALL_EVENT_PREFIX_PATTERN = /^test_event/;
+  const EXPECTED_EVENT_PREFIX_PATTERN = /test_event \(1/;
+  const EXCLUDED_EVENT_PATTERN = /test_event \(2-9/;
+
+  const validateCellTexts = (cellTexts: string[]) => {
+    const hasExpectedEvents = cellTexts.every(text => EXPECTED_EVENT_PREFIX_PATTERN.test(text));
+    const hasNoExcludedEvents = !cellTexts.some(text => EXCLUDED_EVENT_PATTERN.test(text));
+    return cellTexts.length && hasExpectedEvents && hasNoExcludedEvents;
+  };
+
   await expect.poll(async () => {
-    const cellTexts = await panelEditPage.panel.data.getByRole('cell').allInnerTexts();
-    return cellTexts.every(text => /test_event \(0/.test(text)) && !cellTexts.some(text => /test_event \(1-9/.test(text));
+    const cellTexts = await panelEditPage.panel.locator.getByRole('cell', { name: ALL_EVENT_PREFIX_PATTERN }).allTextContents();
+    return validateCellTexts(cellTexts);
   }, { timeout: 10000 }).toBeTruthy();
 });

--- a/tests/queryEditor.spec.ts
+++ b/tests/queryEditor.spec.ts
@@ -145,17 +145,21 @@ test('"Event query" as table is OK', async ({ page, gotoDashboardPage, readProvi
 
   await expect(panelEditPage.panel.fieldNames).toContainText(["externalId", "description", "startTime", "endTime"]);
 
-  await page.getByTestId('data-testid Code editor container').getByRole("textbox").first().fill(`
+  const query = `
     {
       "prefix": {
           "property": ["externalId"],
           "value": "test_event (1"
       }
-    }`
-  , { force: true });
+    }`;
+
+  if (semver.gte(grafanaVersion, '10.2.0')) {
+    await page.getByTestId(/Code editor container/).getByRole("textbox").first().fill(query, { force: true });
+  } else {
+    await page.getByLabel(/Code editor container/).getByRole("textbox").first().fill(query, { force: true });
+  }
 
   await waitForQueriesToFinish(page, grafanaVersion);
-
   await expect(panelEditPage.refreshPanel({ waitForResponsePredicateCallback: isCdfResponse('/events/list') })).toBeOK();
 
   await expect.poll(async () => {

--- a/tests/queryEditor.spec.ts
+++ b/tests/queryEditor.spec.ts
@@ -140,8 +140,8 @@ test('"Timeseries custom query" multiple ts OK', async ({ selectors, readProvisi
 test('"Event query" as table is OK', async ({ page, gotoDashboardPage, readProvisionedDashboard, grafanaVersion }) => {
   const dashboard = await readProvisionedDashboard({ fileName: 'weather-station.json' });
   const dashboardPage = await gotoDashboardPage(dashboard);
-  
-  const panelEditPage = await dashboardPage.gotoPanelEditPage('3')
+  const EVENTS_QUERY_PANEL_ID = '3';
+  const panelEditPage = await dashboardPage.gotoPanelEditPage(EVENTS_QUERY_PANEL_ID)
 
   await expect(panelEditPage.panel.fieldNames).toContainText(["externalId", "description", "startTime", "endTime"]);
 
@@ -154,9 +154,9 @@ test('"Event query" as table is OK', async ({ page, gotoDashboardPage, readProvi
     }`;
 
   if (semver.gte(grafanaVersion, '10.2.0')) {
-    await page.getByTestId(/Code editor container/).getByRole("textbox").first().fill(query, { force: true });
+    await page.getByTestId(/Code editor container/).getByRole("textbox").first().fill(query);
   } else {
-    await page.getByLabel(/Code editor container/).getByRole("textbox").first().fill(query, { force: true });
+    await page.getByLabel(/Code editor container/).getByRole("textbox").first().fill(query);
   }
 
   await waitForQueriesToFinish(page, grafanaVersion);


### PR DESCRIPTION
**Problem / User story**
Continuation of the prev PRs: https://github.com/cognitedata/cognite-grafana-datasource/pull/540 , https://github.com/cognitedata/cognite-grafana-datasource/pull/537


Usage of gf-* CSS classes is not recommended as those might change / be removed in the future.
Legacy forms from grafana/ui are also deprecated long time ago.

**Solution**
Had to move things around a bit, since the CSS looked a bit wrong for the `Advanced filter`. (See screenshots)

-  replace FormField with InlineField
-  use InlineFieldRow, FieldSet, InlineSegmentGroup, etc as a way of grouping form elements
- update docs link to advanced event query

**Affected Resource types**
Events query (forth tab)

**Have tests been updated?**
Yes, added e2e

**Screenshots and examples**
how it looks now:
![Screenshot 2025-05-16 at 13 45 14](https://github.com/user-attachments/assets/394a6da7-4360-4b7c-99c7-a6080f04c62d)

how it used to be:

![Screenshot 2025-05-16 at 13 49 35](https://github.com/user-attachments/assets/4f211b1e-ca09-47e7-9689-3379141d7681)

