### PR TITLE
Small improvements

### DIFF
--- a/src/__tests__/configEditorUtils.test.ts
+++ b/src/__tests__/configEditorUtils.test.ts
@@ -3,7 +3,9 @@ import {
   boolValueHandler, 
   secretValueHandler, 
   resetSecretHandler,
-  masterToggleHandler
+  masterToggleHandler,
+  sanitizeHostname,
+  hostnameValueHandler
 } from '../configEditorUtils';
 import { FEATURE_DEFAULTS } from '../featureDefaults';
 
@@ -56,6 +58,43 @@ describe('ConfigEditor Utility Functions', () => {
 
       expect(mockOnJsonDataChange).toHaveBeenCalledWith({
         oauthClientId: 'client-id_123!@#',
+      });
+    });
+  });
+
+  describe('sanitizeHostname', () => {
+    it('strips https:// scheme', () => {
+      expect(sanitizeHostname('https://bluefield.cognitedata.com')).toBe('bluefield.cognitedata.com');
+    });
+
+    it('strips http:// scheme and trailing slash', () => {
+      expect(sanitizeHostname('http://api.cognitedata.com/')).toBe('api.cognitedata.com');
+    });
+
+    it('trims whitespace', () => {
+      expect(sanitizeHostname('  api.cognitedata.com  ')).toBe('api.cognitedata.com');
+    });
+
+    it('leaves a bare hostname unchanged', () => {
+      expect(sanitizeHostname('bluefield.cognitedata.com')).toBe('bluefield.cognitedata.com');
+    });
+
+    it('is case-insensitive on the scheme', () => {
+      expect(sanitizeHostname('HTTPS://api.cognitedata.com')).toBe('api.cognitedata.com');
+    });
+  });
+
+  describe('hostnameValueHandler', () => {
+    it('persists the sanitized hostname', () => {
+      const handler = hostnameValueHandler('cogniteApiUrl', mockOnJsonDataChange);
+      const mockEvent = {
+        target: { value: 'https://bluefield.cognitedata.com/' }
+      } as React.ChangeEvent<HTMLInputElement>;
+
+      handler(mockEvent);
+
+      expect(mockOnJsonDataChange).toHaveBeenCalledWith({
+        cogniteApiUrl: 'bluefield.cognitedata.com',
       });
     });
   });

