### PR TITLE
fix(ci): bump Go version to 1.25 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,4 +19,4 @@ jobs:
         with:
           policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
           attestation: true
-          go-version: '1.24'
+          go-version: '1.25'


### PR DESCRIPTION
## Summary

The `grafana-plugin-sdk-go` upgrade to v0.292.0 (PR #658) bumped the minimum required Go version to `1.25.7` in `go.mod`. The release workflow was still pinned to `go-version: '1.24'`, causing:

```
go: go.mod requires go >= 1.25.7 (running go 1.24.13; GOTOOLCHAIN=local)
Error: The process '.../mage' failed with exit code 1
```

This PR bumps it to `1.25` to match the build workflow.

## Test plan

- [ ] Re-run release workflow after merge and verify mage build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)