### PR TITLE
chore: bump version to 4.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/cognite-grafana-datasource",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Cognite Data Fusion datasource",
   "repository": "https://github.com/cognitedata/cognite-grafana-datasource",
   "author": "Cognite AS",


### PR DESCRIPTION
## Summary

Bumps `package.json` version from `4.4.0` → `4.5.0` in preparation for the v4.5.0 release.

## Test plan

- [ ] Verify `package.json` version reads `4.5.0`
- [ ] Merge, then re-apply `v4.5.0` git tag to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)