### PR TITLE
Add CogniteActivities tab for querying activities by resource type

### DIFF
--- a/provisioning/dashboards/weather-station-activities.json
+++ b/provisioning/dashboards/weather-station-activities.json
@@ -42,7 +42,9 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true
@@ -62,7 +64,21 @@
                 "externalId": "weather-station-fornebu",
                 "name": "Fornebu Weather Station"
               }
-            ]
+            ],
+            "columns": [
+              "externalId",
+              "name",
+              "description",
+              "startTime",
+              "endTime"
+            ],
+            "sort": [
+              {
+                "property": "startTime",
+                "order": "asc"
+              }
+            ],
+            "activeOnly": true
           },
           "datasource": {
             "type": "cognitedata-datasource",
@@ -101,7 +117,9 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true
@@ -121,7 +139,20 @@
                 "externalId": "sensor-lysaker-visibility-sensor",
                 "name": "Forward Scatter Visibility Sensor"
               }
-            ]
+            ],
+            "columns": [
+              "externalId",
+              "description",
+              "startTime",
+              "endTime"
+            ],
+            "sort": [
+              {
+                "property": "startTime",
+                "order": "asc"
+              }
+            ],
+            "activeOnly": true
           },
           "datasource": {
             "type": "cognitedata-datasource",
@@ -160,7 +191,9 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true
@@ -180,7 +213,20 @@
                 "externalId": "59.9139-10.7522-current.temp",
                 "name": "59.9139-10.7522-current.temp"
               }
-            ]
+            ],
+            "columns": [
+              "externalId",
+              "description",
+              "startTime",
+              "endTime"
+            ],
+            "sort": [
+              {
+                "property": "startTime",
+                "order": "asc"
+              }
+            ],
+            "activeOnly": true
           },
           "datasource": {
             "type": "cognitedata-datasource",

--- a/provisioning/dashboards/weather-station-activities.json
+++ b/provisioning/dashboards/weather-station-activities.json
@@ -1,0 +1,217 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "cognitedata-datasource",
+        "uid": "core-only"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "aggregation": "average",
+          "cogniteActivityTabQuery": {
+            "space": "cdf_cdm",
+            "externalId": "CogniteActivity",
+            "version": "v1",
+            "resourceType": "CogniteAsset",
+            "instanceSpace": "",
+            "assetInstances": [
+              {
+                "space": "cdm_try",
+                "externalId": "weather-station-fornebu",
+                "name": "Fornebu Weather Station"
+              }
+            ]
+          },
+          "datasource": {
+            "type": "cognitedata-datasource",
+            "uid": "core-only"
+          },
+          "expr": "",
+          "granularity": "",
+          "label": "",
+          "latestValue": false,
+          "refId": "A",
+          "tab": "CogniteActivity",
+          "target": ""
+        }
+      ],
+      "title": "Activities - Asset (Fornebu Weather Station)",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "cognitedata-datasource",
+        "uid": "core-only"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 2,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "aggregation": "average",
+          "cogniteActivityTabQuery": {
+            "space": "cdf_cdm",
+            "externalId": "CogniteActivity",
+            "version": "v1",
+            "resourceType": "CogniteEquipment",
+            "instanceSpace": "",
+            "assetInstances": [
+              {
+                "space": "cdm_try",
+                "externalId": "sensor-lysaker-visibility-sensor",
+                "name": "Forward Scatter Visibility Sensor"
+              }
+            ]
+          },
+          "datasource": {
+            "type": "cognitedata-datasource",
+            "uid": "core-only"
+          },
+          "expr": "",
+          "granularity": "",
+          "label": "",
+          "latestValue": false,
+          "refId": "A",
+          "tab": "CogniteActivity",
+          "target": ""
+        }
+      ],
+      "title": "Activities - Equipment (Lysaker Visibility Sensor)",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "cognitedata-datasource",
+        "uid": "core-only"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 3,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "aggregation": "average",
+          "cogniteActivityTabQuery": {
+            "space": "cdf_cdm",
+            "externalId": "CogniteActivity",
+            "version": "v1",
+            "resourceType": "CogniteTimeSeries",
+            "instanceSpace": "",
+            "assetInstances": [
+              {
+                "space": "cdm_try",
+                "externalId": "59.9139-10.7522-current.temp",
+                "name": "59.9139-10.7522-current.temp"
+              }
+            ]
+          },
+          "datasource": {
+            "type": "cognitedata-datasource",
+            "uid": "core-only"
+          },
+          "expr": "",
+          "granularity": "",
+          "label": "",
+          "latestValue": false,
+          "refId": "A",
+          "tab": "CogniteActivity",
+          "target": ""
+        }
+      ],
+      "title": "Activities - TimeSeries (59.9139-10.7522-current.temp)",
+      "type": "table"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1y",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "CogniteActivities - by Resource Type",
+  "uid": "cognite-activities",
+  "version": 1,
+  "weekStart": ""
+}

--- a/src/cdf/client.ts
+++ b/src/cdf/client.ts
@@ -25,6 +25,7 @@ import {
   CogniteActivity,
   InvolvedView,
   ContainerInspectResponse,
+  DMSViewWithProperties,
 } from '../types/dms';
 import {
   Tab,
@@ -464,6 +465,32 @@ export function fetchDMSViews(
     params,
     cacheTime: CacheTime.ResourceByIds,
   });
+}
+
+// Fetch all property names of a specific DMS view (includes inherited properties)
+export async function fetchDMSViewProperties(
+  connector: Connector,
+  viewSpec: { space: string; externalId: string; version: string }
+): Promise<string[]> {
+  try {
+    const response = await connector.fetchData<{ data: { items: DMSViewWithProperties[] } }>({
+      method: HttpMethod.POST,
+      path: '/models/views/byids',
+      data: {
+        items: [{ space: viewSpec.space, externalId: viewSpec.externalId, version: viewSpec.version }],
+        includeInheritedProperties: true,
+      },
+      cacheTime: CacheTime.ResourceByIds,
+    });
+    const view = response.data?.items?.[0];
+    if (!view?.properties) {
+      return [];
+    }
+    return Object.keys(view.properties);
+  } catch (err) {
+    console.warn('Failed to fetch DMS view properties:', err);
+    return [];
+  }
 }
 
 // Helper function to retry DMS API calls with exponential backoff and jitter on 429 errors

--- a/src/cdf/client.ts
+++ b/src/cdf/client.ts
@@ -706,6 +706,41 @@ export async function fetchCogniteActivityViews(
   }
 }
 
+async function fetchCogniteContainerViews(connector: Connector, containerExternalId: string): Promise<InvolvedView[]> {
+  try {
+    const response = await retryOnRateLimit(() =>
+      connector.fetchData<{ data: ContainerInspectResponse }>({
+        method: HttpMethod.POST,
+        path: '/models/containers/inspect',
+        data: {
+          items: [{ space: 'cdf_cdm', externalId: containerExternalId }],
+          inspectionOperations: {
+            involvedViews: { allVersions: true },
+            totalInvolvedViewCount: { allVersions: true, includeUnavailableViews: true },
+          },
+        },
+        cacheTime: CacheTime.ResourceByIds,
+      })
+    );
+    const item = response.data?.items?.[0];
+    if (item?.inspectionResults?.involvedViews) {
+      return item.inspectionResults.involvedViews;
+    }
+    return [];
+  } catch (err) {
+    console.warn(`Failed to fetch ${containerExternalId} views:`, err);
+    return [];
+  }
+}
+
+export function fetchCogniteAssetViews(connector: Connector): Promise<InvolvedView[]> {
+  return fetchCogniteContainerViews(connector, 'CogniteAsset');
+}
+
+export function fetchCogniteEquipmentViews(connector: Connector): Promise<InvolvedView[]> {
+  return fetchCogniteContainerViews(connector, 'CogniteEquipment');
+}
+
 // Fetch activities from DMS for a given time range, filtered to a specific time series
 export async function fetchActivitiesFromDMS(
   connector: Connector,
@@ -804,4 +839,70 @@ export async function fetchActivitiesFromDMS(
   }
 }
 
+// Fetch activities from DMS filtered by a set of related instances (assets, equipment, or timeSeries)
+export async function fetchActivitiesByAssets(
+  connector: Connector,
+  viewSpec: { space: string; externalId: string; version: string },
+  assetInstances: Array<{ space: string; externalId: string }>,
+  filterProperty = 'assets'
+): Promise<CogniteActivity[]> {
+  if (!assetInstances.length) {
+    return [];
+  }
+  try {
+    const filter: DMSFilter = {
+      in: {
+        property: [viewSpec.space, `${viewSpec.externalId}/${viewSpec.version}`, filterProperty],
+        values: assetInstances.map((a) => ({ space: a.space, externalId: a.externalId })),
+      },
+    };
+
+    const listRequest: DMSListRequest = {
+      sources: [
+        {
+          source: {
+            type: 'view',
+            space: viewSpec.space,
+            externalId: viewSpec.externalId,
+            version: viewSpec.version,
+          },
+        },
+      ],
+      instanceType: 'node',
+      limit: 1000,
+      filter,
+    };
+
+    const instances = await retryOnRateLimit(() =>
+      connector.fetchItems<DMSInstance>({
+        method: HttpMethod.POST,
+        path: '/models/instances/list',
+        data: listRequest,
+      })
+    );
+
+    return instances.map((instance) => {
+      const props =
+        instance.properties?.[viewSpec.space]?.[`${viewSpec.externalId}/${viewSpec.version}`] || {};
+      return {
+        space: instance.space,
+        externalId: instance.externalId,
+        version: instance.version,
+        lastUpdatedTime: instance.lastUpdatedTime,
+        createdTime: instance.createdTime,
+        name: props.name,
+        description: props.description,
+        startTime: props.startTime,
+        endTime: props.endTime,
+        scheduledStartTime: props.scheduledStartTime,
+        scheduledEndTime: props.scheduledEndTime,
+        type: props.type,
+        ...props,
+      };
+    });
+  } catch (err) {
+    console.warn('Failed to fetch activities by assets from DMS:', err);
+    return [];
+  }
+}
 

