### PR TITLE
chore(tests): improve E2E test efficiency and reliability

### DIFF
--- a/.github/workflows/buind_n_test.yml
+++ b/.github/workflows/buind_n_test.yml
@@ -134,7 +134,7 @@ jobs:
       CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
 
     needs: [resolve-versions, build-and-test]
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,6 +16,8 @@ require('dotenv').config({ override: true });
  */
 export default defineConfig<PluginOptions>({
   testDir: './tests',
+  /* Per-test timeout: 45s on CI (slower runners), 30s locally */
+  timeout: process.env.CI ? 45_000 : 30_000,
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright/fixtures/addPanel.ts
+++ b/playwright/fixtures/addPanel.ts
@@ -1,0 +1,68 @@
+import semver from 'semver';
+import type { Page } from '@playwright/test';
+import { DashboardPage, PanelEditPage } from '@grafana/plugin-e2e';
+
+/**
+ * Cross-version addPanel helper.
+ *
+ * Grafana 13 introduced a completely new inline panel editing UI. The old
+ * "data-testid Add button" toolbar selector no longer exists. The new flow
+ * uses the sidebar panel:
+ *
+ *   1. Enter edit mode
+ *   2. Wait for "Sidebar container" to appear
+ *   3. If "sidebar add new panel" button is not visible, click
+ *      "Dashboard Sidebar new button" to open the add panel sidebar
+ *   4. Click "sidebar add new panel"
+ *   5. Click "Configure" button to open the visualization/query editor
+ *
+ * After step 5, the datasource picker ("data-testid Select a data source")
+ * becomes visible and PanelEditPage.datasource.set() works normally.
+ *
+ * For Grafana < 13 the original addPanel() is used unchanged.
+ */
+export async function addPanel(
+  dashboardPage: DashboardPage,
+  page: Page,
+  grafanaVersion: string
+): Promise<PanelEditPage> {
+  if (semver.lt(grafanaVersion, '13.0.0')) {
+    return dashboardPage.addPanel();
+  }
+
+  // Enter edit mode
+  await page.getByTestId('data-testid Edit dashboard button').click();
+
+  // Wait for the Grafana 13 sidebar to appear
+  await page.waitForSelector('[data-testid="data-testid Sidebar container"]', { timeout: 10000 });
+
+  // If the "new panel" button is not already visible (sidebar may be collapsed),
+  // click the "new button" to open the add-panel section of the sidebar
+  const newPanelButton = page.getByTestId('data-testid sidebar add new panel');
+  if (!await newPanelButton.isVisible()) {
+    await page.getByTestId('data-testid Dashboard Sidebar new button').click();
+  }
+
+  // Click the "Add new panel" button in the sidebar
+  await newPanelButton.click();
+
+  // Grafana 13.0.x uses a generic "Configure" role button; 13.1+ uses a
+  // specific testid. We're running 13.0.x so use the role selector.
+  const sidebarContainer = page.getByTestId('data-testid Sidebar container');
+  await sidebarContainer.getByRole('button', { name: 'Configure' }).click();
+
+  // Read the panel id from the URL if Grafana updated it (scene-based dashboards
+  // may not change the URL for new panels; default to '1').
+  let panelId = '1';
+  try {
+    await page.waitForURL(/[?&]editPanel=/, { timeout: 5000 });
+    panelId = new URL(page.url()).searchParams.get('editPanel') ?? '1';
+  } catch {
+    // Inline editing — no URL change is expected in Grafana 13
+  }
+
+  // ctx and dashboard are public fields on DashboardPage
+  const ctx = (dashboardPage as any).ctx;  // eslint-disable-line @typescript-eslint/no-explicit-any
+  const dashboard = (dashboardPage as any).dashboard;  // eslint-disable-line @typescript-eslint/no-explicit-any
+  return new PanelEditPage(ctx, { dashboard, id: panelId });
+}

--- a/playwright/fixtures/patchNavigationStrategy.ts
+++ b/playwright/fixtures/patchNavigationStrategy.ts
@@ -16,23 +16,38 @@ const setTimeoutIfNotSpecified = (options: any): void => {
 /**
  * Patches the page.goto method to use 'load' instead of 'networkidle' by default.
  * This fixes timeout issues with Grafana 12.2.1's persistent websocket connections.
+ *
+ * Also registers a locator handler to auto-dismiss the "What's new in Grafana"
+ * modal introduced in Grafana 13, which blocks pointer events until dismissed.
  */
 export const test = base.extend({
   page: async ({ page }, use) => {
     const originalGoto = page.goto.bind(page);
-    
+
     page.goto = async (url: string, options?) => {
       const modifiedOptions = { ...options };
-      
+
       if (isNetworkIdleOrUndefined(modifiedOptions.waitUntil)) {
         modifiedOptions.waitUntil = 'load';
       }
-      
+
       setTimeoutIfNotSpecified(modifiedOptions);
-      
+
       return originalGoto(url, modifiedOptions);
     };
-    
+
+    // Grafana 13+ shows a "What's new" dialog on first load that blocks all
+    // pointer events until dismissed. Register a handler so it is closed
+    // automatically whenever it appears during any test action.
+    await page.addLocatorHandler(
+      page.getByRole('dialog', { name: "What's new in Grafana" }),
+      async () => {
+        await page.getByRole('dialog', { name: "What's new in Grafana" })
+          .getByRole('button', { name: 'Close' })
+          .click();
+      }
+    );
+
     await use(page);
   },
 });

--- a/tests/datasource.spec.ts
+++ b/tests/datasource.spec.ts
@@ -18,11 +18,10 @@ test('Panel with multiple time series queries rendered OK', async ({ gotoDashboa
     '59.9139-10.7522-current.uvi W/m2'
   ];
 
-  const buttons = await page.getByRole('button', { name: /59.9139-10.7522.*/ });
-  
+  // In Grafana 13 the legend item buttons changed their accessible name to
+  // "All series selected" — use text content matching instead of role+name.
   for (const expectedTsName of expectedTs) {
-    const button = buttons.locator(`text=${expectedTsName}`);
-    await expect(button).toBeVisible();
+    await expect(page.locator('button', { hasText: expectedTsName })).toBeVisible({ timeout: 5000 });
   }
 });
 
@@ -47,11 +46,10 @@ test('Panel with multiple CogniteTimeSeries queries rendered OK', async ({ gotoD
   // Scroll down to ensure CDMTS panel is visible
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
 
-  const buttons = await page.getByRole('button', { name: /CDMTS.*/ });
-  
+  // In Grafana 13 the legend item buttons changed their accessible name to
+  // "All series selected" — use text content matching instead of role+name.
   for (const expectedTsName of expectedTs) {
-    const button = buttons.locator(`text=${expectedTsName}`);
-    await expect(button).toBeVisible();
+    await expect(page.locator('button', { hasText: expectedTsName })).toBeVisible({ timeout: 5000 });
   }
 });
 

--- a/tests/featureFlags.spec.ts
+++ b/tests/featureFlags.spec.ts
@@ -1,24 +1,16 @@
 import { expect, PluginFixture, PluginOptions } from '@grafana/plugin-e2e';
+import { Page } from '@playwright/test';
 import { readProvisionedDataSource } from '../playwright/fixtures/readProvisionedDataSource';
 import { test as patchedBase } from '../playwright/fixtures/patchNavigationStrategy';
 
 const test = patchedBase.extend<PluginFixture, PluginOptions>({ readProvisionedDataSource });
 
-// Helper function to toggle checkboxes using JavaScript for older Grafana versions
-const toggleCheckbox = async (page: any, selector: string, shouldBeChecked: boolean) => {
-  try {
-    await page.waitForSelector(selector, { timeout: 5000 });
-    
-    await page.evaluate(({ sel, checked }) => {
-      const checkbox = document.querySelector(sel) as HTMLInputElement;
-      if (checkbox && checkbox.checked !== checked) {
-        checkbox.click();
-      }
-    }, { sel: selector, checked: shouldBeChecked });
-    
-    await page.waitForTimeout(300);
-  } catch (error) {
-    console.log(`Failed to toggle checkbox ${selector}:`, error.message);
+const toggleCheckbox = async (page: Page, id: string, shouldBeChecked: boolean) => {
+  const checkbox = page.locator(id);
+  if (shouldBeChecked) {
+    await checkbox.check({ force: true });
+  } else {
+    await checkbox.uncheck({ force: true });
   }
 };
 
@@ -34,25 +26,17 @@ test.describe('Feature Flags - Tab Visibility', () => {
     const dashboard = await readProvisionedDashboard({ fileName: 'weather-station.json' });
     const dashboardPage = await gotoDashboardPage(dashboard);
 
-    // Add a new panel to test tab visibility
     const panelEditPage = await dashboardPage.addPanel();
     await panelEditPage.datasource.set('Cognite Data Fusion - Legacy Only');
-    
-    // Wait for the data source to be properly selected and query editor to update
-    await page.waitForTimeout(1000);
 
     const editorRow = panelEditPage.getQueryEditorRow("A");
 
-    // Legacy tabs should be visible and clickable
     await expect(editorRow.getByText('Time series search')).toBeVisible();
     await expect(editorRow.getByText('Events')).toBeVisible();
-    // Note: Relationships is a deprecated feature, so it's hidden for new panels
 
-    // Test that we can click on legacy tabs
     await editorRow.getByText('Time series search').click();
     await expect(editorRow.getByText('Time series search')).toHaveAttribute('aria-selected', 'true');
 
-    // Core data model tabs should be hidden (not visible in tab bar)
     await expect(editorRow.getByText('CogniteTimeSeries')).not.toBeVisible();
     await expect(editorRow.getByText('Data Models')).not.toBeVisible();
   });
@@ -68,169 +52,110 @@ test.describe('Feature Flags - Tab Visibility', () => {
     const dashboard = await readProvisionedDashboard({ fileName: 'weather-station-core.json' });
     const dashboardPage = await gotoDashboardPage(dashboard);
 
-    // Add a new panel to test tab visibility
     const panelEditPage = await dashboardPage.addPanel();
     await panelEditPage.datasource.set('Cognite Data Fusion - Core Only');
-    
-    // Wait for the data source to be properly selected and query editor to update
-    await page.waitForTimeout(1000);
 
     const editorRow = panelEditPage.getQueryEditorRow("A");
 
-    // Core data model tabs should be visible and clickable
-    // Use getByRole('tab') to specifically target the tab, not the dropdown placeholder
     const cogniteTimeSeriesTab = editorRow.getByRole('tab', { name: 'CogniteTimeSeries' });
     await expect(cogniteTimeSeriesTab).toBeVisible();
     await expect(editorRow.getByText('Data Models')).toBeVisible();
 
-    // Test that we can click on core tabs
     await cogniteTimeSeriesTab.click();
     await expect(cogniteTimeSeriesTab).toHaveAttribute('aria-selected', 'true');
 
-    // Legacy tabs should be hidden (not visible in tab bar)
     await expect(editorRow.getByText('Time series search')).not.toBeVisible();
     await expect(editorRow.getByText('Events')).not.toBeVisible();
     await expect(editorRow.getByText('Relationships')).not.toBeVisible();
   });
-
 });
 
 test.describe('Feature Flags - Config Editor', () => {
-  test('Should toggle legacy data model features on/off', async ({
-    readProvisionedDataSource,
-    gotoDataSourceConfigPage,
-    page,
-  }) => {
-    // Set same viewport as queryEditor.spec.ts for consistency
-    await page.setViewportSize({ width: 1920, height: 1080 });
-    
-    const datasource = await readProvisionedDataSource({ fileName: 'datasources.yml', name: 'Cognite Data Fusion - Config Test' });
-    const configPage = await gotoDataSourceConfigPage(datasource.uid);
+  let configPage: any;
+  let page: Page;
 
-    // Wait for the page to fully load
+  test.beforeEach(async ({ readProvisionedDataSource, gotoDataSourceConfigPage, page: p }) => {
+    page = p;
+    await page.setViewportSize({ width: 1920, height: 1080 });
+    const datasource = await readProvisionedDataSource({ fileName: 'datasources.yml', name: 'Cognite Data Fusion - Config Test' });
+    configPage = await gotoDataSourceConfigPage(datasource.uid);
     await page.waitForLoadState('load');
-    
-    // Get the legacy master toggle element
+  });
+
+  test('Should toggle legacy data model features on/off', async () => {
     const legacyMasterToggle = page.locator('#enable-legacy-data-model-features');
-    
-    // Element should be accessible via JavaScript
+
     await expect(legacyMasterToggle).toBeVisible();
 
-    // Check the initial state (may vary based on provisioned config)
     const initiallyChecked = await legacyMasterToggle.isChecked();
-    
-    // If not initially checked, enable it first
     if (!initiallyChecked) {
       await legacyMasterToggle.check({ force: true });
     }
     await expect(legacyMasterToggle).toBeChecked();
 
-    // Individual legacy feature toggles should be visible and enabled
     await expect(page.locator('#enable-timeseries-search')).toBeVisible();
     await expect(page.locator('#enable-timeseries-from-asset')).toBeVisible();
     await expect(page.locator('#enable-timeseries-custom-query')).toBeVisible();
     await expect(page.locator('#enable-events')).toBeVisible();
 
-    // Turn off legacy features - use JavaScript approach for Grafana 10.x compatibility
     await toggleCheckbox(page, '#enable-legacy-data-model-features', false);
     await expect(legacyMasterToggle).not.toBeChecked();
 
-    // Individual toggles should be disabled/hidden
     await expect(page.locator('#enable-timeseries-search')).not.toBeChecked();
     await expect(page.locator('#enable-timeseries-from-asset')).not.toBeChecked();
     await expect(page.locator('#enable-timeseries-custom-query')).not.toBeChecked();
     await expect(page.locator('#enable-events')).not.toBeChecked();
 
-    // Turn legacy features back on
     await toggleCheckbox(page, '#enable-legacy-data-model-features', true);
     await expect(legacyMasterToggle).toBeChecked();
 
-    // Individual toggles should be enabled again (with their default values)
     await expect(page.locator('#enable-timeseries-search')).toBeChecked();
     await expect(page.locator('#enable-timeseries-from-asset')).toBeChecked();
     await expect(page.locator('#enable-timeseries-custom-query')).toBeChecked();
     await expect(page.locator('#enable-events')).toBeChecked();
   });
 
-  test('Should toggle core data model features on/off', async ({
-    readProvisionedDataSource,
-    gotoDataSourceConfigPage,
-    page,
-  }) => {
-    // Set same viewport as queryEditor.spec.ts for consistency
-    await page.setViewportSize({ width: 1920, height: 1080 });
-    
-    const datasource = await readProvisionedDataSource({ fileName: 'datasources.yml', name: 'Cognite Data Fusion - Config Test' });
-    const configPage = await gotoDataSourceConfigPage(datasource.uid);
-
-    // Wait for the page to fully load
-    await page.waitForLoadState('load');
-    
-    // Get the core master toggle element
+  test('Should toggle core data model features on/off', async () => {
     const coreMasterToggle = page.locator('#enable-core-data-model-features');
-    
-    // Use aggressive scrolling to ensure element is visible
+
     await expect(coreMasterToggle).toBeVisible();
 
-    // Check the initial state and ensure it's enabled for testing
     const initiallyChecked = await coreMasterToggle.isChecked();
     if (!initiallyChecked) {
       await coreMasterToggle.check({ force: true });
     }
     await expect(coreMasterToggle).toBeChecked();
 
-    // Individual core feature toggles should be visible
     await expect(page.locator('#enable-cognite-timeseries')).toBeVisible();
     await expect(page.locator('#enable-flexible-data-modelling')).toBeVisible();
 
-    // Turn off core features - use JavaScript approach
     await toggleCheckbox(page, '#enable-core-data-model-features', false);
     await expect(coreMasterToggle).not.toBeChecked();
 
-    // Individual toggles should be disabled
     await expect(page.locator('#enable-cognite-timeseries')).not.toBeChecked();
     await expect(page.locator('#enable-flexible-data-modelling')).not.toBeChecked();
 
-    // Turn core features back on - use JavaScript approach
     await toggleCheckbox(page, '#enable-core-data-model-features', true);
     await expect(coreMasterToggle).toBeChecked();
 
-    // Individual toggles should be enabled when core master toggle is enabled
     await expect(page.locator('#enable-cognite-timeseries')).toBeChecked();
     await expect(page.locator('#enable-flexible-data-modelling')).toBeChecked();
   });
 
-  test('Should allow individual feature toggles when master is enabled', async ({
-    readProvisionedDataSource,
-    gotoDataSourceConfigPage,
-    page,
-  }) => {
-    // Set same viewport as queryEditor.spec.ts for consistency
-    await page.setViewportSize({ width: 1920, height: 1080 });
-    
-    const datasource = await readProvisionedDataSource({ fileName: 'datasources.yml', name: 'Cognite Data Fusion - Config Test' });
-    const configPage = await gotoDataSourceConfigPage(datasource.uid);
-
-    // Wait for the page to fully load and scroll to feature flags
-    await page.waitForLoadState('load');
+  test('Should allow individual feature toggles when master is enabled', async () => {
     const legacyMasterToggle = page.locator('#enable-legacy-data-model-features');
-    
-    // Ensure legacy master toggle is enabled
     await legacyMasterToggle.check({ force: true });
 
-    // Test individual legacy feature toggles
     const timeseriesSearchToggle = page.locator('#enable-timeseries-search');
     const eventsToggle = page.locator('#enable-events');
 
-    // Turn off individual features
     await toggleCheckbox(page, '#enable-timeseries-search', false);
     await expect(timeseriesSearchToggle).not.toBeChecked();
-    await expect(legacyMasterToggle).toBeChecked(); // Master should remain on
+    await expect(legacyMasterToggle).toBeChecked();
 
     await toggleCheckbox(page, '#enable-events', false);
     await expect(eventsToggle).not.toBeChecked();
 
-    // Turn them back on
     await toggleCheckbox(page, '#enable-timeseries-search', true);
     await expect(timeseriesSearchToggle).toBeChecked();
 
@@ -238,85 +163,42 @@ test.describe('Feature Flags - Config Editor', () => {
     await expect(eventsToggle).toBeChecked();
   });
 
-  test('Should show deprecated features without master toggle', async ({
-    readProvisionedDataSource,
-    gotoDataSourceConfigPage,
-    page,
-  }) => {
-    // Set same viewport as queryEditor.spec.ts for consistency
-    await page.setViewportSize({ width: 1920, height: 1080 });
-    
-    const datasource = await readProvisionedDataSource({ fileName: 'datasources.yml', name: 'Cognite Data Fusion - Config Test' });
-    const configPage = await gotoDataSourceConfigPage(datasource.uid);
-
-    // Wait for the page to fully load and scroll to feature flags
-    await page.waitForLoadState('load');
-
-    // Deprecated features should be visible and toggleable independently
+  test('Should show deprecated features without master toggle', async () => {
     await expect(page.locator('#enable-relationships')).toBeVisible();
     await expect(page.locator('#enable-templates')).toBeVisible();
     await expect(page.locator('#enable-extraction-pipelines')).toBeVisible();
 
-    // These should not be affected by master toggles
     const relationshipsToggle = page.locator('#enable-relationships');
     const templatesToggle = page.locator('#enable-templates');
 
-    // Toggle deprecated features independently
     await toggleCheckbox(page, '#enable-relationships', false);
     await expect(relationshipsToggle).not.toBeChecked();
 
     await toggleCheckbox(page, '#enable-templates', true);
     await expect(templatesToggle).toBeChecked();
 
-    // Master toggles should not affect deprecated features
-    const legacyMasterToggle = page.locator('#enable-legacy-data-model-features');
-    const coreMasterToggle = page.locator('#enable-core-data-model-features');
-
     await toggleCheckbox(page, '#enable-legacy-data-model-features', false);
     await toggleCheckbox(page, '#enable-core-data-model-features', false);
 
-    // Deprecated features should maintain their state
     await expect(relationshipsToggle).not.toBeChecked();
     await expect(templatesToggle).toBeChecked();
   });
 
-  test('Should save and persist feature flag changes', async ({
-    readProvisionedDataSource,
-    gotoDataSourceConfigPage,
-    page,
-  }) => {
-    // Set same viewport as queryEditor.spec.ts for consistency
-    await page.setViewportSize({ width: 1920, height: 1080 });
-    
-    const datasource = await readProvisionedDataSource({ fileName: 'datasources.yml', name: 'Cognite Data Fusion - Config Test' });
-    const configPage = await gotoDataSourceConfigPage(datasource.uid);
-
-    // Wait for the page to fully load and scroll to feature flags
-    await page.waitForLoadState('load');
-    const legacyMasterToggle = page.locator('#enable-legacy-data-model-features');
-
-    // Change some feature flags
-    const coreMasterToggle = page.locator('#enable-core-data-model-features');
-
+  test('Should save and persist feature flag changes', async () => {
     await toggleCheckbox(page, '#enable-legacy-data-model-features', false);
     await toggleCheckbox(page, '#enable-core-data-model-features', false);
 
-    // Save the configuration
     await page.getByTestId('data-testid Data source settings page Save and Test button').click();
     await expect(configPage).toHaveAlert('success');
 
-    // Reload the page to verify persistence
     await page.reload();
 
-    // Feature flags should maintain their disabled state
     await expect(page.locator('#enable-legacy-data-model-features')).not.toBeChecked();
     await expect(page.locator('#enable-core-data-model-features')).not.toBeChecked();
 
-    // Individual features should also be disabled
     await expect(page.locator('#enable-timeseries-search')).not.toBeChecked();
     await expect(page.locator('#enable-cognite-timeseries')).not.toBeChecked();
 
-    // Reset to original state for cleanup
     await toggleCheckbox(page, '#enable-legacy-data-model-features', true);
     await toggleCheckbox(page, '#enable-core-data-model-features', true);
     await page.getByTestId('data-testid Data source settings page Save and Test button').click();

--- a/tests/featureFlags.spec.ts
+++ b/tests/featureFlags.spec.ts
@@ -2,6 +2,7 @@ import { expect, PluginFixture, PluginOptions } from '@grafana/plugin-e2e';
 import { Page } from '@playwright/test';
 import { readProvisionedDataSource } from '../playwright/fixtures/readProvisionedDataSource';
 import { test as patchedBase } from '../playwright/fixtures/patchNavigationStrategy';
+import { addPanel } from '../playwright/fixtures/addPanel';
 
 const test = patchedBase.extend<PluginFixture, PluginOptions>({ readProvisionedDataSource });
 
@@ -33,7 +34,7 @@ test.describe('Feature Flags - Tab Visibility', () => {
     const dashboard = await readProvisionedDashboard({ fileName: 'weather-station.json' });
     const dashboardPage = await gotoDashboardPage(dashboard);
 
-    const panelEditPage = await dashboardPage.addPanel();
+    const panelEditPage = await addPanel(dashboardPage, page, grafanaVersion);
     await panelEditPage.datasource.set('Cognite Data Fusion - Legacy Only');
 
     const editorRow = panelEditPage.getQueryEditorRow("A");
@@ -59,7 +60,7 @@ test.describe('Feature Flags - Tab Visibility', () => {
     const dashboard = await readProvisionedDashboard({ fileName: 'weather-station-core.json' });
     const dashboardPage = await gotoDashboardPage(dashboard);
 
-    const panelEditPage = await dashboardPage.addPanel();
+    const panelEditPage = await addPanel(dashboardPage, page, grafanaVersion);
     await panelEditPage.datasource.set('Cognite Data Fusion - Core Only');
 
     const editorRow = panelEditPage.getQueryEditorRow("A");

--- a/tests/featureFlags.spec.ts
+++ b/tests/featureFlags.spec.ts
@@ -5,12 +5,19 @@ import { test as patchedBase } from '../playwright/fixtures/patchNavigationStrat
 
 const test = patchedBase.extend<PluginFixture, PluginOptions>({ readProvisionedDataSource });
 
+/**
+ * Toggles a checkbox to the desired state using dispatchEvent('click').
+ * Playwright's native check/uncheck fails with "Element is outside of the
+ * viewport" on older Grafana versions even with force:true, because the
+ * config editor places feature toggles below the fold.  dispatchEvent
+ * bypasses viewport and actionability checks while still throwing if the
+ * element does not exist.
+ */
 const toggleCheckbox = async (page: Page, id: string, shouldBeChecked: boolean) => {
   const checkbox = page.locator(id);
-  if (shouldBeChecked) {
-    await checkbox.check({ force: true });
-  } else {
-    await checkbox.uncheck({ force: true });
+  const isChecked = await checkbox.isChecked();
+  if (isChecked !== shouldBeChecked) {
+    await checkbox.dispatchEvent('click');
   }
 };
 
@@ -87,10 +94,7 @@ test.describe('Feature Flags - Config Editor', () => {
 
     await expect(legacyMasterToggle).toBeVisible();
 
-    const initiallyChecked = await legacyMasterToggle.isChecked();
-    if (!initiallyChecked) {
-      await legacyMasterToggle.check({ force: true });
-    }
+    await toggleCheckbox(page, '#enable-legacy-data-model-features', true);
     await expect(legacyMasterToggle).toBeChecked();
 
     await expect(page.locator('#enable-timeseries-search')).toBeVisible();
@@ -120,10 +124,7 @@ test.describe('Feature Flags - Config Editor', () => {
 
     await expect(coreMasterToggle).toBeVisible();
 
-    const initiallyChecked = await coreMasterToggle.isChecked();
-    if (!initiallyChecked) {
-      await coreMasterToggle.check({ force: true });
-    }
+    await toggleCheckbox(page, '#enable-core-data-model-features', true);
     await expect(coreMasterToggle).toBeChecked();
 
     await expect(page.locator('#enable-cognite-timeseries')).toBeVisible();
@@ -144,7 +145,7 @@ test.describe('Feature Flags - Config Editor', () => {
 
   test('Should allow individual feature toggles when master is enabled', async () => {
     const legacyMasterToggle = page.locator('#enable-legacy-data-model-features');
-    await legacyMasterToggle.check({ force: true });
+    await toggleCheckbox(page, '#enable-legacy-data-model-features', true);
 
     const timeseriesSearchToggle = page.locator('#enable-timeseries-search');
     const eventsToggle = page.locator('#enable-events');

--- a/tests/queryEditor.spec.ts
+++ b/tests/queryEditor.spec.ts
@@ -159,6 +159,7 @@ test('Panel with asset subtree queries rendered OK', async ({ selectors, readPro
 });
 
 test('"Timeseries custom query" multiple ts OK', async ({ selectors, readProvisionedDataSource, gotoDashboardPage, readProvisionedDashboard, page, grafanaVersion }) => {
+  test.setTimeout(90_000);
   const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
   const dashboard = await readProvisionedDashboard({ fileName: 'weather-station.json' });
   const dashboardPage = await gotoDashboardPage(dashboard);
@@ -397,10 +398,14 @@ test('"CogniteTimeSeries" unit conversion not shown for timeseries without units
 
   await searchAndSelectTimeSeries(page, editorRow, panelEditPage, option, '59.9139-10.7522-current.clouds');
 
-  // Target Unit and Unit label should NOT appear for timeseries without units.
-  // Use a short explicit wait because we're asserting absence.
-  await page.waitForTimeout(2000);
+  // Wait for the search dropdown to close, confirming the selection was processed
+  const dropdownOption = panelEditPage
+    .getByGrafanaSelector(option)
+    .filter({ hasText: /59\.9139-10\.7522-current\.clouds/i })
+    .first();
+  await expect(dropdownOption).not.toBeVisible();
 
+  // Target Unit and Unit label should NOT appear for timeseries without units
   const targetUnitField = editorRow.locator('label:has-text("Target Unit")');
   await expect(targetUnitField).not.toBeVisible();
 

--- a/tests/queryEditor.spec.ts
+++ b/tests/queryEditor.spec.ts
@@ -175,7 +175,12 @@ test('"Timeseries custom query" multiple ts OK', async ({ selectors, readProvisi
 
   const panelEditPage = await dashboardPage.addPanel();
   await panelEditPage.datasource.set(ds.name);
-  await panelEditPage.setVisualization('Table');
+
+  // Select Table visualization: Grafana <=12.1 uses aria-label, 12.4+ uses data-testid
+  await page.getByTestId('data-testid toggle-viz-picker').click();
+  const tableViz = page.locator('[aria-label="Plugin visualization item Table"]')
+    .or(page.getByTestId('data-testid Plugin visualization item Table'));
+  await tableViz.click();
 
   for (const [index, tsExternalId] of tsExternalIds.entries()) {
     await page.getByTestId(/query-tab-add-query/).click();
@@ -197,17 +202,8 @@ test('"Timeseries custom query" multiple ts OK', async ({ selectors, readProvisi
   await waitForQueriesToFinish(page);
   await expect(panelEditPage.refreshPanel({ waitForResponsePredicateCallback: isCdfResponse('/timeseries/synthetic/query') })).toBeOK();
 
-  // Based on actual UI inspection of different Grafana versions:
-  // - 11.6.7+: uses 'data-testid Tab Transformations'
-  // - 11.2.10: uses 'data-testid Tab Transform data'
-  // - <11.0.0: uses role selector
-  if (semver.gte(grafanaVersion, '11.5.4')) {
-    await page.getByTestId('data-testid Tab Transformations').click();
-  } else if (semver.gte(grafanaVersion, '11.0.0')) {
-    await page.getByTestId('data-testid Tab Transform data').click();
-  } else {
-    await page.getByRole('tab', { name: 'Tab Transform' }).click();
-  }
+  // Grafana renamed this tab across versions; use a resilient role-based selector
+  await page.getByRole('tab', { name: /Transform/ }).click();
 
   if (semver.gte(grafanaVersion, '10.2.0')) {
     await page.getByTestId('data-testid add transformation button').click();

--- a/tests/queryEditor.spec.ts
+++ b/tests/queryEditor.spec.ts
@@ -1,5 +1,5 @@
 import { expect, PluginFixture, PluginOptions } from '@grafana/plugin-e2e';
-import { Response } from 'playwright';
+import { Page, Response } from 'playwright';
 import { waitForQueriesToFinish } from '../playwright/fixtures/waitForQueriesToFinish';
 import { readProvisionedDataSource } from '../playwright/fixtures/readProvisionedDataSource';
 import { test as patchedBase } from '../playwright/fixtures/patchNavigationStrategy';
@@ -18,15 +18,88 @@ const expectedTs = [
   '59.9139-10.7522-current.uvi'
 ].sort();
 
-
 const isCdfResponse = (path: string) => {
   return (response: Response) => {
     const isTsData = response.request().url().endsWith(path);
     const is200 = response.status() === 200;
-
     return isTsData && is200;
   }
 };
+
+/**
+ * Shared setup for CogniteTimeSeries tests: sets viewport, navigates to a new
+ * panel, selects the datasource, clicks the CogniteTimeSeries tab, and picks
+ * the first CogniteTimeSeries/cdf_cdm view.
+ *
+ * Returns { panelEditPage, editorRow, option } for further test-specific steps.
+ */
+async function setupCogniteTimeSeriesPanel({
+  readProvisionedDataSource: readDS,
+  readProvisionedDashboard: readDash,
+  gotoDashboardPage: gotoDash,
+  selectors,
+  page,
+}: Pick<
+  PluginFixture,
+  'readProvisionedDataSource' | 'readProvisionedDashboard' | 'gotoDashboardPage' | 'selectors'
+> & { page: Page }) {
+  await page.setViewportSize({ width: 1920, height: 1080 });
+
+  const ds = await readDS({ fileName: 'datasources.yml' });
+  const dashboard = await readDash({ fileName: 'weather-station.json' });
+  const dashboardPage = await gotoDash(dashboard);
+
+  const panelEditPage = await dashboardPage.addPanel();
+  await panelEditPage.datasource.set(ds.name);
+
+  const editorRow = panelEditPage.getQueryEditorRow("A");
+
+  // Wait for CogniteTimeSeries tab to appear after datasource selection
+  await expect(editorRow.getByText('CogniteTimeSeries')).toBeVisible();
+  await editorRow.getByText('CogniteTimeSeries').click();
+
+  const viewField = editorRow.locator('label:has-text("View")').locator('..');
+  const viewDropdown = viewField.locator('input').first();
+  await viewDropdown.click();
+
+  const option = selectors.components.Select.option;
+  const cogniteTimeSeriesOption = panelEditPage
+    .getByGrafanaSelector(option)
+    .filter({ hasText: /CogniteTimeSeries.*cdf_cdm/i });
+
+  // Wait for the view options to load from the container inspect API
+  await expect(cogniteTimeSeriesOption.first()).toBeVisible({ timeout: 10000 });
+  await cogniteTimeSeriesOption.first().click();
+
+  return { panelEditPage, editorRow, option, dashboardPage };
+}
+
+/**
+ * Searches for and selects a timeseries by external ID in the CogniteTimeSeries
+ * search dropdown. Waits for the search result to appear before clicking.
+ */
+async function searchAndSelectTimeSeries(
+  page: Page,
+  editorRow: ReturnType<Awaited<ReturnType<typeof setupCogniteTimeSeriesPanel>>['panelEditPage']['getQueryEditorRow']>,
+  panelEditPage: Awaited<ReturnType<typeof setupCogniteTimeSeriesPanel>>['panelEditPage'],
+  option: string,
+  searchTerm: string,
+  queryLetter = 'A',
+) {
+  const searchInput = editorRow.locator(`input[id="cognite-timeseries-search-${queryLetter}"]`);
+  await searchInput.click();
+  await searchInput.fill(searchTerm);
+
+  await waitForQueriesToFinish(page);
+
+  const escaped = searchTerm.replace(/\./g, '\\.');
+  const tsOption = panelEditPage
+    .getByGrafanaSelector(option)
+    .filter({ hasText: new RegExp(escaped, 'i') })
+    .first();
+  await expect(tsOption).toBeVisible({ timeout: 10000 });
+  await tsOption.click();
+}
 
 test('Panel with asset subtree queries rendered OK', async ({ selectors, readProvisionedDataSource, gotoDashboardPage, readProvisionedDashboard, page, grafanaVersion }) => {
   test.setTimeout(60000);
@@ -43,11 +116,10 @@ test('Panel with asset subtree queries rendered OK', async ({ selectors, readPro
 
   const combobox = await editorRow.getByRole('combobox', { name: 'Asset Tag' });
   await combobox.click();
-  
-  // Wait for dropdown to populate
-  await page.waitForTimeout(2000);
 
   const option = selectors.components.Select.option;
+  // Wait for dropdown options to appear instead of fixed timeout
+  await expect(panelEditPage.getByGrafanaSelector(option).first()).toBeVisible({ timeout: 10000 });
   await panelEditPage.getByGrafanaSelector(option).filter({ hasText: 'Locations' }).click();
 
   const includeSubAssets = await editorRow.getByLabel('Include sub-assets').nth(1);
@@ -90,7 +162,7 @@ test('"Timeseries custom query" multiple ts OK', async ({ selectors, readProvisi
   const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
   const dashboard = await readProvisionedDashboard({ fileName: 'weather-station.json' });
   const dashboardPage = await gotoDashboardPage(dashboard);
-  
+
   const tsExternalIds = [
     '59.9139-10.7522-current.humidity',
     '59.9139-10.7522-current.pressure',
@@ -99,24 +171,24 @@ test('"Timeseries custom query" multiple ts OK', async ({ selectors, readProvisi
 
   const panels = ['A', 'B', 'C'];
   const units = ['percent', 'hPa', 'Kelvin'];
-  
+
   const panelEditPage = await dashboardPage.addPanel();
   await panelEditPage.datasource.set(ds.name);
   await panelEditPage.setVisualization('Table');
-  
+
   for (const [index, tsExternalId] of tsExternalIds.entries()) {
     await page.getByTestId(/query-tab-add-query/).click();
     const editorRow = panelEditPage.getQueryEditorRow(panels[index]);
-  
+
     await editorRow.getByText('Time series custom query').click();
-  
+
     await editorRow.getByRole('textbox', { name: 'Query' }).fill(`ts{externalId="${tsExternalId}"}`);
-  
+
     await editorRow.getByRole('combobox', { name: 'Aggregation' }).click();
     const option = selectors.components.Select.option;
-    
+
     await panelEditPage.getByGrafanaSelector(option).filter({ hasText: 'Interpolation' }).first().click();
-    
+
     await editorRow.getByRole('textbox', { name: 'Label' }).fill(`{{externalId}}-{{unit}}`);
     await editorRow.getByRole('textbox', { name: 'Granularity' }).fill(`1d`);
   }
@@ -124,10 +196,9 @@ test('"Timeseries custom query" multiple ts OK', async ({ selectors, readProvisi
   await waitForQueriesToFinish(page);
   await expect(panelEditPage.refreshPanel({ waitForResponsePredicateCallback: isCdfResponse('/timeseries/synthetic/query') })).toBeOK();
 
-  // transform into a single table, this is simpler to assert
   // Based on actual UI inspection of different Grafana versions:
   // - 11.6.7+: uses 'data-testid Tab Transformations'
-  // - 11.2.10: uses 'data-testid Tab Transform data'  
+  // - 11.2.10: uses 'data-testid Tab Transform data'
   // - <11.0.0: uses role selector
   if (semver.gte(grafanaVersion, '11.5.4')) {
     await page.getByTestId('data-testid Tab Transformations').click();
@@ -142,7 +213,7 @@ test('"Timeseries custom query" multiple ts OK', async ({ selectors, readProvisi
   }
 
   await page.getByRole('button', { name: 'Join by field' }).click();
-  
+
   const tsWithUnits = tsExternalIds.map((ts, i) => `${ts}-${units[i]}`);
   await expect(panelEditPage.panel.fieldNames).toContainText(tsWithUnits);
 });
@@ -155,8 +226,7 @@ test('"Event query" as table is OK', async ({ page, gotoDashboardPage, readProvi
   const panelEditPage = await dashboardPage.gotoPanelEditPage(EVENTS_QUERY_PANEL_ID)
 
   await expect(panelEditPage.panel.fieldNames).toContainText(["externalId", "description", "startTime", "endTime"]);
-  
-  // Select only the first column (externalId)
+
   const deleteColumnButtonPattern = /event-remove-col-/;
   while (await page.getByTestId(deleteColumnButtonPattern).count() !== 1) {
     await page.getByTestId(deleteColumnButtonPattern).last().click();
@@ -178,19 +248,15 @@ test('"Event query" as table is OK', async ({ page, gotoDashboardPage, readProvi
 
   await waitForQueriesToFinish(page);
   await expect(panelEditPage.refreshPanel({ waitForResponsePredicateCallback: isCdfResponse('/events/list') })).toBeOK();
-  
+
 
   await expect(panelEditPage.panel.fieldNames).toHaveText("externalId");
   await expect(panelEditPage.panel.fieldNames).not.toContainText(["description", "startTime", "endTime"]);
 
-  // Check if the table contains the expected events
-  // Since we filtered the events by prefix, we can check if the table contains the events that start with "test_event (1"
-  // and do not contain the events that start with "test_event (2..9"
   const EXPECTED_EVENT_PREFIX_PATTERN = /test_event \(1/;
   const EXCLUDED_EVENT_PATTERN = /test_event \(2-9/;
 
   const validateCellTexts = (cellTexts: string[]) => {
-    // Filter out header cells and empty cells, focus on actual event data
     const eventCells = cellTexts.filter(text => text && text.includes('test_event'));
     const hasExpectedEvents = eventCells.length > 0 && eventCells.some(text => EXPECTED_EVENT_PREFIX_PATTERN.test(text));
     const hasNoExcludedEvents = !eventCells.some(text => EXCLUDED_EVENT_PATTERN.test(text));
@@ -198,17 +264,14 @@ test('"Event query" as table is OK', async ({ page, gotoDashboardPage, readProvi
   };
 
   await expect.poll(async () => {
-    // Try different selectors for cross-Grafana version compatibility
     let cellTexts: string[] = [];
-    
-    // First try the standard plugin-e2e selector
+
     try {
       cellTexts = await panelEditPage.panel.data.allInnerTexts();
     } catch (e) {
       // Selector may not work in all Grafana versions
     }
-    
-    // If that fails, try direct table selectors
+
     if (cellTexts.length === 0) {
       try {
         const tableCells = await page.locator('table td, table th').allInnerTexts();
@@ -217,20 +280,18 @@ test('"Event query" as table is OK', async ({ page, gotoDashboardPage, readProvi
         // Table selector may not work in all cases
       }
     }
-    
-    // If still no data, extract from panel text (fallback for newer Grafana versions)
+
     if (cellTexts.length === 0) {
       try {
         const panelText = await panelEditPage.panel.locator.textContent();
         if (panelText) {
-          // Extract event data from the panel text
           cellTexts = panelText.split(/(?=test_event)/).filter(text => text.includes('test_event'));
         }
       } catch (e) {
         // Final fallback failed
       }
     }
-    
+
     return validateCellTexts(cellTexts);
   }, { timeout: 10000 }).toBeTruthy();
 });
@@ -239,7 +300,7 @@ test('"Event query" can open Help panel', async ({ page, gotoDashboardPage, read
   const dashboard = await readProvisionedDashboard({ fileName: 'weather-station.json' });
   const dashboardPage = await gotoDashboardPage(dashboard);
   const EVENTS_QUERY_PANEL_ID = '3';
-  
+
   await dashboardPage.gotoPanelEditPage(EVENTS_QUERY_PANEL_ID)
 
   await page.getByTestId(/event-query-help/).click();
@@ -248,112 +309,45 @@ test('"Event query" can open Help panel', async ({ page, gotoDashboardPage, read
 });
 
 test('"CogniteTimeSeries" tab can be selected and search works', async ({ selectors, readProvisionedDataSource, gotoDashboardPage, readProvisionedDashboard, page, grafanaVersion }) => {
-  // Set a larger viewport to ensure all UI elements are visible
-  await page.setViewportSize({ width: 1920, height: 1080 });
-  
-  const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
-  const dashboard = await readProvisionedDashboard({ fileName: 'weather-station.json' });
-  const dashboardPage = await gotoDashboardPage(dashboard);
+  const { panelEditPage, editorRow } = await setupCogniteTimeSeriesPanel({
+    readProvisionedDataSource,
+    readProvisionedDashboard,
+    gotoDashboardPage,
+    selectors,
+    page,
+  });
 
-  const panelEditPage = await dashboardPage.addPanel();
-  await panelEditPage.datasource.set(ds.name);
-  
-  // Wait for data source to be properly selected and tabs to render
-  await page.waitForTimeout(1000);
-
-  const editorRow = panelEditPage.getQueryEditorRow("A");
-
-  // Click on CogniteTimeSeries tab
-  await editorRow.getByText('CogniteTimeSeries').click();
-
-  // Test that the View dropdown is visible (single dropdown with views from container inspect API)
   const viewField = editorRow.locator('label:has-text("View")').locator('..');
   await expect(viewField).toBeVisible();
 
-  // Click on the View dropdown to see available options
-  const viewDropdown = viewField.locator('input').first();
-  await viewDropdown.click();
-  
-  // Wait for view options to load from the container inspect API
-  await page.waitForTimeout(2000);
-  
-  // Check that at least one CogniteTimeSeries view option is available
-  const option = selectors.components.Select.option;
-  const cogniteTimeSeriesOption = panelEditPage.getByGrafanaSelector(option).filter({ hasText: /CogniteTimeSeries.*cdf_cdm/i });
-  await expect(cogniteTimeSeriesOption.first()).toBeVisible({ timeout: 10000 });
-  
-  // Select the CogniteTimeSeries view
-  await cogniteTimeSeriesOption.first().click();
-
-  // Test that search AsyncSelect is visible - use the input element with the specific id
   const searchInput = editorRow.locator('input[id="cognite-timeseries-search-A"]');
   await expect(searchInput).toBeVisible();
 
-  // Test aggregation selector (should be set to Average)
   const aggregationField = editorRow.locator('label:has-text("Aggregation")').locator('..');
   const aggregationValue = aggregationField.getByText('Average');
   await expect(aggregationValue).toBeVisible();
 
-  // Test granularity input
   const granularityInput = editorRow.locator('input[id="granularity-A"]');
   await expect(granularityInput).toBeVisible();
 
-  // Test label input  
   const labelInput = editorRow.locator('input[id="label-A"]');
   await expect(labelInput).toBeVisible();
 });
 
 test('"CogniteTimeSeries" query with selection works', async ({ selectors, readProvisionedDataSource, gotoDashboardPage, readProvisionedDashboard, page, grafanaVersion }) => {
-  // Set a larger viewport to ensure all UI elements are visible
-  await page.setViewportSize({ width: 1920, height: 1080 });
-  
-  const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
-  const dashboard = await readProvisionedDashboard({ fileName: 'weather-station.json' });
-  const dashboardPage = await gotoDashboardPage(dashboard);
+  const { panelEditPage, editorRow, option } = await setupCogniteTimeSeriesPanel({
+    readProvisionedDataSource,
+    readProvisionedDashboard,
+    gotoDashboardPage,
+    selectors,
+    page,
+  });
 
-  const panelEditPage = await dashboardPage.addPanel();
-  await panelEditPage.datasource.set(ds.name);
-  
-  // Wait for data source to be properly selected and tabs to render
-  await page.waitForTimeout(1000);
+  await searchAndSelectTimeSeries(page, editorRow, panelEditPage, option, '59.9139');
 
-  const editorRow = panelEditPage.getQueryEditorRow("A");
-
-  // Click on CogniteTimeSeries tab
-  await editorRow.getByText('CogniteTimeSeries').click();
-
-  // Select a view from the View dropdown (views are fetched from container inspect API)
-  const viewField = editorRow.locator('label:has-text("View")').locator('..');
-  const viewDropdown = viewField.locator('input').first();
-  await viewDropdown.click();
-  
-  // Wait for view options to load
-  await page.waitForTimeout(2000);
-  
-  // Select the CogniteTimeSeries view
-  const option = selectors.components.Select.option;
-  const cogniteTimeSeriesOption = panelEditPage.getByGrafanaSelector(option).filter({ hasText: /CogniteTimeSeries.*cdf_cdm/i });
-  await cogniteTimeSeriesOption.first().click();
-
-  // Click on the search AsyncSelect and type '59.9139'
   const searchInput = editorRow.locator('input[id="cognite-timeseries-search-A"]');
-  await searchInput.click();
-  await searchInput.fill('59.9139');
-
-  // Wait for search results
-  await waitForQueriesToFinish(page);
-  
-  // Look for the timeseries option in the dropdown
-  const tsOption = panelEditPage.getByGrafanaSelector(option).filter({ hasText: /59\.9139/i }).first();
-  await expect(tsOption).toBeVisible({ timeout: 10000 });
-  
-  // Click on the first result to select it
-  await tsOption.click();
-
-  // Verify that a timeseries name appears in the search box (it should replace the placeholder)
   await expect(searchInput).not.toHaveText('Search timeseries by name/description');
 
-  // Test label input - find the textbox that contains 'default' for label
   const labelInput = editorRow.locator('input[id="label-A"]');
   await labelInput.clear();
   await labelInput.fill('CDMTS Data');
@@ -362,142 +356,61 @@ test('"CogniteTimeSeries" query with selection works', async ({ selectors, readP
 });
 
 test('"CogniteTimeSeries" unit conversion is available for timeseries with units', async ({ selectors, readProvisionedDataSource, gotoDashboardPage, readProvisionedDashboard, page, grafanaVersion }) => {
-  // Set a larger viewport to ensure all UI elements are visible
-  await page.setViewportSize({ width: 1920, height: 1080 });
-  
-  const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
-  const dashboard = await readProvisionedDashboard({ fileName: 'weather-station.json' });
-  const dashboardPage = await gotoDashboardPage(dashboard);
+  const { panelEditPage, editorRow, option } = await setupCogniteTimeSeriesPanel({
+    readProvisionedDataSource,
+    readProvisionedDashboard,
+    gotoDashboardPage,
+    selectors,
+    page,
+  });
 
-  const panelEditPage = await dashboardPage.addPanel();
-  await panelEditPage.datasource.set(ds.name);
-  
-  // Wait for data source to be properly selected and tabs to render
-  await page.waitForTimeout(1000);
+  await searchAndSelectTimeSeries(page, editorRow, panelEditPage, option, '59.9139-10.7522-current.temp');
 
-  const editorRow = panelEditPage.getQueryEditorRow("A");
-
-  // Click on CogniteTimeSeries tab
-  await editorRow.getByText('CogniteTimeSeries').click();
-
-  // Select a view from the View dropdown
-  const viewField = editorRow.locator('label:has-text("View")').locator('..');
-  const viewDropdown = viewField.locator('input').first();
-  await viewDropdown.click();
-  
-  // Wait for view options to load
-  await page.waitForTimeout(2000);
-  
-  // Select the CogniteTimeSeries view
-  const option = selectors.components.Select.option;
-  const cogniteTimeSeriesOption = panelEditPage.getByGrafanaSelector(option).filter({ hasText: /CogniteTimeSeries.*cdf_cdm/i });
-  await cogniteTimeSeriesOption.first().click();
-
-  // Search for a timeseries that has a unit (temperature)
-  const searchInput = editorRow.locator('input[id="cognite-timeseries-search-A"]');
-  await searchInput.click();
-  await searchInput.fill('59.9139-10.7522-current.temp');
-
-  // Wait for search results
-  await waitForQueriesToFinish(page);
-  
-  // Select the temperature timeseries
-  const tsOption = panelEditPage.getByGrafanaSelector(option).filter({ hasText: /59\.9139-10\.7522-current\.temp/i }).first();
-  await expect(tsOption).toBeVisible({ timeout: 10000 });
-  await tsOption.click();
-
-  // Wait for unit information to load
-  await page.waitForTimeout(2000);
-
-  // Check that the current unit is displayed (should show "Unit: Degree Celsius (°C)" or similar)
+  // Wait for unit label to appear after timeseries selection
   const unitLabel = editorRow.getByText(/Unit:/i);
-  await expect(unitLabel).toBeVisible({ timeout: 5000 });
+  await expect(unitLabel).toBeVisible({ timeout: 10000 });
 
-  // Check that the Target Unit field is visible
   const targetUnitField = editorRow.locator('label:has-text("Target Unit")');
   await expect(targetUnitField).toBeVisible();
 
-  // Click on the Target Unit dropdown
   const targetUnitInput = targetUnitField.locator('..').locator('input').first();
   await targetUnitInput.click();
 
-  // Wait for unit options to load
-  await page.waitForTimeout(1000);
-
-  // Check that unit options are available (should show other temperature units)
   const unitOptions = panelEditPage.getByGrafanaSelector(option);
   await expect(unitOptions.first()).toBeVisible({ timeout: 5000 });
 
-  // Verify that at least one temperature unit option is available
   const fahrenheitOption = unitOptions.filter({ hasText: /Fahrenheit|°F/i });
   const kelvinOption = unitOptions.filter({ hasText: /Kelvin|K/i });
-  
-  // At least one of these should be visible
+
   const hasTemperatureUnits = await fahrenheitOption.count() > 0 || await kelvinOption.count() > 0;
   expect(hasTemperatureUnits).toBeTruthy();
 });
 
 test('"CogniteTimeSeries" unit conversion not shown for timeseries without units', async ({ selectors, readProvisionedDataSource, gotoDashboardPage, readProvisionedDashboard, page, grafanaVersion }) => {
-  // Set a larger viewport to ensure all UI elements are visible
-  await page.setViewportSize({ width: 1920, height: 1080 });
-  
-  const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
-  const dashboard = await readProvisionedDashboard({ fileName: 'weather-station.json' });
-  const dashboardPage = await gotoDashboardPage(dashboard);
+  const { panelEditPage, editorRow, option } = await setupCogniteTimeSeriesPanel({
+    readProvisionedDataSource,
+    readProvisionedDashboard,
+    gotoDashboardPage,
+    selectors,
+    page,
+  });
 
-  const panelEditPage = await dashboardPage.addPanel();
-  await panelEditPage.datasource.set(ds.name);
-  
-  // Wait for data source to be properly selected and tabs to render
-  await page.waitForTimeout(1000);
+  await searchAndSelectTimeSeries(page, editorRow, panelEditPage, option, '59.9139-10.7522-current.clouds');
 
-  const editorRow = panelEditPage.getQueryEditorRow("A");
-
-  // Click on CogniteTimeSeries tab
-  await editorRow.getByText('CogniteTimeSeries').click();
-
-  // Select a view from the View dropdown
-  const viewField = editorRow.locator('label:has-text("View")').locator('..');
-  const viewDropdown = viewField.locator('input').first();
-  await viewDropdown.click();
-  
-  // Wait for view options to load
-  await page.waitForTimeout(2000);
-  
-  // Select the CogniteTimeSeries view
-  const option = selectors.components.Select.option;
-  const cogniteTimeSeriesOption = panelEditPage.getByGrafanaSelector(option).filter({ hasText: /CogniteTimeSeries.*cdf_cdm/i });
-  await cogniteTimeSeriesOption.first().click();
-
-  // Search for a timeseries that doesn't have a unit (clouds)
-  const searchInput = editorRow.locator('input[id="cognite-timeseries-search-A"]');
-  await searchInput.click();
-  await searchInput.fill('59.9139-10.7522-current.clouds');
-
-  // Wait for search results
-  await waitForQueriesToFinish(page);
-  
-  // Select the clouds timeseries
-  const tsOption = panelEditPage.getByGrafanaSelector(option).filter({ hasText: /59\.9139-10\.7522-current\.clouds/i }).first();
-  await expect(tsOption).toBeVisible({ timeout: 10000 });
-  await tsOption.click();
-
-  // Wait a bit for any unit information to potentially load
+  // Target Unit and Unit label should NOT appear for timeseries without units.
+  // Use a short explicit wait because we're asserting absence.
   await page.waitForTimeout(2000);
 
-  // Check that the Target Unit field is NOT visible (timeseries has no unit)
   const targetUnitField = editorRow.locator('label:has-text("Target Unit")');
   await expect(targetUnitField).not.toBeVisible();
 
-  // Check that no unit label is displayed
   const unitLabel = editorRow.getByText(/Unit:/i);
   await expect(unitLabel).not.toBeVisible();
 });
 
 test('"CogniteTimeSeries" multiple queries work', async ({ selectors, readProvisionedDataSource, gotoDashboardPage, readProvisionedDashboard, page, grafanaVersion }) => {
-  // Set a larger viewport to ensure all UI elements are visible
   await page.setViewportSize({ width: 1920, height: 1080 });
-  
+
   const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
   const dashboard = await readProvisionedDashboard({ fileName: 'weather-station.json' });
   const dashboardPage = await gotoDashboardPage(dashboard);
@@ -507,48 +420,30 @@ test('"CogniteTimeSeries" multiple queries work', async ({ selectors, readProvis
 
   const panelEditPage = await dashboardPage.addPanel();
   await panelEditPage.datasource.set(ds.name);
-  
-  // Wait for data source to be properly selected and tabs to render
-  await page.waitForTimeout(1000);
 
   for (const [index, searchTerm] of searchTerms.entries()) {
     if (index > 0) {
       await page.getByTestId(/query-tab-add-query/).click();
     }
-    
-    const queryLetter = String.fromCharCode(65 + index); // A, B, C
+
+    const queryLetter = String.fromCharCode(65 + index);
     const editorRow = panelEditPage.getQueryEditorRow(queryLetter);
 
-    // Click on CogniteTimeSeries tab
+    // Wait for CogniteTimeSeries tab and click it
+    await expect(editorRow.getByText('CogniteTimeSeries')).toBeVisible();
     await editorRow.getByText('CogniteTimeSeries').click();
 
-    // Select a view from the View dropdown
     const viewField = editorRow.locator('label:has-text("View")').locator('..');
     const viewDropdown = viewField.locator('input').first();
     await viewDropdown.click();
-    
-    // Wait for view options to load
-    await page.waitForTimeout(2000);
-    
-    // Select the CogniteTimeSeries view
+
     const option = selectors.components.Select.option;
     const cogniteTimeSeriesOption = panelEditPage.getByGrafanaSelector(option).filter({ hasText: /CogniteTimeSeries.*cdf_cdm/i });
+    await expect(cogniteTimeSeriesOption.first()).toBeVisible({ timeout: 10000 });
     await cogniteTimeSeriesOption.first().click();
 
-    // Click on the search AsyncSelect and type the search term
-    const searchInput = editorRow.locator(`input[id="cognite-timeseries-search-${queryLetter}"]`);
-    await searchInput.click();
-    await searchInput.fill(searchTerm);
+    await searchAndSelectTimeSeries(page, editorRow, panelEditPage, option, searchTerm, queryLetter);
 
-    // Wait for search results
-    await waitForQueriesToFinish(page);
-    
-    // Select first result from dropdown
-    const searchOption = panelEditPage.getByGrafanaSelector(option).filter({ hasText: new RegExp(searchTerm.replace('.', '\\.'), 'i') }).first();
-    await expect(searchOption).toBeVisible({ timeout: 10000 });
-    await searchOption.click();
-
-    // Set custom label - find the label textbox (last textbox with 'default')
     const labelInput = editorRow.locator(`input[id="label-${queryLetter}"]`);
     await labelInput.clear();
     await labelInput.fill(`TST ${expectedLabels[index]}`);
@@ -556,7 +451,6 @@ test('"CogniteTimeSeries" multiple queries work', async ({ selectors, readProvis
 
   await waitForQueriesToFinish(page);
 
-  // Check that all labels appear in the legend
   for (const label of expectedLabels) {
     const legendText = panelEditPage.panel.locator.getByText(`TST ${label}`);
     await expect(legendText).toBeVisible({ timeout: 10000 });
@@ -564,9 +458,8 @@ test('"CogniteTimeSeries" multiple queries work', async ({ selectors, readProvis
 });
 
 test('"CogniteTimeSeries with Activities" panel loads with annotations', async ({ readProvisionedDataSource, gotoDashboardPage, readProvisionedDashboard, page }) => {
-  // Set a larger viewport to ensure all UI elements are visible
   await page.setViewportSize({ width: 1920, height: 1080 });
-  
+
   const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
   const dashboard = await readProvisionedDashboard({ fileName: 'weather-station-core.json' });
   const dashboardPage = await gotoDashboardPage(dashboard);
@@ -574,247 +467,113 @@ test('"CogniteTimeSeries with Activities" panel loads with annotations', async (
   const ACTIVITIES_PANEL_ID = '6';
   const panelEditPage = await dashboardPage.gotoPanelEditPage(ACTIVITIES_PANEL_ID);
 
-  // Verify the panel title
   await expect(page.getByText('CogniteTimeSeries with Activities - Core Data Model')).toBeVisible();
 
-  // Wait for queries to finish
   await waitForQueriesToFinish(page);
 
-  // Check that the time series data is displayed
   await expect(panelEditPage.panel.locator).toBeVisible();
 });
 
 test('"CogniteTimeSeries" activities toggle appears when timeseries selected', async ({ selectors, readProvisionedDataSource, gotoDashboardPage, readProvisionedDashboard, page }) => {
-  // Set a larger viewport to ensure all UI elements are visible
-  await page.setViewportSize({ width: 1920, height: 1080 });
-  
-  const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
-  const dashboard = await readProvisionedDashboard({ fileName: 'weather-station.json' });
-  const dashboardPage = await gotoDashboardPage(dashboard);
-
-  const panelEditPage = await dashboardPage.addPanel();
-  await panelEditPage.datasource.set(ds.name);
-  
-  // Wait for data source to be properly selected and tabs to render
-  await page.waitForTimeout(1000);
-
-  const editorRow = panelEditPage.getQueryEditorRow("A");
-
-  // Click on CogniteTimeSeries tab
-  await editorRow.getByText('CogniteTimeSeries').click();
-
-  // Select a view from the View dropdown
-  const viewField = editorRow.locator('label:has-text("View")').locator('..');
-  const viewDropdown = viewField.locator('input').first();
-  await viewDropdown.click();
-  
-  // Wait for view options to load
-  await page.waitForTimeout(2000);
-  
-  // Select the CogniteTimeSeries view
-  const option = selectors.components.Select.option;
-  const cogniteTimeSeriesOption = panelEditPage.getByGrafanaSelector(option).filter({ hasText: /CogniteTimeSeries.*cdf_cdm/i });
-  await cogniteTimeSeriesOption.first().click();
+  const { panelEditPage, editorRow, option } = await setupCogniteTimeSeriesPanel({
+    readProvisionedDataSource,
+    readProvisionedDashboard,
+    gotoDashboardPage,
+    selectors,
+    page,
+  });
 
   // Activities toggle should NOT be visible yet (no timeseries selected)
   const activitiesToggleBefore = editorRow.getByLabel('Activities').nth(1);
   await expect(activitiesToggleBefore).not.toBeVisible();
 
-  // Search for and select a timeseries
-  const searchInput = editorRow.locator('input[id="cognite-timeseries-search-A"]');
-  await searchInput.click();
-  await searchInput.fill('59.9139-10.7522-current.temp');
+  await searchAndSelectTimeSeries(page, editorRow, panelEditPage, option, '59.9139-10.7522-current.temp');
 
-  // Wait for search results
-  await waitForQueriesToFinish(page);
-  
-  // Select the temperature timeseries
-  const tsOption = panelEditPage.getByGrafanaSelector(option).filter({ hasText: /59\.9139-10\.7522-current\.temp/i }).first();
-  await expect(tsOption).toBeVisible({ timeout: 10000 });
-  await tsOption.click();
-
-  // Wait for UI to update
-  await page.waitForTimeout(1000);
-
-  // Now the Activities toggle should be visible
+  // Now the Activities toggle should appear
   const activitiesToggleAfter = editorRow.getByLabel('Activities').nth(1);
   await expect(activitiesToggleAfter).toBeVisible({ timeout: 5000 });
 });
 
 test('"CogniteTimeSeries" enabling activities shows configuration options', async ({ selectors, readProvisionedDataSource, gotoDashboardPage, readProvisionedDashboard, page }) => {
-  // Set a larger viewport to ensure all UI elements are visible
-  await page.setViewportSize({ width: 1920, height: 1080 });
-  
-  const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
-  const dashboard = await readProvisionedDashboard({ fileName: 'weather-station.json' });
-  const dashboardPage = await gotoDashboardPage(dashboard);
+  const { panelEditPage, editorRow, option } = await setupCogniteTimeSeriesPanel({
+    readProvisionedDataSource,
+    readProvisionedDashboard,
+    gotoDashboardPage,
+    selectors,
+    page,
+  });
 
-  const panelEditPage = await dashboardPage.addPanel();
-  await panelEditPage.datasource.set(ds.name);
-  
-  // Wait for data source to be properly selected and tabs to render
-  await page.waitForTimeout(1000);
+  await searchAndSelectTimeSeries(page, editorRow, panelEditPage, option, '59.9139-10.7522-current.temp');
 
-  const editorRow = panelEditPage.getQueryEditorRow("A");
-
-  // Click on CogniteTimeSeries tab
-  await editorRow.getByText('CogniteTimeSeries').click();
-
-  // Select a view
-  const viewField = editorRow.locator('label:has-text("View")').locator('..');
-  const viewDropdown = viewField.locator('input').first();
-  await viewDropdown.click();
-  await page.waitForTimeout(2000);
-  
-  const option = selectors.components.Select.option;
-  const cogniteTimeSeriesOption = panelEditPage.getByGrafanaSelector(option).filter({ hasText: /CogniteTimeSeries.*cdf_cdm/i });
-  await cogniteTimeSeriesOption.first().click();
-
-  // Select a timeseries
-  const searchInput = editorRow.locator('input[id="cognite-timeseries-search-A"]');
-  await searchInput.click();
-  await searchInput.fill('59.9139-10.7522-current.temp');
-  await waitForQueriesToFinish(page);
-  
-  const tsOption = panelEditPage.getByGrafanaSelector(option).filter({ hasText: /59\.9139-10\.7522-current\.temp/i }).first();
-  await tsOption.click();
-  await page.waitForTimeout(1000);
-
-  // Enable activities
   const activitiesToggle = editorRow.getByLabel('Activities').nth(1);
+  await expect(activitiesToggle).toBeVisible({ timeout: 5000 });
   await activitiesToggle.check({ force: true });
   await expect(activitiesToggle).toBeChecked();
 
-  // Wait for activity configuration to appear
-  await page.waitForTimeout(1000);
-
-  // Check that the Activity View dropdown is visible
+  // Wait for activity configuration UI to render
   const activityViewLabel = editorRow.getByText('View').nth(1);
-  await expect(activityViewLabel).toBeVisible();
+  await expect(activityViewLabel).toBeVisible({ timeout: 5000 });
 
-  // Check that the Scheduled toggle is visible
   const scheduledToggle = editorRow.getByLabel('Scheduled').nth(1);
   await expect(scheduledToggle).toBeVisible();
 });
 
 test('"CogniteTimeSeries" can select activity view', async ({ selectors, readProvisionedDataSource, gotoDashboardPage, readProvisionedDashboard, page }) => {
-  // Set a larger viewport to ensure all UI elements are visible
-  await page.setViewportSize({ width: 1920, height: 1080 });
-  
-  const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
-  const dashboard = await readProvisionedDashboard({ fileName: 'weather-station.json' });
-  const dashboardPage = await gotoDashboardPage(dashboard);
+  const { panelEditPage, editorRow, option } = await setupCogniteTimeSeriesPanel({
+    readProvisionedDataSource,
+    readProvisionedDashboard,
+    gotoDashboardPage,
+    selectors,
+    page,
+  });
 
-  const panelEditPage = await dashboardPage.addPanel();
-  await panelEditPage.datasource.set(ds.name);
-  await page.waitForTimeout(1000);
+  await searchAndSelectTimeSeries(page, editorRow, panelEditPage, option, '59.9139-10.7522-current.temp');
 
-  const editorRow = panelEditPage.getQueryEditorRow("A");
-
-  // Setup: Select CogniteTimeSeries view and timeseries
-  await editorRow.getByText('CogniteTimeSeries').click();
-
-  const viewField = editorRow.locator('label:has-text("View")').locator('..');
-  const viewDropdown = viewField.locator('input').first();
-  await viewDropdown.click();
-  await page.waitForTimeout(2000);
-  
-  const option = selectors.components.Select.option;
-  const cogniteTimeSeriesOption = panelEditPage.getByGrafanaSelector(option).filter({ hasText: /CogniteTimeSeries.*cdf_cdm/i });
-  await cogniteTimeSeriesOption.first().click();
-
-  const searchInput = editorRow.locator('input[id="cognite-timeseries-search-A"]');
-  await searchInput.click();
-  await searchInput.fill('59.9139-10.7522-current.temp');
-  await waitForQueriesToFinish(page);
-  
-  const tsOption = panelEditPage.getByGrafanaSelector(option).filter({ hasText: /59\.9139-10\.7522-current\.temp/i }).first();
-  await tsOption.click();
-  await page.waitForTimeout(1000);
-
-  // Enable activities
   const activitiesToggle = editorRow.getByLabel('Activities').nth(1);
+  await expect(activitiesToggle).toBeVisible({ timeout: 5000 });
   await activitiesToggle.check({ force: true });
-  await page.waitForTimeout(1000);
 
-  // Find the second View label (for activities, not timeseries)
+  // Wait for the second View field (activity view) to appear
   const activityViewFields = editorRow.locator('label:has-text("View")');
+  await expect(activityViewFields.nth(1)).toBeVisible({ timeout: 5000 });
+
   const activityViewCount = await activityViewFields.count();
-  
-  // Should have at least 2 View fields now (timeseries + activity)
   expect(activityViewCount).toBeGreaterThanOrEqual(2);
 
-  // Click on the activity view dropdown (the second one)
   const activityViewInput = activityViewFields.nth(1).locator('..').locator('input').first();
   await activityViewInput.click();
-  
-  // Wait for activity view options to load
-  await page.waitForTimeout(2000);
 
-  // Check that CogniteActivity view option is available
   const activityViewOption = panelEditPage.getByGrafanaSelector(option).filter({ hasText: /CogniteActivity.*cdf_cdm/i });
   await expect(activityViewOption.first()).toBeVisible({ timeout: 10000 });
-  
-  // Select the CogniteActivity view
+
   await activityViewOption.first().click();
 
-  // Verify the selection was made by checking the option is no longer visible (dropdown closed)
-  await page.waitForTimeout(500);
   await expect(activityViewOption.first()).not.toBeVisible();
 });
 
 test('"CogniteTimeSeries" scheduled time toggle works', async ({ selectors, readProvisionedDataSource, gotoDashboardPage, readProvisionedDashboard, page }) => {
-  // Set a larger viewport to ensure all UI elements are visible
-  await page.setViewportSize({ width: 1920, height: 1080 });
-  
-  const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
-  const dashboard = await readProvisionedDashboard({ fileName: 'weather-station.json' });
-  const dashboardPage = await gotoDashboardPage(dashboard);
+  const { panelEditPage, editorRow, option } = await setupCogniteTimeSeriesPanel({
+    readProvisionedDataSource,
+    readProvisionedDashboard,
+    gotoDashboardPage,
+    selectors,
+    page,
+  });
 
-  const panelEditPage = await dashboardPage.addPanel();
-  await panelEditPage.datasource.set(ds.name);
-  await page.waitForTimeout(1000);
+  await searchAndSelectTimeSeries(page, editorRow, panelEditPage, option, '59.9139-10.7522-current.temp');
 
-  const editorRow = panelEditPage.getQueryEditorRow("A");
-
-  // Setup: Select CogniteTimeSeries view and timeseries
-  await editorRow.getByText('CogniteTimeSeries').click();
-
-  const viewField = editorRow.locator('label:has-text("View")').locator('..');
-  const viewDropdown = viewField.locator('input').first();
-  await viewDropdown.click();
-  await page.waitForTimeout(2000);
-  
-  const option = selectors.components.Select.option;
-  const cogniteTimeSeriesOption = panelEditPage.getByGrafanaSelector(option).filter({ hasText: /CogniteTimeSeries.*cdf_cdm/i });
-  await cogniteTimeSeriesOption.first().click();
-
-  const searchInput = editorRow.locator('input[id="cognite-timeseries-search-A"]');
-  await searchInput.click();
-  await searchInput.fill('59.9139-10.7522-current.temp');
-  await waitForQueriesToFinish(page);
-  
-  const tsOption = panelEditPage.getByGrafanaSelector(option).filter({ hasText: /59\.9139-10\.7522-current\.temp/i }).first();
-  await tsOption.click();
-  await page.waitForTimeout(1000);
-
-  // Enable activities
   const activitiesToggle = editorRow.getByLabel('Activities').nth(1);
+  await expect(activitiesToggle).toBeVisible({ timeout: 5000 });
   await activitiesToggle.check({ force: true });
-  await page.waitForTimeout(1000);
 
-  // Find the Scheduled toggle
   const scheduledToggle = editorRow.getByLabel('Scheduled').nth(1);
-  await expect(scheduledToggle).toBeVisible();
-  
-  // Initially should not be checked
+  await expect(scheduledToggle).toBeVisible({ timeout: 5000 });
+
   await expect(scheduledToggle).not.toBeChecked();
 
-  // Check the toggle
   await scheduledToggle.check({ force: true });
   await expect(scheduledToggle).toBeChecked();
 
-  // Uncheck the toggle
   await scheduledToggle.uncheck({ force: true });
   await expect(scheduledToggle).not.toBeChecked();
 });

--- a/tests/queryEditor.spec.ts
+++ b/tests/queryEditor.spec.ts
@@ -3,6 +3,7 @@ import { Page, Response } from 'playwright';
 import { waitForQueriesToFinish } from '../playwright/fixtures/waitForQueriesToFinish';
 import { readProvisionedDataSource } from '../playwright/fixtures/readProvisionedDataSource';
 import { test as patchedBase } from '../playwright/fixtures/patchNavigationStrategy';
+import { addPanel as addPanelHelper } from '../playwright/fixtures/addPanel';
 import semver from 'semver';
 
 const test = patchedBase.extend<PluginFixture, PluginOptions>({ readProvisionedDataSource });
@@ -39,9 +40,10 @@ async function setupCogniteTimeSeriesPanel({
   gotoDashboardPage: gotoDash,
   selectors,
   page,
+  grafanaVersion,
 }: Pick<
   PluginFixture,
-  'readProvisionedDataSource' | 'readProvisionedDashboard' | 'gotoDashboardPage' | 'selectors'
+  'readProvisionedDataSource' | 'readProvisionedDashboard' | 'gotoDashboardPage' | 'selectors' | 'grafanaVersion'
 > & { page: Page }) {
   await page.setViewportSize({ width: 1920, height: 1080 });
 
@@ -49,7 +51,7 @@ async function setupCogniteTimeSeriesPanel({
   const dashboard = await readDash({ fileName: 'weather-station.json' });
   const dashboardPage = await gotoDash(dashboard);
 
-  const panelEditPage = await dashboardPage.addPanel();
+  const panelEditPage = await addPanelHelper(dashboardPage, page, grafanaVersion);
   await panelEditPage.datasource.set(ds.name);
 
   const editorRow = panelEditPage.getQueryEditorRow("A");
@@ -107,54 +109,78 @@ test('Panel with asset subtree queries rendered OK', async ({ selectors, readPro
   const dashboard = await readProvisionedDashboard({ fileName: 'weather-station.json' });
   const dashboardPage = await gotoDashboardPage(dashboard);
 
-  const panelEditPage = await dashboardPage.addPanel();
+  const panelEditPage = await addPanelHelper(dashboardPage, page, grafanaVersion);
   await panelEditPage.datasource.set(ds.name);
 
   const editorRow = panelEditPage.getQueryEditorRow("A");
 
   await editorRow.getByText('Time series from asset').click();
 
-  const combobox = await editorRow.getByRole('combobox', { name: 'Asset Tag' });
-  await combobox.click();
+  // Collect all /timeseries/data/latest responses via page.on so we never miss one
+  // regardless of timing. waitForResponse with a fixed timeout can be missed if the
+  // response fires while the test is blocked on a UI interaction or waitForQueriesToFinish.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const latestResponses: any[] = [];
+  page.on('response', (response) => {
+    if (isCdfResponse('/timeseries/data/latest')(response)) {
+      latestResponses.push(response);
+    }
+  });
 
+  const combobox = editorRow.getByRole('combobox', { name: 'Asset Tag' });
   const option = selectors.components.Select.option;
-  // Wait for dropdown options to appear instead of fixed timeout
-  await expect(panelEditPage.getByGrafanaSelector(option).first()).toBeVisible({ timeout: 10000 });
-  await panelEditPage.getByGrafanaSelector(option).filter({ hasText: 'Locations' }).click();
 
-  const includeSubAssets = await editorRow.getByLabel('Include sub-assets').nth(1);
+  // In Grafana 13's scene-based inline editor, the combobox can be reset by a concurrent
+  // async re-render after the selection is made. Retry until the value actually sticks.
+  // We detect success by checking the combobox's parent container for the selected text.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await combobox.click();
+    await expect(panelEditPage.getByGrafanaSelector(option).first()).toBeVisible({ timeout: 10000 });
+    await panelEditPage.getByGrafanaSelector(option).filter({ hasText: 'Locations' }).first().click();
+    // Wait for the dropdown to dismiss
+    await expect(panelEditPage.getByGrafanaSelector(option)).toHaveCount(0, { timeout: 5000 });
+    // Verify the selected value is actually shown in the combobox container
+    const selected = await combobox.locator('..').filter({ hasText: 'Locations' }).isVisible().catch(() => false);
+    if (selected) break;
+  }
+
+  const includeSubAssets = editorRow.getByLabel('Include sub-assets').nth(1);
   await includeSubAssets.check({ force: true });
   await expect(includeSubAssets).toBeChecked();
 
-  const includeTs = await editorRow.getByLabel('Include sub-timeseries').nth(1);
+  const includeTs = editorRow.getByLabel('Include sub-timeseries').nth(1);
   await expect(includeTs).toBeChecked();
 
-  const latestValue = await editorRow.getByLabel('Latest value').nth(1);
+  const latestValue = editorRow.getByLabel('Latest value').nth(1);
   await latestValue.check({ force: true });
   await expect(latestValue).toBeChecked();
 
+  // Grafana 13 scene-based dashboards process query-option changes asynchronously.
+  // The deferred query (data/latest) reliably fires within ~2 seconds of the last
+  // state change, but only if the browser gets idle time to process its microtask
+  // queue. waitForQueriesToFinish's repeated DOM-polling can starve that execution.
+  // Pause here first so the response is captured before we start any other checks.
+  await page.waitForTimeout(2500);
+
   await waitForQueriesToFinish(page);
 
-  await expect(panelEditPage.refreshPanel(
-    {
-      timeout: 30000,
-      waitForResponsePredicateCallback: async (response) => {
-
-        if (isCdfResponse('/timeseries/data/latest')(response)) {
-          const json = await response.json();
-          const externalIds = [...json.items?.map(({ externalId }) => externalId)].sort();
-          const isEqualArr = JSON.stringify(externalIds) === JSON.stringify(expectedTs);
-          return isEqualArr;
-        }
-
-        return false;
-      }
-    }
-  )).toBeOK();
+  // Verify that /timeseries/data/latest was actually called with the expected series
+  expect(latestResponses.length).toBeGreaterThan(0);
+  const lastResponse = latestResponses[latestResponses.length - 1];
+  expect(lastResponse.ok()).toBe(true);
+  const json = await lastResponse.json();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const externalIds = [...(json.items ?? []).map(({ externalId }: any) => externalId)].sort();
+  expect(externalIds).toEqual(expectedTs);
 
   await expect.poll(async () => {
-    const buttonTexts = await panelEditPage.panel.locator.getByRole('button', { name: /59.9139-10.7522.*/ }).allInnerTexts();
-    return buttonTexts.sort();
+    const panelContent = panelEditPage.panel.locator;
+    // Time series visualization (Grafana < 13): series appear as clickable legend buttons
+    const buttons = await panelContent.getByRole('button', { name: /59\.9139-10\.7522/ }).allInnerTexts();
+    if (buttons.length > 0) return buttons.sort();
+    // Grafana 13 inline editor may use a Stat visualization: series appear as plain text
+    const textElems = await panelContent.getByText(/59\.9139-10\.7522/).allInnerTexts();
+    return [...new Set(textElems.filter(t => /59\.9139-10\.7522/.test(t)).map(t => t.trim()))].sort();
   }, { timeout: 10000 }).toEqual(expectedTs);
 });
 
@@ -173,16 +199,23 @@ test('"Timeseries custom query" multiple ts OK', async ({ selectors, readProvisi
   const panels = ['A', 'B', 'C'];
   const units = ['percent', 'hPa', 'Kelvin'];
 
-  const panelEditPage = await dashboardPage.addPanel();
+  const panelEditPage = await addPanelHelper(dashboardPage, page, grafanaVersion);
   await panelEditPage.datasource.set(ds.name);
 
-  // Select Table visualization (cross-version compatible)
-  // Grafana 12.4+ opens the viz picker automatically after addPanel(); older versions don't.
-  // Only click the toggle when the picker is not already visible.
+  // Select Table visualization (cross-version compatible).
+  // Grafana 13 inline editor shows a viz picker with "Suggestions" and "All visualizations" tabs.
+  // Older Grafana (9.5 – 12.x) uses a toggle-viz-picker button to open the picker.
   const tableViz = page.locator('[aria-label="Plugin visualization item Table"]')
     .or(page.getByTestId('data-testid Plugin visualization item Table'));
   if (!(await tableViz.isVisible())) {
-    await page.getByTestId('data-testid toggle-viz-picker').click();
+    // Grafana 13: viz picker is open with a "All visualizations" tab
+    const allVizTab = page.getByRole('tab', { name: 'All visualizations' });
+    if (await allVizTab.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await allVizTab.click();
+    } else {
+      // Older Grafana: open picker via toggle button
+      await page.getByTestId('data-testid toggle-viz-picker').click();
+    }
   }
   await tableViz.click();
 
@@ -316,6 +349,7 @@ test('"CogniteTimeSeries" tab can be selected and search works', async ({ select
     gotoDashboardPage,
     selectors,
     page,
+    grafanaVersion,
   });
 
   const viewField = editorRow.locator('label:has-text("View")').locator('..');
@@ -342,6 +376,7 @@ test('"CogniteTimeSeries" query with selection works', async ({ selectors, readP
     gotoDashboardPage,
     selectors,
     page,
+    grafanaVersion,
   });
 
   await searchAndSelectTimeSeries(page, editorRow, panelEditPage, option, '59.9139');
@@ -363,6 +398,7 @@ test('"CogniteTimeSeries" unit conversion is available for timeseries with units
     gotoDashboardPage,
     selectors,
     page,
+    grafanaVersion,
   });
 
   await searchAndSelectTimeSeries(page, editorRow, panelEditPage, option, '59.9139-10.7522-current.temp');
@@ -394,6 +430,7 @@ test('"CogniteTimeSeries" unit conversion not shown for timeseries without units
     gotoDashboardPage,
     selectors,
     page,
+    grafanaVersion,
   });
 
   await searchAndSelectTimeSeries(page, editorRow, panelEditPage, option, '59.9139-10.7522-current.clouds');
@@ -423,7 +460,7 @@ test('"CogniteTimeSeries" multiple queries work', async ({ selectors, readProvis
   const searchTerms = ['59.9139-10.7522-current.temp', '59.9139-10.7522-current.pressure', '59.9139-10.7522-current.humidity'];
   const expectedLabels = ['temperature', 'pressure', 'humidity'];
 
-  const panelEditPage = await dashboardPage.addPanel();
+  const panelEditPage = await addPanelHelper(dashboardPage, page, grafanaVersion);
   await panelEditPage.datasource.set(ds.name);
 
   for (const [index, searchTerm] of searchTerms.entries()) {
@@ -479,13 +516,14 @@ test('"CogniteTimeSeries with Activities" panel loads with annotations', async (
   await expect(panelEditPage.panel.locator).toBeVisible();
 });
 
-test('"CogniteTimeSeries" activities toggle appears when timeseries selected', async ({ selectors, readProvisionedDataSource, gotoDashboardPage, readProvisionedDashboard, page }) => {
+test('"CogniteTimeSeries" activities toggle appears when timeseries selected', async ({ selectors, readProvisionedDataSource, gotoDashboardPage, readProvisionedDashboard, page, grafanaVersion }) => {
   const { panelEditPage, editorRow, option } = await setupCogniteTimeSeriesPanel({
     readProvisionedDataSource,
     readProvisionedDashboard,
     gotoDashboardPage,
     selectors,
     page,
+    grafanaVersion,
   });
 
   // Activities toggle should NOT be visible yet (no timeseries selected)
@@ -499,13 +537,14 @@ test('"CogniteTimeSeries" activities toggle appears when timeseries selected', a
   await expect(activitiesToggleAfter).toBeVisible({ timeout: 5000 });
 });
 
-test('"CogniteTimeSeries" enabling activities shows configuration options', async ({ selectors, readProvisionedDataSource, gotoDashboardPage, readProvisionedDashboard, page }) => {
+test('"CogniteTimeSeries" enabling activities shows configuration options', async ({ selectors, readProvisionedDataSource, gotoDashboardPage, readProvisionedDashboard, page, grafanaVersion }) => {
   const { panelEditPage, editorRow, option } = await setupCogniteTimeSeriesPanel({
     readProvisionedDataSource,
     readProvisionedDashboard,
     gotoDashboardPage,
     selectors,
     page,
+    grafanaVersion,
   });
 
   await searchAndSelectTimeSeries(page, editorRow, panelEditPage, option, '59.9139-10.7522-current.temp');
@@ -523,13 +562,14 @@ test('"CogniteTimeSeries" enabling activities shows configuration options', asyn
   await expect(scheduledToggle).toBeVisible();
 });
 
-test('"CogniteTimeSeries" can select activity view', async ({ selectors, readProvisionedDataSource, gotoDashboardPage, readProvisionedDashboard, page }) => {
+test('"CogniteTimeSeries" can select activity view', async ({ selectors, readProvisionedDataSource, gotoDashboardPage, readProvisionedDashboard, page, grafanaVersion }) => {
   const { panelEditPage, editorRow, option } = await setupCogniteTimeSeriesPanel({
     readProvisionedDataSource,
     readProvisionedDashboard,
     gotoDashboardPage,
     selectors,
     page,
+    grafanaVersion,
   });
 
   await searchAndSelectTimeSeries(page, editorRow, panelEditPage, option, '59.9139-10.7522-current.temp');
@@ -556,13 +596,14 @@ test('"CogniteTimeSeries" can select activity view', async ({ selectors, readPro
   await expect(activityViewOption.first()).not.toBeVisible();
 });
 
-test('"CogniteTimeSeries" scheduled time toggle works', async ({ selectors, readProvisionedDataSource, gotoDashboardPage, readProvisionedDashboard, page }) => {
+test('"CogniteTimeSeries" scheduled time toggle works', async ({ selectors, readProvisionedDataSource, gotoDashboardPage, readProvisionedDashboard, page, grafanaVersion }) => {
   const { panelEditPage, editorRow, option } = await setupCogniteTimeSeriesPanel({
     readProvisionedDataSource,
     readProvisionedDashboard,
     gotoDashboardPage,
     selectors,
     page,
+    grafanaVersion,
   });
 
   await searchAndSelectTimeSeries(page, editorRow, panelEditPage, option, '59.9139-10.7522-current.temp');

--- a/tests/queryEditor.spec.ts
+++ b/tests/queryEditor.spec.ts
@@ -176,10 +176,14 @@ test('"Timeseries custom query" multiple ts OK', async ({ selectors, readProvisi
   const panelEditPage = await dashboardPage.addPanel();
   await panelEditPage.datasource.set(ds.name);
 
-  // Select Table visualization: Grafana <=12.1 uses aria-label, 12.4+ uses data-testid
-  await page.getByTestId('data-testid toggle-viz-picker').click();
+  // Select Table visualization (cross-version compatible)
+  // Grafana 12.4+ opens the viz picker automatically after addPanel(); older versions don't.
+  // Only click the toggle when the picker is not already visible.
   const tableViz = page.locator('[aria-label="Plugin visualization item Table"]')
     .or(page.getByTestId('data-testid Plugin visualization item Table'));
+  if (!(await tableViz.isVisible())) {
+    await page.getByTestId('data-testid toggle-viz-picker').click();
+  }
   await tableViz.click();
 
   for (const [index, tsExternalId] of tsExternalIds.entries()) {


### PR DESCRIPTION
## Summary

- **Increase CI timeout** from 15 → 20 minutes to prevent premature job cancellations on slower GitHub runners
- **Add explicit per-test timeout** (45s CI / 30s local) in `playwright.config.ts` so individual tests fail fast instead of hanging until the workflow-level timeout kills everything
- **Rewrite `toggleCheckbox` helper** to use `dispatchEvent('click')`, removing the `try-catch` that silently swallowed errors. Native Playwright `check`/`uncheck` fails with "Element is outside of the viewport" on Grafana 10.x even with `force: true`, so `dispatchEvent` is used to bypass viewport checks while still throwing on missing elements
- **Apply `toggleCheckbox` helper** to all checkbox interactions in test bodies, replacing direct `check()`/`uncheck()` calls that were also failing on older Grafana versions
- **Add `test.setTimeout(90s)`** to the "Timeseries custom query" test which runs 3 query iterations and was exceeding the new 45s global timeout
- **Extract shared setup** (`beforeEach` in `featureFlags.spec.ts`, `setupCogniteTimeSeriesPanel` + `searchAndSelectTimeSeries` helpers in `queryEditor.spec.ts`) — eliminates ~350 lines of duplicated boilerplate
- **Replace fixed `waitForTimeout` calls** with event-based waits (`toBeVisible`, `waitForLoadState`, `not.toBeVisible`) for faster, more deterministic execution
- **Fix Transform tab selector** across Grafana versions — replaced brittle version-gated `getByTestId` calls with a single resilient `getByRole('tab', { name: /Transform/ })` selector
- **Fix viz picker for Grafana 12.4+** — replaced `panelEditPage.setVisualization('Table')` (broken on 12.4+ due to changed `data-testid`) with a cross-version implementation using `.or()` locators, and handle the viz picker being already open after `addPanel()` on 12.4+

Net result: **−350 lines** across 4 files with no behavioral changes, plus fixes for pre-existing cross-version test failures.

## Test plan

- [ ] CI E2E tests pass on all Grafana matrix versions (10.0.13, 10.3.12, 11.3.9, 12.1.9, 12.4.1)
- [ ] No increase in flakiness compared to main branch