--- a/src/__tests__/connector.featureFlags.test.ts
+++ b/src/__tests__/connector.featureFlags.test.ts
@@ -17,6 +17,7 @@ describe("Connector Feature Flags", () => {
         true, // enableCoreDataModelFeatures
         true, // enableLegacyDataModelFeatures
         true, // enableCogniteTimeSeries
+        true, // enableCogniteActivities
         true, // enableFlexibleDataModelling
         true,
         true,
@@ -39,6 +40,7 @@ describe("Connector Feature Flags", () => {
         false, // enableCoreDataModelFeatures - DISABLED
         true, // enableLegacyDataModelFeatures
         true, // enableCogniteTimeSeries
+        true, // enableCogniteActivities
         true, // enableFlexibleDataModelling
         true,
         true,
@@ -61,6 +63,7 @@ describe("Connector Feature Flags", () => {
         true, // enableCoreDataModelFeatures
         true, // enableLegacyDataModelFeatures
         false, // enableCogniteTimeSeries - DISABLED
+        false, // enableCogniteActivities
         true, // enableFlexibleDataModelling
         true,
         true,
@@ -83,6 +86,7 @@ describe("Connector Feature Flags", () => {
         false, // enableCoreDataModelFeatures - DISABLED
         true, // enableLegacyDataModelFeatures
         false, // enableCogniteTimeSeries - DISABLED
+        false, // enableCogniteActivities
         true, // enableFlexibleDataModelling
         true,
         true,
@@ -96,6 +100,96 @@ describe("Connector Feature Flags", () => {
       expect(connectorBothDisabled.isCogniteTimeSeriesEnabled()).toBe(false);
     });
 
+    it("should enable CogniteActivities only when both master and feature flags are enabled", () => {
+      const connectorEnabled = new Connector(
+        project,
+        protocol,
+        fetcher,
+        false,
+        false,
+        true, // enableCoreDataModelFeatures
+        true, // enableLegacyDataModelFeatures
+        true, // enableCogniteTimeSeries
+        true, // enableCogniteActivities
+        true, // enableFlexibleDataModelling
+        true,
+        true,
+        true,
+        true,
+        true, // legacy features (5 total)
+        false,
+        false,
+        false, // deprecated features (3 total)
+      );
+      expect(connectorEnabled.isCogniteActivitiesEnabled()).toBe(true);
+
+      const connectorMasterDisabled = new Connector(
+        project,
+        protocol,
+        fetcher,
+        false,
+        false,
+        false, // enableCoreDataModelFeatures - DISABLED
+        true, // enableLegacyDataModelFeatures
+        true, // enableCogniteTimeSeries
+        true, // enableCogniteActivities
+        true, // enableFlexibleDataModelling
+        true,
+        true,
+        true,
+        true,
+        true, // legacy features (5 total)
+        false,
+        false,
+        false, // deprecated features (3 total)
+      );
+      expect(connectorMasterDisabled.isCogniteActivitiesEnabled()).toBe(false);
+
+      const connectorFeatureDisabled = new Connector(
+        project,
+        protocol,
+        fetcher,
+        false,
+        false,
+        true, // enableCoreDataModelFeatures
+        true, // enableLegacyDataModelFeatures
+        true, // enableCogniteTimeSeries
+        false, // enableCogniteActivities - DISABLED
+        true, // enableFlexibleDataModelling
+        true,
+        true,
+        true,
+        true,
+        true, // legacy features (5 total)
+        false,
+        false,
+        false, // deprecated features (3 total)
+      );
+      expect(connectorFeatureDisabled.isCogniteActivitiesEnabled()).toBe(false);
+
+      const connectorBothDisabled = new Connector(
+        project,
+        protocol,
+        fetcher,
+        false,
+        false,
+        false, // enableCoreDataModelFeatures - DISABLED
+        true, // enableLegacyDataModelFeatures
+        false, // enableCogniteTimeSeries
+        false, // enableCogniteActivities - DISABLED
+        true, // enableFlexibleDataModelling
+        true,
+        true,
+        true,
+        true,
+        true, // legacy features (5 total)
+        false,
+        false,
+        false, // deprecated features (3 total)
+      );
+      expect(connectorBothDisabled.isCogniteActivitiesEnabled()).toBe(false);
+    });
+
     it("should enable FlexibleDataModelling only when both core master and feature flags are enabled", () => {
       // Both enabled
       const connectorEnabled = new Connector(
@@ -107,6 +201,7 @@ describe("Connector Feature Flags", () => {
         true, // enableCoreDataModelFeatures
         true, // enableLegacyDataModelFeatures
         false, // enableCogniteTimeSeries
+        false, // enableCogniteActivities
         true, // enableFlexibleDataModelling
         true,
         true,
@@ -129,6 +224,7 @@ describe("Connector Feature Flags", () => {
         false, // enableCoreDataModelFeatures - DISABLED
         true, // enableLegacyDataModelFeatures
         false, // enableCogniteTimeSeries
+        false, // enableCogniteActivities
         true, // enableFlexibleDataModelling
         true,
         true,
@@ -153,6 +249,7 @@ describe("Connector Feature Flags", () => {
         true, // enableCoreDataModelFeatures
         true, // enableLegacyDataModelFeatures
         false, // enableCogniteTimeSeries
+        false, // enableCogniteActivities
         false, // enableFlexibleDataModelling - DISABLED
         true,
         true,
@@ -181,6 +278,7 @@ describe("Connector Feature Flags", () => {
         false, // enableCoreDataModelFeatures
         true, // enableLegacyDataModelFeatures
         false, // enableCogniteTimeSeries
+        false, // enableCogniteActivities
         false, // enableFlexibleDataModelling
         true,
         true,
@@ -203,6 +301,7 @@ describe("Connector Feature Flags", () => {
         false, // enableCoreDataModelFeatures
         false, // enableLegacyDataModelFeatures - DISABLED
         false, // enableCogniteTimeSeries
+        false, // enableCogniteActivities
         false, // enableFlexibleDataModelling
         true,
         true,
@@ -225,6 +324,7 @@ describe("Connector Feature Flags", () => {
         false, // enableCoreDataModelFeatures
         true, // enableLegacyDataModelFeatures
         false, // enableCogniteTimeSeries
+        false, // enableCogniteActivities
         false, // enableFlexibleDataModelling
         false,
         true,
@@ -249,6 +349,7 @@ describe("Connector Feature Flags", () => {
         false, // enableCoreDataModelFeatures
         true, // enableLegacyDataModelFeatures
         false, // enableCogniteTimeSeries
+        false, // enableCogniteActivities
         false, // enableFlexibleDataModelling
         true,
         true,
@@ -271,6 +372,7 @@ describe("Connector Feature Flags", () => {
         false, // enableCoreDataModelFeatures
         false, // enableLegacyDataModelFeatures - DISABLED
         false, // enableCogniteTimeSeries
+        false, // enableCogniteActivities
         false, // enableFlexibleDataModelling
         true,
         true,
@@ -295,6 +397,7 @@ describe("Connector Feature Flags", () => {
         false, // enableCoreDataModelFeatures
         true, // enableLegacyDataModelFeatures
         false, // enableCogniteTimeSeries
+        false, // enableCogniteActivities
         false, // enableFlexibleDataModelling
         true,
         true,
@@ -320,6 +423,7 @@ describe("Connector Feature Flags", () => {
         false, // enableCoreDataModelFeatures
         true, // enableLegacyDataModelFeatures
         false, // enableCogniteTimeSeries
+        false, // enableCogniteActivities
         false, // enableFlexibleDataModelling
         true,
         true,
@@ -348,6 +452,7 @@ describe("Connector Feature Flags", () => {
         false, // enableCoreDataModelFeatures
         false, // enableLegacyDataModelFeatures - DISABLED
         false, // enableCogniteTimeSeries
+        false, // enableCogniteActivities
         false, // enableFlexibleDataModelling
         true,
         true,
@@ -378,6 +483,7 @@ describe("Connector Feature Flags", () => {
         false, // enableCoreDataModelFeatures - disabled
         false, // enableLegacyDataModelFeatures - disabled
         false, // enableCogniteTimeSeries
+        false, // enableCogniteActivities
         false, // enableFlexibleDataModelling
         false,
         false,
@@ -405,6 +511,7 @@ describe("Connector Feature Flags", () => {
         true, // enableCoreDataModelFeatures
         true, // enableLegacyDataModelFeatures
         false, // enableCogniteTimeSeries
+        false, // enableCogniteActivities
         false, // enableFlexibleDataModelling
         true,
         true,
@@ -433,6 +540,7 @@ describe("Connector Feature Flags", () => {
         true, // enableCoreDataModelFeatures - enabled
         false, // enableLegacyDataModelFeatures - disabled
         true, // enableCogniteTimeSeries
+        true, // enableCogniteActivities
         true, // enableFlexibleDataModelling
         true,
         true,

--- a/src/__tests__/connector.test.ts
+++ b/src/__tests__/connector.test.ts
@@ -24,7 +24,7 @@ describe('connector', () => {
     const reqBase = { url, method };
 
     beforeEach(() => {
-      connector = new Connector(project, protocol, fetcher, false, false, true, true, true, true, true, true, true, true, true, true, true, true);
+      connector = new Connector(project, protocol, fetcher, false, false, true, true, true, true, true, true, true, true, true, true, true);
     });
 
     it('should not chunk under the limit', async () => {
@@ -83,7 +83,7 @@ describe('connector', () => {
     };
 
     beforeEach(() => {
-      connector = new Connector(project, protocol, fetcher, false, false, true, true, true, true, true, true, true, true, true, true, true, true);
+      connector = new Connector(project, protocol, fetcher, false, false, true, true, true, true, true, true, true, true, true, true, true);
     });
 
     it('returns all 10k elements', async () => {
@@ -123,7 +123,7 @@ describe('connector', () => {
     const response = async () => ({ data: { items: [1] } });
 
     beforeEach(() => {
-      connector = new Connector(project, protocol, fetcher, false, false, true, true, true, true, true, true, true, true, true, true, true, true);
+      connector = new Connector(project, protocol, fetcher, false, false, true, true, true, true, true, true, true, true, true, true, true);
       jest.useFakeTimers();
     });
 
@@ -189,7 +189,7 @@ describe('connector', () => {
     const request = { path: '' };
 
     beforeEach(() => {
-      connector = new Connector(project, protocol, fetcher, true, false, true, true, true, true, true, true, true, true, true, true, true, true);
+      connector = new Connector(project, protocol, fetcher, true, false, true, true, true, true, true, true, true, true, true, true, true);
     });
 
     it('uses cdf-oauth route when oauthPassThru=true', async () => {
@@ -206,7 +206,7 @@ describe('connector', () => {
     const request = { path: '' };
 
     beforeEach(() => {
-      connector = new Connector(project, protocol, fetcher, false, true, true, true, true, true, true, true, true, true, true, true, true, true);
+      connector = new Connector(project, protocol, fetcher, false, true, true, true, true, true, true, true, true, true, true, true, true);
     });
 
     it('uses cdf-cc-oauth route when oauthClientCreds=true', async () => {

--- a/src/__tests__/queryEditorUtils.test.ts
+++ b/src/__tests__/queryEditorUtils.test.ts
@@ -16,21 +16,34 @@ describe('QueryEditor Utility Functions', () => {
   describe('isTabDisabled', () => {
     it('should correctly identify disabled Core Data Model tabs', () => {
       mockDataSource.connector.isCogniteTimeSeriesEnabled = jest.fn().mockReturnValue(false);
+      mockDataSource.connector.isCogniteActivitiesEnabled = jest.fn().mockReturnValue(false);
       mockDataSource.connector.isFlexibleDataModellingEnabled = jest.fn().mockReturnValue(false);
 
       expect(isTabDisabled(Tabs.CogniteTimeSeriesSearch, mockDataSource)).toBe(true);
+      expect(isTabDisabled(Tabs.CogniteActivity, mockDataSource)).toBe(true);
       expect(isTabDisabled(Tabs.FlexibleDataModelling, mockDataSource)).toBe(true);
 
       expect(mockDataSource.connector.isCogniteTimeSeriesEnabled).toHaveBeenCalled();
+      expect(mockDataSource.connector.isCogniteActivitiesEnabled).toHaveBeenCalled();
       expect(mockDataSource.connector.isFlexibleDataModellingEnabled).toHaveBeenCalled();
     });
 
     it('should correctly identify enabled Core Data Model tabs', () => {
       mockDataSource.connector.isCogniteTimeSeriesEnabled = jest.fn().mockReturnValue(true);
+      mockDataSource.connector.isCogniteActivitiesEnabled = jest.fn().mockReturnValue(true);
       mockDataSource.connector.isFlexibleDataModellingEnabled = jest.fn().mockReturnValue(true);
 
       expect(isTabDisabled(Tabs.CogniteTimeSeriesSearch, mockDataSource)).toBe(false);
+      expect(isTabDisabled(Tabs.CogniteActivity, mockDataSource)).toBe(false);
       expect(isTabDisabled(Tabs.FlexibleDataModelling, mockDataSource)).toBe(false);
+    });
+
+    it('should gate Activities tab on enableCogniteActivities independent of Time Series', () => {
+      mockDataSource.connector.isCogniteTimeSeriesEnabled = jest.fn().mockReturnValue(true);
+      mockDataSource.connector.isCogniteActivitiesEnabled = jest.fn().mockReturnValue(false);
+
+      expect(isTabDisabled(Tabs.CogniteTimeSeriesSearch, mockDataSource)).toBe(false);
+      expect(isTabDisabled(Tabs.CogniteActivity, mockDataSource)).toBe(true);
     });
 
     it('should correctly identify disabled Legacy Data Model tabs', () => {
@@ -94,9 +107,11 @@ describe('QueryEditor Utility Functions', () => {
 
     it('should handle Core Data Model tabs backward compatibility', () => {
       mockDataSource.connector.isCogniteTimeSeriesEnabled = jest.fn().mockReturnValue(false);
+      mockDataSource.connector.isCogniteActivitiesEnabled = jest.fn().mockReturnValue(false);
 
       // Disabled but selected - should not be hidden
       expect(isTabHidden(Tabs.CogniteTimeSeriesSearch, Tabs.CogniteTimeSeriesSearch, mockDataSource)).toBe(false);
+      expect(isTabHidden(Tabs.CogniteActivity, Tabs.CogniteActivity, mockDataSource)).toBe(false);
       
       // Disabled and not selected - should be hidden
       expect(isTabHidden(Tabs.CogniteTimeSeriesSearch, Tabs.Asset, mockDataSource)).toBe(true);
@@ -108,6 +123,7 @@ describe('QueryEditor Utility Functions', () => {
       // Disable first two tabs, enable Asset tab (third in order)
       mockDataSource.connector.isTimeseriesSearchEnabled = jest.fn().mockReturnValue(false);
       mockDataSource.connector.isCogniteTimeSeriesEnabled = jest.fn().mockReturnValue(false);
+      mockDataSource.connector.isCogniteActivitiesEnabled = jest.fn().mockReturnValue(false);
       mockDataSource.connector.isTimeseriesFromAssetEnabled = jest.fn().mockReturnValue(true);
       // Ensure other tabs are also properly mocked
       mockDataSource.connector.isTimeseriesCustomQueryEnabled = jest.fn().mockReturnValue(false);
@@ -136,6 +152,7 @@ describe('QueryEditor Utility Functions', () => {
       // Disable all tabs
       mockDataSource.connector.isTimeseriesSearchEnabled = jest.fn().mockReturnValue(false);
       mockDataSource.connector.isCogniteTimeSeriesEnabled = jest.fn().mockReturnValue(false);
+      mockDataSource.connector.isCogniteActivitiesEnabled = jest.fn().mockReturnValue(false);
       mockDataSource.connector.isTimeseriesFromAssetEnabled = jest.fn().mockReturnValue(false);
       mockDataSource.connector.isTimeseriesCustomQueryEnabled = jest.fn().mockReturnValue(false);
       mockDataSource.connector.isEventsEnabled = jest.fn().mockReturnValue(false);
@@ -153,6 +170,7 @@ describe('QueryEditor Utility Functions', () => {
       // Disable first few tabs, enable Events tab
       mockDataSource.connector.isTimeseriesSearchEnabled = jest.fn().mockReturnValue(false);
       mockDataSource.connector.isCogniteTimeSeriesEnabled = jest.fn().mockReturnValue(false);
+      mockDataSource.connector.isCogniteActivitiesEnabled = jest.fn().mockReturnValue(false);
       mockDataSource.connector.isTimeseriesFromAssetEnabled = jest.fn().mockReturnValue(false);
       mockDataSource.connector.isTimeseriesCustomQueryEnabled = jest.fn().mockReturnValue(false);
       mockDataSource.connector.isEventsEnabled = jest.fn().mockReturnValue(true);
@@ -178,6 +196,7 @@ describe('QueryEditor Utility Functions', () => {
     it('should switch to first available tab when current tab is disabled', () => {
       mockDataSource.connector.isTimeseriesSearchEnabled = jest.fn().mockReturnValue(false);
       mockDataSource.connector.isCogniteTimeSeriesEnabled = jest.fn().mockReturnValue(true);
+      mockDataSource.connector.isCogniteActivitiesEnabled = jest.fn().mockReturnValue(false);
 
       // Tab is disabled - should switch to first available tab
       const result = getActiveTab(Tabs.Timeseries, mockDataSource);
@@ -205,6 +224,7 @@ describe('QueryEditor Utility Functions', () => {
       // Disable first few tabs, enable Events
       mockDataSource.connector.isTimeseriesSearchEnabled = jest.fn().mockReturnValue(false);
       mockDataSource.connector.isCogniteTimeSeriesEnabled = jest.fn().mockReturnValue(false);
+      mockDataSource.connector.isCogniteActivitiesEnabled = jest.fn().mockReturnValue(false);
       mockDataSource.connector.isTimeseriesFromAssetEnabled = jest.fn().mockReturnValue(false);
       mockDataSource.connector.isTimeseriesCustomQueryEnabled = jest.fn().mockReturnValue(false);
       mockDataSource.connector.isEventsEnabled = jest.fn().mockReturnValue(true);

--- a/src/components/cogniteActivityTab.tsx
+++ b/src/components/cogniteActivityTab.tsx
@@ -513,6 +513,7 @@ export const CogniteActivityTab: React.FC<CogniteActivityTabProps> = ({
           <AsyncMultiSelect
             key={`${selectedInstanceView?.space}:${selectedInstanceView?.externalId}:${selectedInstanceView?.version}:${instanceSpace}`}
             loadOptions={searchInstances}
+            defaultOptions
             value={selectedInstanceValues}
             onChange={handleInstancesChange}
             placeholder={`Search ${resourceType} by name...`}

--- a/src/components/cogniteTimeSeriesSearchTab.tsx
+++ b/src/components/cogniteTimeSeriesSearchTab.tsx
@@ -77,7 +77,7 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
   }, [connector]);
 
   const searchTimeseries = useCallback(async (searchQuery: string) => {
-    if (!searchQuery.trim() || !cogniteTimeSeries.space || !cogniteTimeSeries.externalId) {
+    if (!cogniteTimeSeries.space || !cogniteTimeSeries.externalId) {
       return [];
     }
 
@@ -89,7 +89,7 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
           externalId: cogniteTimeSeries.externalId,
           version: cogniteTimeSeries.version,
         },
-        query: searchQuery,
+        query: searchQuery.trim(),
         filter: {
           not: {
             equals: {
@@ -361,6 +361,7 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
             <AsyncSelect
               key={`${cogniteTimeSeries.space}-${cogniteTimeSeries.externalId}-${cogniteTimeSeries.version}`}
               loadOptions={searchTimeseries}
+              defaultOptions
               value={getCurrentTimeseriesValue()}
               onChange={handleTimeseriesSelection}
               placeholder="Search timeseries by name/description"

--- a/src/components/configEditor.tsx
+++ b/src/components/configEditor.tsx
@@ -18,6 +18,7 @@ import { CogniteDataSourceOptions, CogniteSecureJsonData } from "../types";
 import { FEATURE_DEFAULTS, FeatureKey } from "../featureDefaults";
 import {
   boolValueHandler,
+  hostnameValueHandler,
   resetSecretHandler,
   secretValueHandler,
   stringValueHandler,
@@ -30,7 +31,7 @@ type ConfigEditorProps = DataSourcePluginOptionsEditorProps<
 >;
 
 const baseUrlTooltip =
-  `The base URL for your CDF cluster (e.g. api.cognitedata.com, westeurope-1.cognitedata.com, az-eastus-1.cognitedata.com). Keep the default if your project is on the api.cognitedata.com cluster. See docs.cognite.com/cdf/admin/clusters_regions for a full list.`;
+  `The base URL for your CDF cluster (e.g. api.cognitedata.com, westeurope-1.cognitedata.com, az-eastus-1.cognitedata.com). Keep the default if your project is on the api.cognitedata.com cluster. See docs.cognite.com/cdf/admin/clusters_regions for a full list. The https:// scheme is optional and will be stripped automatically.`;
 
 const oAuthPassThruTooltip =
   `Forward the user's OAuth token from Grafana to CDF. Requires Grafana to authenticate with the same identity provider (e.g. Microsoft Entra ID) as the CDF project. Available on Grafana Enterprise, self-hosted, and Cloud Pro.`;
@@ -52,6 +53,9 @@ const oAuthScopeTooltip =
 
 const enableCogniteTimeSeriesTooltip =
   `Enable the Time Series tab to browse and select time series instances from the Core Data Model (CogniteTimeSeries type).`;
+
+const enableCogniteActivitiesTooltip =
+  `Enable the Activities tab to query CogniteActivity instances from the Core Data Model.`;
 
 const enableTimeseriesSearchTooltip =
   `Enable the Time series search tab to find and select time series by name, description, or metadata.`;
@@ -88,6 +92,7 @@ const enableLegacyDataModelFeaturesTooltip =
 
 const CORE_DEPENDENT_KEYS: FeatureKey[] = [
   "enableCogniteTimeSeries",
+  "enableCogniteActivities",
   "enableFlexibleDataModelling",
 ];
 const LEGACY_DEPENDENT_KEYS: FeatureKey[] = [
@@ -124,6 +129,7 @@ export function ConfigEditor(props: ConfigEditorProps) {
     enableLegacyDataModelFeatures =
       FEATURE_DEFAULTS.enableLegacyDataModelFeatures,
     enableCogniteTimeSeries = FEATURE_DEFAULTS.enableCogniteTimeSeries,
+    enableCogniteActivities = FEATURE_DEFAULTS.enableCogniteActivities,
     enableTimeseriesSearch = FEATURE_DEFAULTS.enableTimeseriesSearch,
     enableTimeseriesFromAsset = FEATURE_DEFAULTS.enableTimeseriesFromAsset,
     enableTimeseriesCustomQuery = FEATURE_DEFAULTS.enableTimeseriesCustomQuery,
@@ -233,7 +239,7 @@ export function ConfigEditor(props: ConfigEditorProps) {
                   value={cogniteApiUrl}
                   width={INPUT_WIDTH}
                   placeholder={clusterUrl ?? "api.cognitedata.com"}
-                  onChange={onJsonStringValueChange("cogniteApiUrl")}
+                  onChange={hostnameValueHandler("cogniteApiUrl", onJsonDataChange)}
                 />
               </InlineField>
             </div>
@@ -405,6 +411,21 @@ export function ConfigEditor(props: ConfigEditorProps) {
                       label="Time Series"
                       value={enableCogniteTimeSeries}
                       onChange={onJsonBoolValueChange("enableCogniteTimeSeries")}
+                    />
+                  </InlineFieldRow>
+                  <InlineFieldRow style={{ marginBottom: "4px" }}>
+                    <InlineFormLabel
+                      htmlFor="enable-cognite-activities"
+                      tooltip={enableCogniteActivitiesTooltip}
+                      width={FEATURE_LABEL_WIDTH}
+                    >
+                      Activities
+                    </InlineFormLabel>
+                    <InlineSwitch
+                      id="enable-cognite-activities"
+                      label="Activities"
+                      value={enableCogniteActivities}
+                      onChange={onJsonBoolValueChange("enableCogniteActivities")}
                     />
                   </InlineFieldRow>
                   <InlineFieldRow style={{ marginBottom: "4px" }}>

--- a/src/configEditorUtils.ts
+++ b/src/configEditorUtils.ts
@@ -13,6 +13,25 @@ export const stringValueHandler = (
   onJsonDataChange({ [key]: event.target.value });
 
 /**
+ * Strip an optional http(s):// scheme and trailing slashes from a hostname-like
+ * value. The plugin route in plugin.json hardcodes the https:// scheme, so the
+ * stored value must be a bare hostname.
+ */
+export const sanitizeHostname = (value: string): string =>
+  value.trim().replace(/^https?:\/\//i, "").replace(/\/+$/, "");
+
+/**
+ * Handler for hostname value changes - strips any scheme/trailing slashes so
+ * pasted full URLs (e.g. https://bluefield.cognitedata.com) still work.
+ */
+export const hostnameValueHandler = (
+  key: keyof CogniteDataSourceOptions,
+  onJsonDataChange: (patch: Partial<CogniteDataSourceOptions>) => void,
+) =>
+(event: ChangeEvent<HTMLInputElement>) =>
+  onJsonDataChange({ [key]: sanitizeHostname(event.target.value) });
+
+/**
  * Handler for boolean value changes in jsonData
  */
 export const boolValueHandler = (

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -31,6 +31,7 @@ export class Connector {
     private enableLegacyDataModelFeatures?: boolean,
     // Core data model (CDM) features
     private enableCogniteTimeSeries?: boolean,
+    private enableCogniteActivities?: boolean,
     private enableFlexibleDataModelling?: boolean,
     // Legacy data model features
     private enableTimeseriesSearch?: boolean,
@@ -156,6 +157,10 @@ export class Connector {
   // Core data model (CDM) features
   isCogniteTimeSeriesEnabled() {
     return this.enableCoreDataModelFeatures && this.enableCogniteTimeSeries;
+  }
+
+  isCogniteActivitiesEnabled() {
+    return this.enableCoreDataModelFeatures && this.enableCogniteActivities;
   }
 
   isFlexibleDataModellingEnabled() {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -97,6 +97,7 @@ export default class CogniteDatasource extends DataSourceWithBackend<
         FEATURE_DEFAULTS.enableLegacyDataModelFeatures,
       // Core data model (CDM) features
       enableCogniteTimeSeries = FEATURE_DEFAULTS.enableCogniteTimeSeries,
+      enableCogniteActivities = FEATURE_DEFAULTS.enableCogniteActivities,
       // Legacy data model features
       enableTimeseriesSearch = FEATURE_DEFAULTS.enableTimeseriesSearch,
       enableTimeseriesFromAsset = FEATURE_DEFAULTS.enableTimeseriesFromAsset,
@@ -127,6 +128,7 @@ export default class CogniteDatasource extends DataSourceWithBackend<
       enableLegacyDataModelFeatures,
       // Core data model (CDM) features
       enableCogniteTimeSeries,
+      enableCogniteActivities,
       enableFlexibleDataModelling,
       // Legacy data model features
       enableTimeseriesSearch,

--- a/src/featureDefaults.ts
+++ b/src/featureDefaults.ts
@@ -10,19 +10,20 @@ export const FEATURE_DEFAULTS = {
 
   // Core data model (CDM) features - default to enabled when core master toggle is on
   enableCogniteTimeSeries: true,
+  enableCogniteActivities: true,
+  enableFlexibleDataModelling: true, // GraphQL / Data Models tab
 
   // Legacy data model features - default to enabled for backward compatibility
   enableTimeseriesSearch: true,
   enableTimeseriesFromAsset: true,
   enableTimeseriesCustomQuery: true,
   enableEvents: true,
+  enableEventsAdvancedFiltering: false, // Off by default
 
-  // Deprecated features - keep existing behavior for backward compatibility
+  // Deprecated features
   enableTemplates: false, // Disabled by default
-  enableEventsAdvancedFiltering: false, // Disabled by default
-  enableFlexibleDataModelling: true, // Enable Data Models by default
   enableExtractionPipelines: false, // Disabled by default
-  enableRelationships: true, // Default enabled for backward compatibility
+  enableRelationships: false, // Disabled by default
 } as const;
 
 /**

--- a/src/queryEditorUtils.ts
+++ b/src/queryEditorUtils.ts
@@ -49,9 +49,8 @@ export function isTabDisabled(
     return false;
   }
 
-  // CogniteActivity tab - gated under the same CDM toggle as CogniteTimeSeriesSearch
   if (tab === Tabs.CogniteActivity) {
-    return !datasource.connector.isCogniteTimeSeriesEnabled();
+    return !datasource.connector.isCogniteActivitiesEnabled();
   }
 
   return false;

--- a/src/test_utils.ts
+++ b/src/test_utils.ts
@@ -70,17 +70,18 @@ export const getMockedDataSource = (
     // Master toggles - enabled for tests
     true, // enableCoreDataModelFeatures
     true, // enableLegacyDataModelFeatures
-    // Core data model (CDM) features - enabled for tests (default is false in production)
+    // Core data model (CDM) features - enabled for tests
     true, // enableCogniteTimeSeries
-    // Legacy data model features - default to enabled for tests
+    true, // enableCogniteActivities
+    true, // enableFlexibleDataModelling
+    // Legacy data model features - enabled for tests
     true, // enableTimeseriesSearch
     true, // enableTimeseriesFromAsset
     true, // enableTimeseriesCustomQuery
     true, // enableEvents
-    // Deprecated features - default to enabled for tests
-    true, // enableTemplates
     true, // enableEventsAdvancedFiltering
-    true, // enableFlexibleDataModelling
+    // Deprecated features - enabled for tests
+    true, // enableTemplates
     true, // enableExtractionPipelines
     true, // enableRelationships
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,7 @@ export const TabTitles = {
   [Tab.Relationships]: "Relationships",
   [Tab.Templates]: "Templates",
   [Tab.FlexibleDataModelling]: "GraphQL",
-  [Tab.CogniteActivity]: "CogniteActivities",
+  [Tab.CogniteActivity]: "Activities",
 };
 const defaultFlexibleDataModellingQuery: FlexibleDataModellingQuery = {
   externalId: "",
@@ -254,6 +254,7 @@ export interface CogniteDataSourceOptions extends DataSourceJsonData {
   enableLegacyDataModelFeatures?: boolean;
   // Core data model (CDM) features
   enableCogniteTimeSeries?: boolean;
+  enableCogniteActivities?: boolean;
   enableFlexibleDataModelling?: boolean;
   // Legacy data model features
   enableTimeseriesSearch?: boolean;


### PR DESCRIPTION
Quality-of-life fixes to the configuration and CDM query editor tabs.

- **Configuration**: strip `http(s)://` and trailing slashes from the Base URL field so pasting `https://bluefield.cognitedata.com` no longer produces an invalid `https://https://...` proxy URL (the `dial tcp: lookup https on 127.0.0.11:53: no such host` Bad Gateway).
- **CDM Time Series and Activities tabs**: dropdowns load options when the menu is opened (mirroring the legacy Time series search behaviour).
- **Activities tab**: display name is **Activities** instead of "CogniteActivities" (persisted tab id unchanged: `CogniteActivity`). Gated by its own **`enableCogniteActivities`** toggle in Features (between Time Series and GraphQL).
- **Relationships**: default is **off** for new datasources (existing datasources keep their saved value).

## Backward compatibility

- Saved queries keep tab id **`CogniteActivity`** (only display label changed).
- **`enableRelationships`** applies to new datasource defaults only; stored `jsonData` overrides.