--- a/src/components/cogniteActivityTab.tsx
+++ b/src/components/cogniteActivityTab.tsx
@@ -1,13 +1,24 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Select, AsyncMultiSelect, InlineFieldRow, InlineField } from '@grafana/ui';
+import {
+  Select,
+  AsyncMultiSelect,
+  InlineFieldRow,
+  InlineField,
+  InlineSwitch,
+  InlineFormLabel,
+  InlineSegmentGroup,
+  Segment,
+  Button,
+} from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
-import { SelectedProps, CogniteActivityResourceType } from '../types';
+import { SelectedProps, CogniteActivityResourceType, ActivitySortProp, EventsOrderDirection, CogniteActivityTabQuery, defaultCogniteActivityTabQuery } from '../types';
 import {
   fetchCogniteActivityViews,
   fetchCogniteAssetViews,
   fetchCogniteEquipmentViews,
   fetchCogniteTimeSeriesViews,
   fetchDMSSpaces,
+  fetchDMSViewProperties,
   searchDMSInstances,
   stringifyError,
 } from '../cdf/client';
@@ -49,6 +60,145 @@ function viewToOption(view: InvolvedView): SelectableValue<InvolvedView> {
   };
 }
 
+const ActivityOrderDirectionEditor = ({
+  onChange,
+  direction = 'asc',
+}: {
+  direction: EventsOrderDirection;
+  onChange: (val: EventsOrderDirection) => void;
+}) => {
+  const options = [
+    { label: 'ascending', value: 'asc' as EventsOrderDirection },
+    { label: 'descending', value: 'desc' as EventsOrderDirection },
+  ];
+  return (
+    <InlineFieldRow>
+      <InlineFormLabel width={6}>Order</InlineFormLabel>
+      <Select
+        onChange={({ value }) => onChange(value!)}
+        options={options}
+        menuPosition="fixed"
+        value={direction}
+        className="cog-mr-4 width-10"
+      />
+    </InlineFieldRow>
+  );
+};
+
+interface ActivitySubProps {
+  query: CogniteActivityTabQuery;
+  onChange: (e: Partial<CogniteActivityTabQuery>) => void;
+  fields: string[];
+}
+
+const ActiveOnlySwitch = ({ query, onChange, fields: _ }: ActivitySubProps) => (
+  <InlineFieldRow>
+    <InlineField
+      label="Active only"
+      labelWidth={LABEL_WIDTH}
+      tooltip="Show only activities that are active (overlapping) within the current time range"
+    >
+      <InlineSwitch
+        label="Active only"
+        id="activity-active-only"
+        value={query.activeOnly ?? true}
+        onChange={({ currentTarget }) => onChange({ activeOnly: currentTarget.checked })}
+      />
+    </InlineField>
+  </InlineFieldRow>
+);
+
+const ActivityColumnsPicker = ({ query, onChange, fields }: ActivitySubProps) => {
+  const allOptions = fields.map((value) => ({ value, label: value }));
+  const columns = query.columns ?? defaultCogniteActivityTabQuery.columns!;
+  const addOptions = fields
+    .filter((f) => !columns.includes(f))
+    .map((value) => ({ value, label: value }));
+  return (
+    <InlineFieldRow>
+      <InlineFormLabel tooltip="Choose which columns to display" width={LABEL_WIDTH}>
+        Columns
+      </InlineFormLabel>
+      <InlineSegmentGroup>
+        {columns.map((val, key) => (
+          <React.Fragment key={key}>
+            <Segment
+              value={val}
+              options={allOptions}
+              onChange={({ value }) =>
+                onChange({ columns: columns.map((old, i) => (i === key ? value! : old)) })
+              }
+              allowCustomValue
+            />
+            <Button
+              variant="secondary"
+              onClick={() => onChange({ columns: columns.filter((_, i) => i !== key) })}
+              icon="times"
+              className="cog-mr-4"
+              data-testId={`activity-remove-col-${key}`}
+            />
+          </React.Fragment>
+        ))}
+        {addOptions.length > 0 && (
+          <Segment
+            value="+"
+            options={addOptions}
+            onChange={({ value }) => onChange({ columns: [...columns, value!] })}
+            data-testId="activity-add-col"
+          />
+        )}
+      </InlineSegmentGroup>
+    </InlineFieldRow>
+  );
+};
+
+const ActivitySortByPicker = ({ query, onChange, fields }: ActivitySubProps) => {
+  const options = fields.map((value) => ({ value, label: value }));
+  const sort: ActivitySortProp[] = query.sort ?? [];
+  return (
+    <InlineFieldRow>
+      <InlineFormLabel tooltip="Property to sort results by" width={LABEL_WIDTH}>
+        Sort by
+      </InlineFormLabel>
+      <InlineSegmentGroup>
+        {sort.map((val, key) => (
+          <React.Fragment key={key}>
+            <Segment
+              value={val.property}
+              options={options}
+              onChange={({ value }) =>
+                onChange({ sort: sort.map((old, i) => (i === key ? { ...old, property: value! } : old)) })
+              }
+              allowCustomValue
+            />
+            <ActivityOrderDirectionEditor
+              direction={val.order}
+              onChange={(value) =>
+                onChange({ sort: sort.map((old, i) => (i === key ? { ...old, order: value } : old)) })
+              }
+            />
+            <Button
+              variant="secondary"
+              onClick={() => onChange({ sort: sort.filter((_, i) => i !== key) })}
+              icon="times"
+              className="cog-mr-4"
+              data-testId={`activity-remove-sort-${key}`}
+            />
+          </React.Fragment>
+        ))}
+        {sort.length < 2 && (
+          <Button
+            variant="secondary"
+            onClick={() => onChange({ sort: [...sort, { property: 'startTime', order: 'asc' }] })}
+            icon="plus-circle"
+            data-testId="activity-add-sort"
+          />
+        )}
+      </InlineSegmentGroup>
+    </InlineFieldRow>
+  );
+};
+
 export const CogniteActivityTab: React.FC<CogniteActivityTabProps> = ({
   query,
   onQueryChange,
@@ -78,6 +228,15 @@ export const CogniteActivityTab: React.FC<CogniteActivityTabProps> = ({
   const [selectedInstanceView, setSelectedInstanceView] = useState<InvolvedView | null>(null);
   const [spaceOptions, setSpaceOptions] = useState<Array<SelectableValue<string>>>([]);
   const [loadingSpaces, setLoadingSpaces] = useState(false);
+  const [viewProperties, setViewProperties] = useState<string[]>([]);
+
+  const loadViewProperties = useCallback(
+    async (viewSpec: { space: string; externalId: string; version: string }) => {
+      const props = await fetchDMSViewProperties(connector, viewSpec);
+      setViewProperties(props);
+    },
+    [connector]
+  );
 
   const loadActivityViews = useCallback(async () => {
     try {
@@ -142,6 +301,9 @@ export const CogniteActivityTab: React.FC<CogniteActivityTabProps> = ({
     loadActivityViews();
     loadSpaces();
     loadInstanceViews(resourceType);
+    if (space && externalId && version) {
+      loadViewProperties({ space, externalId, version });
+    }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps -- intentional: load once on mount; resource type changes handled by handleResourceTypeChange
 
   const searchInstances = useCallback(
@@ -218,6 +380,7 @@ export const CogniteActivityTab: React.FC<CogniteActivityTabProps> = ({
           version: v.version,
         },
       });
+      loadViewProperties(v);
     }
   };
 
@@ -268,6 +431,10 @@ export const CogniteActivityTab: React.FC<CogniteActivityTabProps> = ({
           .map((v) => ({ space: v.space!, externalId: v.externalId!, name: v.label })),
       },
     });
+  };
+
+  const handleTabQueryChange = (partial: Partial<CogniteActivityTabQuery>) => {
+    onQueryChange({ cogniteActivityTabQuery: { ...cogniteActivityTabQuery, ...partial } });
   };
 
   return (
@@ -355,6 +522,9 @@ export const CogniteActivityTab: React.FC<CogniteActivityTabProps> = ({
           />
         </InlineField>
       </InlineFieldRow>
+      <ActiveOnlySwitch query={cogniteActivityTabQuery} onChange={handleTabQueryChange} fields={viewProperties} />
+      <ActivityColumnsPicker query={cogniteActivityTabQuery} onChange={handleTabQueryChange} fields={viewProperties} />
+      <ActivitySortByPicker query={cogniteActivityTabQuery} onChange={handleTabQueryChange} fields={viewProperties} />
     </>
   );
 };

--- a/src/components/cogniteActivityTab.tsx
+++ b/src/components/cogniteActivityTab.tsx
@@ -101,7 +101,7 @@ export const CogniteActivityTab: React.FC<CogniteActivityTabProps> = ({
     } finally {
       setLoadingActivityViews(false);
     }
-  }, [connector]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [connector, onQueryChange]);
 
   const loadInstanceViews = useCallback(
     async (type: CogniteActivityResourceType) => {
@@ -142,7 +142,7 @@ export const CogniteActivityTab: React.FC<CogniteActivityTabProps> = ({
     loadActivityViews();
     loadSpaces();
     loadInstanceViews(resourceType);
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []); // intentional: load once on mount; resource type changes handled by handleResourceTypeChange
 
   const searchInstances = useCallback(
     async (inputValue: string) => {
@@ -201,7 +201,7 @@ export const CogniteActivityTab: React.FC<CogniteActivityTabProps> = ({
     ) ?? null;
 
   const selectedInstanceValues = assetInstances.map((a) => ({
-    label: a.externalId,
+    label: a.name ?? a.externalId,
     value: `${a.space}:${a.externalId}`,
     space: a.space,
     externalId: a.externalId,

--- a/src/components/cogniteActivityTab.tsx
+++ b/src/components/cogniteActivityTab.tsx
@@ -1,0 +1,360 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { Select, AsyncMultiSelect, InlineFieldRow, InlineField } from '@grafana/ui';
+import { SelectableValue } from '@grafana/data';
+import { SelectedProps, CogniteActivityResourceType } from '../types';
+import {
+  fetchCogniteActivityViews,
+  fetchCogniteAssetViews,
+  fetchCogniteEquipmentViews,
+  fetchCogniteTimeSeriesViews,
+  fetchDMSSpaces,
+  searchDMSInstances,
+  stringifyError,
+} from '../cdf/client';
+import { DMSSearchRequest, InvolvedView } from '../types/dms';
+import { Connector } from '../connector';
+
+interface CogniteActivityTabProps extends SelectedProps {
+  connector: Connector;
+}
+
+const RESOURCE_TYPE_OPTIONS: Array<SelectableValue<CogniteActivityResourceType>> = [
+  { label: 'CogniteAsset', value: 'CogniteAsset' },
+  { label: 'CogniteEquipment', value: 'CogniteEquipment' },
+  { label: 'CogniteTimeSeries', value: 'CogniteTimeSeries' },
+];
+
+const LABEL_WIDTH = 16;
+
+async function fetchViewsForResourceType(
+  connector: Connector,
+  resourceType: CogniteActivityResourceType
+): Promise<InvolvedView[]> {
+  switch (resourceType) {
+    case 'CogniteEquipment':
+      return fetchCogniteEquipmentViews(connector);
+    case 'CogniteTimeSeries':
+      return fetchCogniteTimeSeriesViews(connector);
+    case 'CogniteAsset':
+    default:
+      return fetchCogniteAssetViews(connector);
+  }
+}
+
+function viewToOption(view: InvolvedView): SelectableValue<InvolvedView> {
+  return {
+    label: `${view.externalId} (${view.space}) ${view.version}`,
+    value: view,
+    description: `Space: ${view.space}, Version: ${view.version}`,
+  };
+}
+
+export const CogniteActivityTab: React.FC<CogniteActivityTabProps> = ({
+  query,
+  onQueryChange,
+  connector,
+}) => {
+  const { cogniteActivityTabQuery } = query;
+  const {
+    space,
+    externalId,
+    version,
+    resourceType,
+    instanceSpace,
+    assetInstances,
+  } = cogniteActivityTabQuery ?? {
+    space: 'cdf_cdm',
+    externalId: 'CogniteActivity',
+    version: 'v1',
+    resourceType: 'CogniteAsset' as CogniteActivityResourceType,
+    instanceSpace: '',
+    assetInstances: [],
+  };
+
+  const [activityViewOptions, setActivityViewOptions] = useState<Array<SelectableValue<InvolvedView>>>([]);
+  const [loadingActivityViews, setLoadingActivityViews] = useState(false);
+  const [instanceViewOptions, setInstanceViewOptions] = useState<Array<SelectableValue<InvolvedView>>>([]);
+  const [loadingInstanceViews, setLoadingInstanceViews] = useState(false);
+  const [selectedInstanceView, setSelectedInstanceView] = useState<InvolvedView | null>(null);
+  const [spaceOptions, setSpaceOptions] = useState<Array<SelectableValue<string>>>([]);
+  const [loadingSpaces, setLoadingSpaces] = useState(false);
+
+  const loadActivityViews = useCallback(async () => {
+    try {
+      setLoadingActivityViews(true);
+      const views = await fetchCogniteActivityViews(connector);
+      const options = views.map(viewToOption);
+      setActivityViewOptions(options);
+      if (options.length === 1) {
+        const v = options[0].value!;
+        onQueryChange({
+          cogniteActivityTabQuery: {
+            ...cogniteActivityTabQuery,
+            space: v.space,
+            externalId: v.externalId,
+            version: v.version,
+          },
+        });
+      }
+    } catch (err) {
+      console.warn('Failed to load CogniteActivity views:', stringifyError(err));
+    } finally {
+      setLoadingActivityViews(false);
+    }
+  }, [connector]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const loadInstanceViews = useCallback(
+    async (type: CogniteActivityResourceType) => {
+      try {
+        setLoadingInstanceViews(true);
+        const views = await fetchViewsForResourceType(connector, type);
+        const options = views.map(viewToOption);
+        setInstanceViewOptions(options);
+        // Pick cdf_cdm standard view by default, fall back to first
+        const preferred =
+          views.find((v) => v.space === 'cdf_cdm') || views[0] || null;
+        setSelectedInstanceView(preferred);
+      } catch (err) {
+        console.warn(`Failed to load ${type} views:`, stringifyError(err));
+      } finally {
+        setLoadingInstanceViews(false);
+      }
+    },
+    [connector]
+  );
+
+  const loadSpaces = useCallback(async () => {
+    try {
+      setLoadingSpaces(true);
+      const spaces = await fetchDMSSpaces(connector);
+      setSpaceOptions([
+        { label: 'All spaces', value: '' },
+        ...spaces.map((s) => ({ label: s.space, value: s.space })),
+      ]);
+    } catch (err) {
+      console.warn('Failed to load DMS spaces:', stringifyError(err));
+    } finally {
+      setLoadingSpaces(false);
+    }
+  }, [connector]);
+
+  useEffect(() => {
+    loadActivityViews();
+    loadSpaces();
+    loadInstanceViews(resourceType);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const searchInstances = useCallback(
+    async (inputValue: string) => {
+      if (!selectedInstanceView) {
+        return [];
+      }
+      try {
+        const searchRequest: DMSSearchRequest = {
+          view: {
+            type: 'view',
+            space: selectedInstanceView.space,
+            externalId: selectedInstanceView.externalId,
+            version: selectedInstanceView.version,
+          },
+          query: inputValue,
+          filter: instanceSpace ? { inSpace: instanceSpace } : undefined,
+          limit: 100,
+        };
+        const instances = await searchDMSInstances(connector, searchRequest);
+        return instances.map((i) => {
+          const props =
+            i.properties?.[selectedInstanceView.space]?.[
+              `${selectedInstanceView.externalId}/${selectedInstanceView.version}`
+            ] ?? {};
+          const name = props.name ?? i.externalId;
+          return {
+            label: name,
+            value: `${i.space}:${i.externalId}`,
+            description: `Space: ${i.space} | ExternalId: ${i.externalId}`,
+            space: i.space,
+            externalId: i.externalId,
+          };
+        });
+      } catch (err) {
+        console.warn('Failed to search instances:', stringifyError(err));
+        return [];
+      }
+    },
+    [connector, selectedInstanceView, instanceSpace]
+  );
+
+  const selectedActivityViewOption =
+    activityViewOptions.find(
+      (o) =>
+        o.value?.space === space &&
+        o.value?.externalId === externalId &&
+        o.value?.version === version
+    ) ?? null;
+
+  const selectedInstanceViewOption =
+    instanceViewOptions.find(
+      (o) =>
+        o.value?.space === selectedInstanceView?.space &&
+        o.value?.externalId === selectedInstanceView?.externalId &&
+        o.value?.version === selectedInstanceView?.version
+    ) ?? null;
+
+  const selectedInstanceValues = assetInstances.map((a) => ({
+    label: a.externalId,
+    value: `${a.space}:${a.externalId}`,
+    space: a.space,
+    externalId: a.externalId,
+  }));
+
+  const handleActivityViewChange = (selected: SelectableValue<InvolvedView>) => {
+    if (selected?.value) {
+      const v = selected.value;
+      onQueryChange({
+        cogniteActivityTabQuery: {
+          ...cogniteActivityTabQuery,
+          space: v.space,
+          externalId: v.externalId,
+          version: v.version,
+        },
+      });
+    }
+  };
+
+  const handleResourceTypeChange = (selected: SelectableValue<CogniteActivityResourceType>) => {
+    if (selected?.value) {
+      onQueryChange({
+        cogniteActivityTabQuery: {
+          ...cogniteActivityTabQuery,
+          resourceType: selected.value,
+          assetInstances: [],
+        },
+      });
+      loadInstanceViews(selected.value);
+    }
+  };
+
+  const handleInstanceViewChange = (selected: SelectableValue<InvolvedView>) => {
+    if (selected?.value) {
+      setSelectedInstanceView(selected.value);
+      onQueryChange({
+        cogniteActivityTabQuery: {
+          ...cogniteActivityTabQuery,
+          assetInstances: [],
+        },
+      });
+    }
+  };
+
+  const handleSpaceChange = (selected: SelectableValue<string>) => {
+    const newSpace = selected?.value ?? '';
+    onQueryChange({
+      cogniteActivityTabQuery: {
+        ...cogniteActivityTabQuery,
+        instanceSpace: newSpace,
+        assetInstances: [],
+      },
+    });
+  };
+
+  const handleInstancesChange = (
+    values: Array<SelectableValue & { space?: string; externalId?: string }>
+  ) => {
+    onQueryChange({
+      cogniteActivityTabQuery: {
+        ...cogniteActivityTabQuery,
+        assetInstances: values
+          .filter((v) => v.space && v.externalId)
+          .map((v) => ({ space: v.space!, externalId: v.externalId!, name: v.label })),
+      },
+    });
+  };
+
+  return (
+    <>
+      <InlineFieldRow>
+        <InlineField
+          label="Activity View"
+          labelWidth={LABEL_WIDTH}
+          tooltip="Select which CogniteActivity view to query"
+        >
+          <Select
+            options={activityViewOptions}
+            value={selectedActivityViewOption}
+            onChange={handleActivityViewChange}
+            placeholder="Select a CogniteActivity view"
+            isLoading={loadingActivityViews}
+            isClearable={false}
+            width={40}
+          />
+        </InlineField>
+      </InlineFieldRow>
+      <InlineFieldRow>
+        <InlineField
+          label="Resource Type"
+          labelWidth={LABEL_WIDTH}
+          tooltip="Type of resource the activity is related to"
+        >
+          <Select
+            options={RESOURCE_TYPE_OPTIONS}
+            value={resourceType}
+            onChange={handleResourceTypeChange}
+            width={40}
+          />
+        </InlineField>
+      </InlineFieldRow>
+      <InlineFieldRow>
+        <InlineField
+          label="Instance View"
+          labelWidth={LABEL_WIDTH}
+          tooltip={`Select which ${resourceType} view to search instances in`}
+        >
+          <Select
+            options={instanceViewOptions}
+            value={selectedInstanceViewOption}
+            onChange={handleInstanceViewChange}
+            placeholder={`Select a ${resourceType} view`}
+            isLoading={loadingInstanceViews}
+            isClearable={false}
+            width={40}
+          />
+        </InlineField>
+      </InlineFieldRow>
+      <InlineFieldRow>
+        <InlineField
+          label="Space"
+          labelWidth={LABEL_WIDTH}
+          tooltip="Filter instance search to a specific DMS space (leave empty to search all spaces)"
+        >
+          <Select
+            options={spaceOptions}
+            value={instanceSpace || ''}
+            onChange={handleSpaceChange}
+            isLoading={loadingSpaces}
+            placeholder="All spaces"
+            isClearable={false}
+            width={40}
+          />
+        </InlineField>
+      </InlineFieldRow>
+      <InlineFieldRow>
+        <InlineField
+          label="Instance(s)"
+          labelWidth={LABEL_WIDTH}
+          tooltip={`Select one or more ${resourceType} instances. Activities related to these will be shown.`}
+        >
+          <AsyncMultiSelect
+            key={`${selectedInstanceView?.space}:${selectedInstanceView?.externalId}:${selectedInstanceView?.version}:${instanceSpace}`}
+            loadOptions={searchInstances}
+            value={selectedInstanceValues}
+            onChange={handleInstancesChange}
+            placeholder={`Search ${resourceType} by name...`}
+            width={40}
+            noOptionsMessage="No instances found"
+            inputId={`cognite-activity-instances-${query.refId}`}
+          />
+        </InlineField>
+      </InlineFieldRow>
+    </>
+  );
+};

--- a/src/components/cogniteActivityTab.tsx
+++ b/src/components/cogniteActivityTab.tsx
@@ -101,7 +101,7 @@ export const CogniteActivityTab: React.FC<CogniteActivityTabProps> = ({
     } finally {
       setLoadingActivityViews(false);
     }
-  }, [connector, onQueryChange]);
+  }, [connector, onQueryChange]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const loadInstanceViews = useCallback(
     async (type: CogniteActivityResourceType) => {
@@ -142,7 +142,7 @@ export const CogniteActivityTab: React.FC<CogniteActivityTabProps> = ({
     loadActivityViews();
     loadSpaces();
     loadInstanceViews(resourceType);
-  }, []); // intentional: load once on mount; resource type changes handled by handleResourceTypeChange
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps -- intentional: load once on mount; resource type changes handled by handleResourceTypeChange
 
   const searchInstances = useCallback(
     async (inputValue: string) => {

--- a/src/components/queryEditor.tsx
+++ b/src/components/queryEditor.tsx
@@ -36,6 +36,7 @@ import { RelationshipsTab } from './relationships';
 import { ExtractionPipelinesTab } from './extractionPipelinesTab';
 import { FlexibleDataModellingTab } from './flexibleDataModellingTab';
 import { CogniteTimeSeriesSearchTab } from './cogniteTimeSeriesSearchTab';
+import { CogniteActivityTab } from './cogniteActivityTab';
 import { CommonEditors, LabelEditor } from './commonEditors';
 import { EventsTab } from './eventsTab';
 import { eventBusService } from '../appEventHandler';
@@ -345,20 +346,21 @@ export function QueryEditor(props: EditorProps) {
     <div>
       <TabsBar>
         {Object.values(Tabs).map((t) => {
+          if (hiddenTab(t)) {
+            return null;
+          }
           const tabIsDisabled = isTabDisabled(t, datasource);
           const isCurrentlySelected = t === tab;
           const showingDisabledTab = tabIsDisabled && isCurrentlySelected;
-          
+
           return (
             <Tab
-              hidden={hiddenTab(t)}
               label={TabTitles[t]}
               key={t}
               active={activeTab === t}
               onChangeTab={onSelectTab(t)}
               style={{ display: 'flex' }}
               suffix={
-                // Show "Disabled" label for tabs that are disabled but shown for backward compatibility
                 showingDisabledTab
                   ? () => (
                       <p className="preview-label" style={{ color: theme.colors.error.text }}>Disabled</p>
@@ -390,6 +392,9 @@ export function QueryEditor(props: EditorProps) {
         )}
         {activeTab === Tabs.CogniteTimeSeriesSearch && (
           <CogniteTimeSeriesSearchTab {...{ onQueryChange, query, connector: datasource.connector }} />
+        )}
+        {activeTab === Tabs.CogniteActivity && (
+          <CogniteActivityTab {...{ onQueryChange, query, connector: datasource.connector }} />
         )}
       </TabContent>
       {errorMessage && <pre className="gf-formatted-error">{errorMessage}</pre>}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -57,6 +57,7 @@ export const EventSortByFields = [
   ...DateFields,
   '_score_',
 ];
+
 const createFields = (parent, field) => `${parent}-${field}`;
 const metaFields = [
   'Dockerfile',

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -176,6 +176,7 @@ export default class CogniteDatasource extends DataSourceWithBackend<
       extractionPipelinesTargets,
       flexibleDataModellingTargets,
       activityTargets,
+      cogniteActivityTabTargets,
     } = groupTargets(queryTargets);
 
     let observables: Array<Observable<DataQueryResponse>> = [];
@@ -257,6 +258,16 @@ export default class CogniteDatasource extends DataSourceWithBackend<
           })
         ).pipe(map((result) => ({ data: result.data })));
         observables.push(activityObservable);
+      }
+
+      if (cogniteActivityTabTargets.length) {
+        const cogniteActivityTabObservable = from(
+          this.activityDatasource.queryByAssets({
+            ...options,
+            targets: cogniteActivityTabTargets,
+          })
+        ).pipe(map((result) => ({ data: result.data })));
+        observables.push(cogniteActivityTabObservable);
       }
     }
 
@@ -638,6 +649,8 @@ export function filterEmptyQueryTargets(targets: CogniteQuery[]): QueryTarget[] 
           );
         case Tab.CogniteTimeSeriesSearch:
           return !!cogniteTimeSeries?.instanceId;
+        case Tab.CogniteActivity:
+          return !!target.cogniteActivityTabQuery?.assetInstances?.length;
         case Tab.DataModellingV2:
           return true;
         case Tab.ExtractionPipelines:
@@ -679,6 +692,7 @@ function groupTargets(targets: CogniteQuery[]) {
     extractionPipelinesTargets: groupedByTab[Tab.ExtractionPipelines] ?? [],
     flexibleDataModellingTargets: groupedByTab[Tab.FlexibleDataModelling] ?? [],
     activityTargets,
+    cogniteActivityTabTargets: groupedByTab[Tab.CogniteActivity] ?? [],
     tsTargets: [
       ...(groupedByTab[Tab.Timeseries] ?? []),
       ...(groupedByTab[Tab.Asset] ?? []),

--- a/src/datasources/ActivityDatasource.spec.ts
+++ b/src/datasources/ActivityDatasource.spec.ts
@@ -28,6 +28,16 @@ function makeActivity(overrides: Partial<CogniteActivity> = {}): CogniteActivity
   };
 }
 
+// Wide range covering all test activity timestamps (Jan 2026)
+const defaultRange = {
+  from: { valueOf: () => new Date('2024-01-01').getTime() },
+  to: { valueOf: () => new Date('2027-01-01').getTime() },
+};
+
+function makeOptions(targets: any[], range = defaultRange) {
+  return { targets, range } as any;
+}
+
 function makeTarget(overrides: object = {}) {
   return {
     refId: 'A',
@@ -48,6 +58,7 @@ function makeTarget(overrides: object = {}) {
       assetInstances: [
         { space: 'cdm_try', externalId: 'weather-station-fornebu', name: 'Fornebu Weather Station' },
       ],
+      columns: ['externalId', 'space', 'name', 'type', 'description', 'startTime', 'endTime', 'scheduledStartTime', 'scheduledEndTime', 'createdTime', 'lastUpdatedTime'],
     },
     ...overrides,
   } as any;
@@ -102,9 +113,9 @@ describe('ActivityDatasource.queryByAssets', () => {
   });
 
   it('returns empty data when no targets have assetInstances', async () => {
-    const result = await datasource.queryByAssets({
-      targets: [makeTarget({ cogniteActivityTabQuery: { assetInstances: [] } })],
-    } as any);
+    const result = await datasource.queryByAssets(
+      makeOptions([makeTarget({ cogniteActivityTabQuery: { assetInstances: [] } })])
+    );
     expect(result.data).toHaveLength(0);
     expect(fetchActivitiesByAssets).not.toHaveBeenCalled();
   });
@@ -112,7 +123,7 @@ describe('ActivityDatasource.queryByAssets', () => {
   it('builds a DataFrame with correct column order for CogniteAsset', async () => {
     fetchActivitiesByAssets.mockResolvedValue([makeActivity({ assets: [{ space: 'cdm_try', externalId: 'weather-station-fornebu' }] })]);
 
-    const result = await datasource.queryByAssets({ targets: [makeTarget()] } as any);
+    const result = await datasource.queryByAssets(makeOptions([makeTarget()]));
 
     expect(result.data).toHaveLength(1);
     const frame = result.data[0];
@@ -128,16 +139,15 @@ describe('ActivityDatasource.queryByAssets', () => {
   it('names the resource column based on resourceType', async () => {
     fetchActivitiesByAssets.mockResolvedValue([makeActivity({ equipment: [{ space: 'cdm_try', externalId: 'sensor-fornebu-anemometer' }] })]);
 
-    const result = await datasource.queryByAssets({
-      targets: [makeTarget({
-        cogniteActivityTabQuery: {
-          space: 'cdf_cdm', externalId: 'CogniteActivity', version: 'v1',
-          resourceType: 'CogniteEquipment',
-          instanceSpace: '',
-          assetInstances: [{ space: 'cdm_try', externalId: 'sensor-fornebu-anemometer', name: 'Ultrasonic Wind Sensor' }],
-        },
-      })],
-    } as any);
+    const result = await datasource.queryByAssets(makeOptions([makeTarget({
+      cogniteActivityTabQuery: {
+        space: 'cdf_cdm', externalId: 'CogniteActivity', version: 'v1',
+        resourceType: 'CogniteEquipment',
+        instanceSpace: '',
+        assetInstances: [{ space: 'cdm_try', externalId: 'sensor-fornebu-anemometer', name: 'Ultrasonic Wind Sensor' }],
+        columns: ['externalId', 'description'],
+      },
+    })]));
 
     const frame = result.data[0];
     const lastField = frame.fields[frame.fields.length - 1];
@@ -149,7 +159,7 @@ describe('ActivityDatasource.queryByAssets', () => {
       makeActivity({ assets: [{ space: 'cdm_try', externalId: 'weather-station-fornebu' }] }),
     ]);
 
-    const result = await datasource.queryByAssets({ targets: [makeTarget()] } as any);
+    const result = await datasource.queryByAssets(makeOptions([makeTarget()]));
 
     const frame = result.data[0];
     const assetField = frame.fields.find((f: any) => f.name === 'asset');
@@ -162,7 +172,7 @@ describe('ActivityDatasource.queryByAssets', () => {
       makeActivity({ assets: [{ space: 'cdm_try', externalId: 'weather-station-lysaker' }] }),
     ]);
 
-    const result = await datasource.queryByAssets({ targets: [makeTarget()] } as any);
+    const result = await datasource.queryByAssets(makeOptions([makeTarget()]));
 
     const frame = result.data[0];
     const assetField = frame.fields.find((f: any) => f.name === 'asset');
@@ -173,7 +183,7 @@ describe('ActivityDatasource.queryByAssets', () => {
   it('time fields have FieldType.time', async () => {
     fetchActivitiesByAssets.mockResolvedValue([makeActivity({ assets: [{ space: 'cdm_try', externalId: 'weather-station-fornebu' }] })]);
 
-    const result = await datasource.queryByAssets({ targets: [makeTarget()] } as any);
+    const result = await datasource.queryByAssets(makeOptions([makeTarget()]));
 
     const frame = result.data[0];
     for (const col of ['startTime', 'endTime', 'scheduledStartTime', 'scheduledEndTime', 'createdTime', 'lastUpdatedTime']) {
@@ -185,7 +195,7 @@ describe('ActivityDatasource.queryByAssets', () => {
   it('string fields have FieldType.string', async () => {
     fetchActivitiesByAssets.mockResolvedValue([makeActivity({ assets: [{ space: 'cdm_try', externalId: 'weather-station-fornebu' }] })]);
 
-    const result = await datasource.queryByAssets({ targets: [makeTarget()] } as any);
+    const result = await datasource.queryByAssets(makeOptions([makeTarget()]));
 
     const frame = result.data[0];
     for (const col of ['externalId', 'space', 'name', 'type', 'description', 'asset']) {
@@ -198,7 +208,7 @@ describe('ActivityDatasource.queryByAssets', () => {
     const { handleError } = jest.requireMock('../appEventHandler');
     fetchActivitiesByAssets.mockRejectedValue(new Error('network error'));
 
-    const result = await datasource.queryByAssets({ targets: [makeTarget()] } as any);
+    const result = await datasource.queryByAssets(makeOptions([makeTarget()]));
 
     expect(result.data).toHaveLength(0);
     expect(handleError).toHaveBeenCalled();
@@ -207,16 +217,15 @@ describe('ActivityDatasource.queryByAssets', () => {
   it('passes filterProperty based on resourceType to fetchActivitiesByAssets', async () => {
     fetchActivitiesByAssets.mockResolvedValue([]);
 
-    await datasource.queryByAssets({
-      targets: [makeTarget({
-        cogniteActivityTabQuery: {
-          space: 'cdf_cdm', externalId: 'CogniteActivity', version: 'v1',
-          resourceType: 'CogniteTimeSeries',
-          instanceSpace: '',
-          assetInstances: [{ space: 'cdm_try', externalId: 'ts-001', name: 'My TS' }],
-        },
-      })],
-    } as any);
+    await datasource.queryByAssets(makeOptions([makeTarget({
+      cogniteActivityTabQuery: {
+        space: 'cdf_cdm', externalId: 'CogniteActivity', version: 'v1',
+        resourceType: 'CogniteTimeSeries',
+        instanceSpace: '',
+        assetInstances: [{ space: 'cdm_try', externalId: 'ts-001', name: 'My TS' }],
+        columns: ['externalId'],
+      },
+    })]));
 
     expect(fetchActivitiesByAssets).toHaveBeenCalledWith(
       expect.anything(),

--- a/src/datasources/ActivityDatasource.spec.ts
+++ b/src/datasources/ActivityDatasource.spec.ts
@@ -1,0 +1,228 @@
+import { FieldType } from '@grafana/data';
+import { convertActivitiesDateFields, ActivityDatasource } from './ActivityDatasource';
+import { CogniteActivity } from '../types/dms';
+import { Connector } from '../connector';
+import { Tab } from '../types';
+
+jest.mock('../cdf/client');
+jest.mock('../appEventHandler', () => ({ handleError: jest.fn() }));
+
+const { fetchActivitiesByAssets } = jest.requireMock('../cdf/client');
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeActivity(overrides: Partial<CogniteActivity> = {}): CogniteActivity {
+  return {
+    space: 'cdm_try',
+    externalId: 'weather-activity-001',
+    name: 'Humidity Study #1',
+    description: 'Activity for humidity level tracking',
+    type: 'inspection',
+    createdTime: 1706000000000,
+    lastUpdatedTime: 1706001000000,
+    startTime: '2026-01-04T09:40:00.000Z',
+    endTime: '2026-01-14T09:40:00.000Z',
+    scheduledStartTime: '2026-01-04T08:00:00.000Z',
+    scheduledEndTime: '2026-01-14T08:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeTarget(overrides: object = {}) {
+  return {
+    refId: 'A',
+    tab: Tab.CogniteActivity,
+    aggregation: 'average',
+    granularity: '',
+    latestValue: false,
+    error: '',
+    label: '',
+    warning: '',
+    expr: '',
+    cogniteActivityTabQuery: {
+      space: 'cdf_cdm',
+      externalId: 'CogniteActivity',
+      version: 'v1',
+      resourceType: 'CogniteAsset' as const,
+      instanceSpace: '',
+      assetInstances: [
+        { space: 'cdm_try', externalId: 'weather-station-fornebu', name: 'Fornebu Weather Station' },
+      ],
+    },
+    ...overrides,
+  } as any;
+}
+
+// ── convertActivitiesDateFields ────────────────────────────────────────────
+
+describe('convertActivitiesDateFields', () => {
+  it('converts all date fields to Date objects when all are present', () => {
+    const result = convertActivitiesDateFields([makeActivity()]);
+    expect(result[0].createdTime).toBeInstanceOf(Date);
+    expect(result[0].lastUpdatedTime).toBeInstanceOf(Date);
+    expect(result[0].startTime).toBeInstanceOf(Date);
+    expect(result[0].endTime).toBeInstanceOf(Date);
+    expect(result[0].scheduledStartTime).toBeInstanceOf(Date);
+    expect(result[0].scheduledEndTime).toBeInstanceOf(Date);
+  });
+
+  it('does not set missing optional date fields', () => {
+    const result = convertActivitiesDateFields([
+      makeActivity({ startTime: undefined, endTime: undefined, scheduledStartTime: undefined, scheduledEndTime: undefined }),
+    ]);
+    expect(result[0].startTime).toBeUndefined();
+    expect(result[0].endTime).toBeUndefined();
+    expect(result[0].scheduledStartTime).toBeUndefined();
+    expect(result[0].scheduledEndTime).toBeUndefined();
+    expect(result[0].createdTime).toBeInstanceOf(Date);
+    expect(result[0].lastUpdatedTime).toBeInstanceOf(Date);
+  });
+
+  it('preserves non-date fields unchanged', () => {
+    const result = convertActivitiesDateFields([makeActivity()]);
+    expect(result[0].externalId).toBe('weather-activity-001');
+    expect(result[0].name).toBe('Humidity Study #1');
+    expect(result[0].description).toBe('Activity for humidity level tracking');
+    expect(result[0].type).toBe('inspection');
+  });
+
+  it('handles an empty array', () => {
+    expect(convertActivitiesDateFields([])).toEqual([]);
+  });
+});
+
+// ── ActivityDatasource.queryByAssets ──────────────────────────────────────
+
+describe('ActivityDatasource.queryByAssets', () => {
+  let datasource: ActivityDatasource;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    datasource = new ActivityDatasource({} as Connector);
+  });
+
+  it('returns empty data when no targets have assetInstances', async () => {
+    const result = await datasource.queryByAssets({
+      targets: [makeTarget({ cogniteActivityTabQuery: { assetInstances: [] } })],
+    } as any);
+    expect(result.data).toHaveLength(0);
+    expect(fetchActivitiesByAssets).not.toHaveBeenCalled();
+  });
+
+  it('builds a DataFrame with correct column order for CogniteAsset', async () => {
+    fetchActivitiesByAssets.mockResolvedValue([makeActivity({ assets: [{ space: 'cdm_try', externalId: 'weather-station-fornebu' }] })]);
+
+    const result = await datasource.queryByAssets({ targets: [makeTarget()] } as any);
+
+    expect(result.data).toHaveLength(1);
+    const frame = result.data[0];
+    const fieldNames = frame.fields.map((f: any) => f.name);
+    expect(fieldNames).toEqual([
+      'externalId', 'space', 'name', 'type', 'description',
+      'startTime', 'endTime', 'scheduledStartTime', 'scheduledEndTime',
+      'createdTime', 'lastUpdatedTime',
+      'asset',
+    ]);
+  });
+
+  it('names the resource column based on resourceType', async () => {
+    fetchActivitiesByAssets.mockResolvedValue([makeActivity({ equipment: [{ space: 'cdm_try', externalId: 'sensor-fornebu-anemometer' }] })]);
+
+    const result = await datasource.queryByAssets({
+      targets: [makeTarget({
+        cogniteActivityTabQuery: {
+          space: 'cdf_cdm', externalId: 'CogniteActivity', version: 'v1',
+          resourceType: 'CogniteEquipment',
+          instanceSpace: '',
+          assetInstances: [{ space: 'cdm_try', externalId: 'sensor-fornebu-anemometer', name: 'Ultrasonic Wind Sensor' }],
+        },
+      })],
+    } as any);
+
+    const frame = result.data[0];
+    const lastField = frame.fields[frame.fields.length - 1];
+    expect(lastField.name).toBe('equipment');
+  });
+
+  it('resource column shows instance name from selected instances', async () => {
+    fetchActivitiesByAssets.mockResolvedValue([
+      makeActivity({ assets: [{ space: 'cdm_try', externalId: 'weather-station-fornebu' }] }),
+    ]);
+
+    const result = await datasource.queryByAssets({ targets: [makeTarget()] } as any);
+
+    const frame = result.data[0];
+    const assetField = frame.fields.find((f: any) => f.name === 'asset');
+    expect(assetField.values[0]).toBe('Fornebu Weather Station');
+  });
+
+  it('resource column falls back to externalId when instance not in selection', async () => {
+    fetchActivitiesByAssets.mockResolvedValue([
+      // activity references a different asset not in the selected list
+      makeActivity({ assets: [{ space: 'cdm_try', externalId: 'weather-station-lysaker' }] }),
+    ]);
+
+    const result = await datasource.queryByAssets({ targets: [makeTarget()] } as any);
+
+    const frame = result.data[0];
+    const assetField = frame.fields.find((f: any) => f.name === 'asset');
+    // not in map → null (only selected instances are shown)
+    expect(assetField.values[0]).toBeNull();
+  });
+
+  it('time fields have FieldType.time', async () => {
+    fetchActivitiesByAssets.mockResolvedValue([makeActivity({ assets: [{ space: 'cdm_try', externalId: 'weather-station-fornebu' }] })]);
+
+    const result = await datasource.queryByAssets({ targets: [makeTarget()] } as any);
+
+    const frame = result.data[0];
+    for (const col of ['startTime', 'endTime', 'scheduledStartTime', 'scheduledEndTime', 'createdTime', 'lastUpdatedTime']) {
+      const field = frame.fields.find((f: any) => f.name === col);
+      expect(field.type).toBe(FieldType.time);
+    }
+  });
+
+  it('string fields have FieldType.string', async () => {
+    fetchActivitiesByAssets.mockResolvedValue([makeActivity({ assets: [{ space: 'cdm_try', externalId: 'weather-station-fornebu' }] })]);
+
+    const result = await datasource.queryByAssets({ targets: [makeTarget()] } as any);
+
+    const frame = result.data[0];
+    for (const col of ['externalId', 'space', 'name', 'type', 'description', 'asset']) {
+      const field = frame.fields.find((f: any) => f.name === col);
+      expect(field.type).toBe(FieldType.string);
+    }
+  });
+
+  it('handles fetch errors and returns empty data', async () => {
+    const { handleError } = jest.requireMock('../appEventHandler');
+    fetchActivitiesByAssets.mockRejectedValue(new Error('network error'));
+
+    const result = await datasource.queryByAssets({ targets: [makeTarget()] } as any);
+
+    expect(result.data).toHaveLength(0);
+    expect(handleError).toHaveBeenCalled();
+  });
+
+  it('passes filterProperty based on resourceType to fetchActivitiesByAssets', async () => {
+    fetchActivitiesByAssets.mockResolvedValue([]);
+
+    await datasource.queryByAssets({
+      targets: [makeTarget({
+        cogniteActivityTabQuery: {
+          space: 'cdf_cdm', externalId: 'CogniteActivity', version: 'v1',
+          resourceType: 'CogniteTimeSeries',
+          instanceSpace: '',
+          assetInstances: [{ space: 'cdm_try', externalId: 'ts-001', name: 'My TS' }],
+        },
+      })],
+    } as any);
+
+    expect(fetchActivitiesByAssets).toHaveBeenCalledWith(
+      expect.anything(),
+      { space: 'cdf_cdm', externalId: 'CogniteActivity', version: 'v1' },
+      [{ space: 'cdm_try', externalId: 'ts-001', name: 'My TS' }],
+      'timeSeries'
+    );
+  });
+});

--- a/src/datasources/ActivityDatasource.ts
+++ b/src/datasources/ActivityDatasource.ts
@@ -3,7 +3,7 @@ import { CogniteQuery, CogniteActivityQuery, HttpMethod, Tuple } from '../types'
 import { Connector } from '../connector';
 import { getRange } from '../utils';
 import { CogniteActivity } from '../types/dms';
-import { fetchActivitiesFromDMS } from '../cdf/client';
+import { fetchActivitiesFromDMS, fetchActivitiesByAssets } from '../cdf/client';
 import { handleError } from '../appEventHandler';
 
 // Convert activities to annotation format for overlay on charts
@@ -92,6 +92,97 @@ export class ActivityDatasource {
       handleError(e, refId);
       return [];
     }
+  }
+
+  async queryByAssets(options: DataQueryRequest<CogniteQuery>): Promise<DataQueryResponse> {
+    const results = await Promise.all(
+      options.targets.map(async (target) => {
+        const { refId, cogniteActivityTabQuery } = target;
+        if (!cogniteActivityTabQuery?.assetInstances?.length) {
+          return null;
+        }
+        const { space, externalId, version, resourceType, assetInstances } = cogniteActivityTabQuery;
+        const filterPropertyMap: Record<string, string> = {
+          CogniteAsset: 'assets',
+          CogniteEquipment: 'equipment',
+          CogniteTimeSeries: 'timeSeries',
+        };
+        const filterProperty = filterPropertyMap[resourceType] ?? 'assets';
+        try {
+          const activities = await fetchActivitiesByAssets(
+            this.connector,
+            { space, externalId, version },
+            assetInstances,
+            filterProperty
+          );
+          const converted = convertActivitiesDateFields(activities);
+
+          // Build lookup: "space:externalId" -> display name (name only, fallback to externalId)
+          const instanceNameMap = new Map(
+            assetInstances.map((a) => [
+              `${a.space}:${a.externalId}`,
+              a.name ?? a.externalId,
+            ])
+          );
+
+          // Column name reflects the resource type
+          const resourceColumnNames: Record<string, string> = {
+            CogniteAsset: 'asset',
+            CogniteEquipment: 'equipment',
+            CogniteTimeSeries: 'timeSeries',
+          };
+          const resourceColName = resourceColumnNames[resourceType] ?? 'Instance';
+
+          const resourceColValues = converted.map((item) => {
+            const refs: Array<{ space: string; externalId: string }> =
+              (item as any)[filterProperty] ?? [];
+            const names = (Array.isArray(refs) ? refs : [refs])
+              .map((r) => instanceNameMap.get(`${r.space}:${r.externalId}`))
+              .filter((name): name is string => name !== undefined)
+              .join(', ');
+            return names || null;
+          });
+
+          const columns = [
+            'externalId', 'space', 'name', 'type', 'description',
+            'startTime', 'endTime',
+            'scheduledStartTime', 'scheduledEndTime',
+            'createdTime', 'lastUpdatedTime',
+          ];
+          const dataFrame: DataFrame = {
+            refId,
+            name: 'CogniteActivities',
+            fields: [
+              ...columns.slice(0, 5).map((col) => ({
+                name: col,
+                type: FieldType.string,
+                config: {},
+                values: converted.map((item) => (item as any)[col] ?? null),
+              })),
+              ...columns.slice(5).map((col) => ({
+                name: col,
+                type: FieldType.time,
+                config: {},
+                values: converted.map((item) => (item as any)[col] ?? null),
+              })),
+              // Dynamic resource column last
+              {
+                name: resourceColName,
+                type: FieldType.string,
+                config: {},
+                values: resourceColValues,
+              },
+            ],
+            length: converted.length,
+          };
+          return dataFrame;
+        } catch (e) {
+          handleError(e, refId);
+          return null;
+        }
+      })
+    );
+    return { data: results.filter(Boolean) };
   }
 
   async fetchActivityTargets(targets: CogniteQuery[], timeRange: Tuple<number>) {

--- a/src/datasources/ActivityDatasource.ts
+++ b/src/datasources/ActivityDatasource.ts
@@ -1,10 +1,24 @@
 import { DataQueryRequest, DataQueryResponse, DataFrame, FieldType, DataTopic } from '@grafana/data';
-import { CogniteQuery, CogniteActivityQuery, HttpMethod, Tuple } from '../types';
+import { CogniteQuery, CogniteActivityQuery, HttpMethod, Tuple, ActivitySortProp } from '../types';
 import { Connector } from '../connector';
 import { getRange } from '../utils';
 import { CogniteActivity } from '../types/dms';
 import { fetchActivitiesFromDMS, fetchActivitiesByAssets } from '../cdf/client';
 import { handleError } from '../appEventHandler';
+
+function inferFieldType(values: any[]): FieldType {
+  const first = values.find((v) => v !== null && v !== undefined);
+  if (first instanceof Date) {
+    return FieldType.time;
+  }
+  if (typeof first === 'number') {
+    return FieldType.number;
+  }
+  if (typeof first === 'boolean') {
+    return FieldType.boolean;
+  }
+  return FieldType.string;
+}
 
 // Convert activities to annotation format for overlay on charts
 const convertActivitiesToAnnotations = (
@@ -46,6 +60,27 @@ export const convertActivitiesDateFields = (activities: CogniteActivity[]) => {
       ...(scheduledStartTime && { scheduledStartTime: new Date(scheduledStartTime) }),
       ...(scheduledEndTime && { scheduledEndTime: new Date(scheduledEndTime) }),
     };
+  });
+};
+
+const sortActivities = (activities: CogniteActivity[], sort: ActivitySortProp[]): CogniteActivity[] => {
+  return [...activities].sort((a, b) => {
+    for (const { property, order } of sort) {
+      const aVal = (a as any)[property];
+      const bVal = (b as any)[property];
+      if (aVal === bVal) {
+        continue;
+      }
+      if (aVal === null || aVal === undefined) {
+        return 1;
+      }
+      if (bVal === null || bVal === undefined) {
+        return -1;
+      }
+      const cmp = aVal < bVal ? -1 : 1;
+      return order === 'desc' ? -cmp : cmp;
+    }
+    return 0;
   });
 };
 
@@ -95,13 +130,19 @@ export class ActivityDatasource {
   }
 
   async queryByAssets(options: DataQueryRequest<CogniteQuery>): Promise<DataQueryResponse> {
+    const [rangeStart, rangeEnd] = getRange(options.range);
     const results = await Promise.all(
       options.targets.map(async (target) => {
         const { refId, cogniteActivityTabQuery } = target;
         if (!cogniteActivityTabQuery?.assetInstances?.length) {
           return null;
         }
-        const { space, externalId, version, resourceType, assetInstances } = cogniteActivityTabQuery;
+        const {
+          space, externalId, version, resourceType, assetInstances,
+          activeOnly = true,
+          columns: selectedColumns = ['externalId', 'description', 'startTime', 'endTime'],
+          sort = [],
+        } = cogniteActivityTabQuery;
         const filterPropertyMap: Record<string, string> = {
           CogniteAsset: 'assets',
           CogniteEquipment: 'equipment',
@@ -109,12 +150,31 @@ export class ActivityDatasource {
         };
         const filterProperty = filterPropertyMap[resourceType] ?? 'assets';
         try {
-          const activities = await fetchActivitiesByAssets(
+          let activities = await fetchActivitiesByAssets(
             this.connector,
             { space, externalId, version },
             assetInstances,
             filterProperty
           );
+
+          // Active only: keep activities that overlap [rangeStart, rangeEnd]
+          if (activeOnly) {
+            activities = activities.filter((a) => {
+              const start = a.startTime ? new Date(a.startTime).getTime() : null;
+              const end = a.endTime ? new Date(a.endTime).getTime() : null;
+              if (start === null) {
+                return false;
+              }
+              // Activity starts before range ends, and either has no end or ends after range starts
+              return start <= rangeEnd && (end === null || end >= rangeStart);
+            });
+          }
+
+          // Client-side sort
+          if (sort.length > 0) {
+            activities = sortActivities(activities, sort);
+          }
+
           const converted = convertActivitiesDateFields(activities);
 
           // Build lookup: "space:externalId" -> display name (name only, fallback to externalId)
@@ -143,29 +203,20 @@ export class ActivityDatasource {
             return names || null;
           });
 
-          const columns = [
-            'externalId', 'space', 'name', 'type', 'description',
-            'startTime', 'endTime',
-            'scheduledStartTime', 'scheduledEndTime',
-            'createdTime', 'lastUpdatedTime',
-          ];
           const dataFrame: DataFrame = {
             refId,
             name: 'CogniteActivities',
             fields: [
-              ...columns.slice(0, 5).map((col) => ({
-                name: col,
-                type: FieldType.string,
-                config: {},
-                values: converted.map((item) => (item as any)[col] ?? null),
-              })),
-              ...columns.slice(5).map((col) => ({
-                name: col,
-                type: FieldType.time,
-                config: {},
-                values: converted.map((item) => (item as any)[col] ?? null),
-              })),
-              // Dynamic resource column last
+              ...selectedColumns.map((col) => {
+                const values = converted.map((item) => (item as any)[col] ?? null);
+                return {
+                  name: col,
+                  type: inferFieldType(values),
+                  config: {},
+                  values,
+                };
+              }),
+              // Dynamic resource column always last
               {
                 name: resourceColName,
                 type: FieldType.string,

--- a/src/queryEditorUtils.ts
+++ b/src/queryEditorUtils.ts
@@ -45,7 +45,12 @@ export function isTabDisabled(tab: Tabs, datasource: CogniteDatasource): boolean
   if (tab === Tabs.DataModellingV2) {
     return false;
   }
-  
+
+  // CogniteActivity tab - gated under the same CDM toggle as CogniteTimeSeriesSearch
+  if (tab === Tabs.CogniteActivity) {
+    return !datasource.connector.isCogniteTimeSeriesEnabled();
+  }
+
   return false;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ import CogniteDatasource from './datasource';
 export enum Tab {
   Timeseries = 'Timeseries',
   CogniteTimeSeriesSearch = 'CogniteTimeSeries',
+  CogniteActivity = 'CogniteActivity',
   Asset = 'Asset',
   Custom = 'Custom',
   Event = 'Event',
@@ -34,6 +35,7 @@ export const TabTitles = {
   [Tab.Relationships]: 'Relationships',
   [Tab.Templates]: 'Templates',
   [Tab.FlexibleDataModelling]: 'Data Models',
+  [Tab.CogniteActivity]: 'CogniteActivities',
 };
 const defaultFlexibleDataModellingQuery: FlexibleDataModellingQuery = {
   externalId: '',
@@ -176,6 +178,26 @@ export const defaultCogniteActivityQuery: CogniteActivityQuery = {
   useScheduledTime: false,
 };
 
+export type CogniteActivityResourceType = 'CogniteAsset' | 'CogniteEquipment' | 'CogniteTimeSeries';
+
+export interface CogniteActivityTabQuery {
+  space: string;
+  externalId: string;
+  version: string;
+  resourceType: CogniteActivityResourceType;
+  instanceSpace: string;
+  assetInstances: Array<{ space: string; externalId: string; name?: string }>;
+}
+
+export const defaultCogniteActivityTabQuery: CogniteActivityTabQuery = {
+  space: 'cdf_cdm',
+  externalId: 'CogniteActivity',
+  version: 'v1',
+  resourceType: 'CogniteAsset',
+  instanceSpace: '',
+  assetInstances: [],
+};
+
 export const defaultQuery: Partial<CogniteQuery> = {
   target: '',
   latestValue: false,
@@ -192,6 +214,7 @@ export const defaultQuery: Partial<CogniteQuery> = {
   flexibleDataModellingQuery: defaultFlexibleDataModellingQuery,
   cogniteTimeSeries: defaultCogniteTimeSeries,
   cogniteActivityQuery: defaultCogniteActivityQuery,
+  cogniteActivityTabQuery: defaultCogniteActivityTabQuery,
 };
 
 /**
@@ -324,6 +347,7 @@ export interface CogniteQueryBase extends DataQuery {
   flexibleDataModellingQuery: FlexibleDataModellingQuery;
   cogniteTimeSeries: CogniteTimeSeries;
   cogniteActivityQuery: CogniteActivityQuery;
+  cogniteActivityTabQuery: CogniteActivityTabQuery;
 }
 
 export type TemplateQuery = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -180,6 +180,11 @@ export const defaultCogniteActivityQuery: CogniteActivityQuery = {
 
 export type CogniteActivityResourceType = 'CogniteAsset' | 'CogniteEquipment' | 'CogniteTimeSeries';
 
+export interface ActivitySortProp {
+  property: string;
+  order: EventsOrderDirection;
+}
+
 export interface CogniteActivityTabQuery {
   space: string;
   externalId: string;
@@ -187,6 +192,9 @@ export interface CogniteActivityTabQuery {
   resourceType: CogniteActivityResourceType;
   instanceSpace: string;
   assetInstances: Array<{ space: string; externalId: string; name?: string }>;
+  activeOnly?: boolean;
+  columns?: string[];
+  sort?: ActivitySortProp[];
 }
 
 export const defaultCogniteActivityTabQuery: CogniteActivityTabQuery = {
@@ -196,6 +204,9 @@ export const defaultCogniteActivityTabQuery: CogniteActivityTabQuery = {
   resourceType: 'CogniteAsset',
   instanceSpace: '',
   assetInstances: [],
+  activeOnly: true,
+  columns: ['externalId', 'description', 'startTime', 'endTime'],
+  sort: [{ property: 'startTime', order: 'asc' }],
 };
 
 export const defaultQuery: Partial<CogniteQuery> = {

--- a/src/types/dms.ts
+++ b/src/types/dms.ts
@@ -109,6 +109,21 @@ export interface CogniteUnit {
   sourceReference?: string;
 }
 
+export interface DMSViewProperty {
+  type: { type: string; list?: boolean };
+  nullable?: boolean;
+  immutable?: boolean;
+  description?: string;
+  name?: string;
+}
+
+export interface DMSViewWithProperties {
+  space: string;
+  externalId: string;
+  version: string;
+  properties?: Record<string, DMSViewProperty>;
+}
+
 // Container inspect API types
 export interface InvolvedView {
   space: string;

--- a/src/types/dms.ts
+++ b/src/types/dms.ts
@@ -40,7 +40,9 @@ export interface DMSFilter {
     gt?: any;
     lte?: any;
     lt?: any;
-  };}
+  };
+  inSpace?: string;
+}
 
 export interface DMSSearchRequest {
   view: {

--- a/tests/queryEditor.spec.ts
+++ b/tests/queryEditor.spec.ts
@@ -691,10 +691,9 @@ test('"CogniteTimeSeries" enabling activities shows configuration options', asyn
   await tsOption.click();
   await page.waitForTimeout(1000);
 
-  // Enable activities
+  // Enable activities (use JS click to bypass scroll-container viewport restrictions in older Grafana)
   const activitiesToggle = editorRow.getByLabel('Activities').nth(1);
-  await activitiesToggle.scrollIntoViewIfNeeded();
-  await activitiesToggle.check({ force: true });
+  await activitiesToggle.evaluate((el) => (el as HTMLInputElement).click());
   await expect(activitiesToggle).toBeChecked();
 
   // Wait for activity configuration to appear
@@ -744,10 +743,9 @@ test('"CogniteTimeSeries" can select activity view', async ({ selectors, readPro
   await tsOption.click();
   await page.waitForTimeout(1000);
 
-  // Enable activities
+  // Enable activities (use JS click to bypass scroll-container viewport restrictions in older Grafana)
   const activitiesToggle = editorRow.getByLabel('Activities').nth(1);
-  await activitiesToggle.scrollIntoViewIfNeeded();
-  await activitiesToggle.check({ force: true });
+  await activitiesToggle.evaluate((el) => (el as HTMLInputElement).click());
   await page.waitForTimeout(1000);
 
   // Find the second View label (for activities, not timeseries)
@@ -811,10 +809,9 @@ test('"CogniteTimeSeries" scheduled time toggle works', async ({ selectors, read
   await tsOption.click();
   await page.waitForTimeout(1000);
 
-  // Enable activities
+  // Enable activities (use JS click to bypass scroll-container viewport restrictions in older Grafana)
   const activitiesToggle = editorRow.getByLabel('Activities').nth(1);
-  await activitiesToggle.scrollIntoViewIfNeeded();
-  await activitiesToggle.check({ force: true });
+  await activitiesToggle.evaluate((el) => (el as HTMLInputElement).click());
   await page.waitForTimeout(1000);
 
   // Find the Scheduled toggle

--- a/tests/queryEditor.spec.ts
+++ b/tests/queryEditor.spec.ts
@@ -693,6 +693,7 @@ test('"CogniteTimeSeries" enabling activities shows configuration options', asyn
 
   // Enable activities
   const activitiesToggle = editorRow.getByLabel('Activities').nth(1);
+  await activitiesToggle.scrollIntoViewIfNeeded();
   await activitiesToggle.check({ force: true });
   await expect(activitiesToggle).toBeChecked();
 
@@ -745,6 +746,7 @@ test('"CogniteTimeSeries" can select activity view', async ({ selectors, readPro
 
   // Enable activities
   const activitiesToggle = editorRow.getByLabel('Activities').nth(1);
+  await activitiesToggle.scrollIntoViewIfNeeded();
   await activitiesToggle.check({ force: true });
   await page.waitForTimeout(1000);
 
@@ -811,6 +813,7 @@ test('"CogniteTimeSeries" scheduled time toggle works', async ({ selectors, read
 
   // Enable activities
   const activitiesToggle = editorRow.getByLabel('Activities').nth(1);
+  await activitiesToggle.scrollIntoViewIfNeeded();
   await activitiesToggle.check({ force: true });
   await page.waitForTimeout(1000);
 

--- a/tests/weatherStationActivities.spec.ts
+++ b/tests/weatherStationActivities.spec.ts
@@ -21,7 +21,7 @@ test.describe('CogniteActivities dashboard', () => {
     // Grafana table uses role="cell" divs, not <td>
     await expect.poll(
       async () => {
-        const cells = await panel.locator.locator('[role="cell"]').allInnerTexts();
+        const cells = await panel.locator.locator('[role="cell"],[role="gridcell"]').allInnerTexts();
         return cells.some((c) => c.startsWith('weather-activity-'));
       },
       { timeout: 30000 }
@@ -45,7 +45,7 @@ test.describe('CogniteActivities dashboard', () => {
 
     await expect.poll(
       async () => {
-        const cells = await panel.locator.locator('[role="cell"]').allInnerTexts();
+        const cells = await panel.locator.locator('[role="cell"],[role="gridcell"]').allInnerTexts();
         return cells.some((c) => c.startsWith('weather-activity-'));
       },
       { timeout: 30000 }
@@ -67,7 +67,7 @@ test.describe('CogniteActivities dashboard', () => {
 
     await expect.poll(
       async () => {
-        const cells = await panel.locator.locator('[role="cell"]').allInnerTexts();
+        const cells = await panel.locator.locator('[role="cell"],[role="gridcell"]').allInnerTexts();
         return cells.some((c) => c.startsWith('weather-activity-'));
       },
       { timeout: 30000 }

--- a/tests/weatherStationActivities.spec.ts
+++ b/tests/weatherStationActivities.spec.ts
@@ -1,0 +1,79 @@
+import { expect, PluginFixture, PluginOptions } from '@grafana/plugin-e2e';
+import { readProvisionedDataSource } from '../playwright/fixtures/readProvisionedDataSource';
+import { test as patchedBase } from '../playwright/fixtures/patchNavigationStrategy';
+
+const test = patchedBase.extend<PluginFixture, PluginOptions>({ readProvisionedDataSource });
+
+test.describe('CogniteActivities dashboard', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1920, height: 1080 });
+  });
+
+  test('Asset activities panel renders rows', async ({ gotoDashboardPage, readProvisionedDashboard, page }) => {
+    test.setTimeout(60000);
+    const dashboard = await readProvisionedDashboard({ fileName: 'weather-station-activities.json' });
+    const dashboardPage = await gotoDashboardPage(dashboard);
+
+    await page.waitForSelector('.react-grid-layout', { timeout: 30000 });
+
+    const panel = await dashboardPage.getPanelByTitle('Activities - Asset (Fornebu Weather Station)');
+
+    // Grafana table uses role="cell" divs, not <td>
+    await expect.poll(
+      async () => {
+        const cells = await panel.locator.locator('[role="cell"]').allInnerTexts();
+        return cells.some((c) => c.startsWith('weather-activity-'));
+      },
+      { timeout: 30000 }
+    ).toBe(true);
+
+    // Verify expected columns are present in the header
+    await expect(panel.locator.locator('[role="columnheader"]').filter({ hasText: 'externalId' })).toBeVisible();
+    await expect(panel.locator.locator('[role="columnheader"]').filter({ hasText: 'name' })).toBeVisible();
+    await expect(panel.locator.locator('[role="columnheader"]').filter({ hasText: 'asset' })).toBeVisible();
+  });
+
+  test('Equipment activities panel renders rows', async ({ gotoDashboardPage, readProvisionedDashboard, page }) => {
+    test.setTimeout(60000);
+    const dashboard = await readProvisionedDashboard({ fileName: 'weather-station-activities.json' });
+    const dashboardPage = await gotoDashboardPage(dashboard);
+
+    await page.waitForSelector('.react-grid-layout', { timeout: 30000 });
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight / 2));
+
+    const panel = await dashboardPage.getPanelByTitle('Activities - Equipment (Lysaker Visibility Sensor)');
+
+    await expect.poll(
+      async () => {
+        const cells = await panel.locator.locator('[role="cell"]').allInnerTexts();
+        return cells.some((c) => c.startsWith('weather-activity-'));
+      },
+      { timeout: 30000 }
+    ).toBe(true);
+
+    await expect(panel.locator.locator('[role="columnheader"]').filter({ hasText: 'externalId' })).toBeVisible();
+    await expect(panel.locator.locator('[role="columnheader"]').filter({ hasText: 'equipment' })).toBeVisible();
+  });
+
+  test('TimeSeries activities panel renders rows', async ({ gotoDashboardPage, readProvisionedDashboard, page }) => {
+    test.setTimeout(60000);
+    const dashboard = await readProvisionedDashboard({ fileName: 'weather-station-activities.json' });
+    const dashboardPage = await gotoDashboardPage(dashboard);
+
+    await page.waitForSelector('.react-grid-layout', { timeout: 30000 });
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+    const panel = await dashboardPage.getPanelByTitle('Activities - TimeSeries (59.9139-10.7522-current.temp)');
+
+    await expect.poll(
+      async () => {
+        const cells = await panel.locator.locator('[role="cell"]').allInnerTexts();
+        return cells.some((c) => c.startsWith('weather-activity-'));
+      },
+      { timeout: 30000 }
+    ).toBe(true);
+
+    await expect(panel.locator.locator('[role="columnheader"]').filter({ hasText: 'externalId' })).toBeVisible();
+    await expect(panel.locator.locator('[role="columnheader"]').filter({ hasText: 'timeSeries' })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a new standalone **CogniteActivities** tab to the query editor, placed after CogniteTimeSeries
- Users can select CogniteAsset, CogniteEquipment, or CogniteTimeSeries as the resource type and pick one or more instances; all related `CogniteActivity` records are returned as a table panel
- Uses the same DMS REST API pattern as the existing activity annotation overlay (no GraphQL)

## Changes

- `cogniteActivityTab.tsx` — new React component with Activity View, Resource Type, Instance View, Space, and Instance(s) selectors; auto-loads views via container inspect; searches instances via DMS search API
- `cdf/client.ts` — `fetchCogniteContainerViews` helper, `fetchCogniteEquipmentViews`, `fetchCogniteTimeSeriesViews`, `fetchActivitiesByAssets`
- `ActivityDatasource.ts` — `queryByAssets` method returning a table DataFrame with columns: `externalId`, `space`, `name`, `type`, `description`, time columns, resource name column (last)
- `datasource.ts` — routing for new tab (filter, group, dispatch)
- `queryEditorUtils.ts` — `isTabDisabled` case gated on CDM toggle
- `types.ts` / `types/dms.ts` — `CogniteActivityTabQuery`, `CogniteActivityResourceType`, `inSpace` filter
- `weather-station-activities.json` — provisioned test dashboard with Asset, Equipment, and TimeSeries panels

## Test plan

- [ ] Unit tests: `ActivityDatasource.spec.ts` — 13 tests covering `convertActivitiesDateFields` and `queryByAssets` (column order, name lookup, FieldType, error handling)
- [ ] E2e tests: `weatherStationActivities.spec.ts` — 3 tests verifying each panel renders activity rows and correct column headers
- [ ] `yarn build` — no TypeScript errors
- [ ] Manual: open CogniteActivities tab, select resource type, search instances, verify table renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)