### PR TITLE
Add support for mixed CogniteTimeSeries types

### DIFF
--- a/src/__mocks__/dmsTestData.ts
+++ b/src/__mocks__/dmsTestData.ts
@@ -108,6 +108,22 @@ export const mockInstancesWithStringType: DMSInstance[] = [
       },
     },
   },
+  {
+    instanceType: 'node',
+    space: 'cdf_cdm',
+    externalId: 'state_sensor',
+    version: 1,
+    lastUpdatedTime: 1640995200000,
+    createdTime: 1640995200000,
+    properties: {
+      cdf_cdm: {
+        'CogniteTimeSeries/v1': {
+          name: 'State Sensor',
+          type: 'state',
+        },
+      },
+    },
+  },
 ];
 
 export const mockSingleSpace: DMSSpace[] = [

--- a/src/__tests__/cogniteTimeSeriesSearch.test.ts
+++ b/src/__tests__/cogniteTimeSeriesSearch.test.ts
@@ -2,6 +2,7 @@ import { getMockedDataSource } from '../test_utils';
 import { fetchDMSSpaces, fetchDMSViews, searchDMSInstances } from '../cdf/client';
 import { DMSSpace, DMSView, DMSInstance } from '../types/dms';
 import { Connector } from '../connector';
+import { getTypeBadgeColor } from '../components/cogniteTimeSeriesSearchTab';
 import {
   mockSpaces,
   mockViews,
@@ -132,14 +133,6 @@ describe('CogniteTimeSeriesSearch DMS Functions', () => {
           version: 'v1',
         },
         query: 'temperature',
-        filter: {
-          not: {
-            equals: {
-              property: ['type'],
-              value: 'string',
-            },
-          },
-        },
         limit: 10,
       };
 
@@ -181,8 +174,7 @@ describe('CogniteTimeSeriesSearch DMS Functions', () => {
       });
     });
 
-    it('should filter out string-type timeseries', async () => {
-
+    it('should return mixed-type timeseries (numeric, string and state)', async () => {
       fetcher.fetch.mockResolvedValue({
         data: { items: mockInstancesWithStringType },
         status: 200,
@@ -196,20 +188,17 @@ describe('CogniteTimeSeriesSearch DMS Functions', () => {
           version: 'v1',
         },
         query: 'sensor',
-        filter: {
-          not: {
-            equals: {
-              property: ['type'],
-              value: 'string',
-            },
-          },
-        },
         limit: 10,
       };
 
       const result = await searchDMSInstances(connector, searchRequest);
 
       expect(result).toEqual(mockInstancesWithStringType);
+      expect(result.map((i) => i.properties?.cdf_cdm['CogniteTimeSeries/v1'].type)).toEqual([
+        'numeric',
+        'string',
+        'state',
+      ]);
       expect(fetcher.fetch).toHaveBeenCalledWith({
         url: '/api/datasources/proxy/6/cdf-oauth/api/v1/projects/TestProject/models/instances/search',
         method: 'POST',
@@ -305,4 +294,23 @@ describe('CogniteTimeSeriesSearch DMS Functions', () => {
       expect(instances).toEqual([]);
     });
   });
-}); 
+});
+
+describe('getTypeBadgeColor', () => {
+  it('returns blue for numeric', () => {
+    expect(getTypeBadgeColor('numeric')).toBe('blue');
+  });
+
+  it('returns orange for string', () => {
+    expect(getTypeBadgeColor('string')).toBe('orange');
+  });
+
+  it('returns purple for state', () => {
+    expect(getTypeBadgeColor('state')).toBe('purple');
+  });
+
+  it('returns darkgrey for unknown types', () => {
+    expect(getTypeBadgeColor('mystery')).toBe('darkgrey');
+    expect(getTypeBadgeColor('')).toBe('darkgrey');
+  });
+});

--- a/src/__tests__/unitConversion.test.ts
+++ b/src/__tests__/unitConversion.test.ts
@@ -1,4 +1,4 @@
-import { fetchCogniteUnits, getTimeSeriesUnit, formQueryForItems } from '../cdf/client';
+import { fetchCogniteUnits, getTimeSeriesUnit, getTimeSeriesProperties, formQueryForItems } from '../cdf/client';
 import { Connector } from '../connector';
 import { CogniteUnit, DMSInstance } from '../types/dms';
 import { HttpMethod, defaultQuery, CogniteQuery, QueryOptions } from '../types';
@@ -292,6 +292,67 @@ describe('Unit Conversion', () => {
       });
 
       expect(unit).toBeUndefined();
+    });
+  });
+
+  describe('getTimeSeriesProperties', () => {
+    const buildInstance = (props: Record<string, unknown>): DMSInstance[] => [
+      {
+        instanceType: 'node',
+        space: 'cdm_try',
+        externalId: 'test-ts',
+        version: 1,
+        lastUpdatedTime: 1234567890,
+        createdTime: 1234567890,
+        properties: {
+          cdf_cdm: {
+            'CogniteTimeSeries/v1': {
+              name: 'Test TS',
+              ...props,
+            },
+          },
+        },
+      },
+    ];
+
+    it.each([
+      ['numeric'],
+      ['string'],
+      ['state'],
+    ])('returns the %s type from the instance', async (type) => {
+      mockConnector.fetchItems.mockResolvedValue(buildInstance({ type }));
+
+      const result = await getTimeSeriesProperties(mockConnector, {
+        space: 'cdm_try',
+        externalId: 'test-ts',
+      });
+
+      expect(result.type).toBe(type);
+    });
+
+    it('returns unit and type together in a single fetch', async () => {
+      mockConnector.fetchItems.mockResolvedValue(
+        buildInstance({ type: 'numeric', unit: 'temperature:deg_c' })
+      );
+
+      const result = await getTimeSeriesProperties(mockConnector, {
+        space: 'cdm_try',
+        externalId: 'test-ts',
+      });
+
+      expect(result).toEqual({ type: 'numeric', unit: 'temperature:deg_c' });
+      expect(mockConnector.fetchItems).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns empty object on error', async () => {
+      mockConnector.fetchItems.mockRejectedValue(new Error('API Error'));
+
+      const result = await getTimeSeriesProperties(mockConnector, {
+        space: 'cdm_try',
+        externalId: 'test-ts',
+      });
+
+      expect(result).toEqual({});
     });
   });
 

--- a/src/cdf/client.ts
+++ b/src/cdf/client.ts
@@ -605,10 +605,15 @@ export async function fetchCogniteUnits(
   }
 }
 
-export async function getTimeSeriesUnit(
+export interface TimeSeriesProperties {
+  unit?: string;
+  type?: string;
+}
+
+export async function getTimeSeriesProperties(
   connector: Connector,
   instanceId: { space: string; externalId: string }
-): Promise<string | undefined> {
+): Promise<TimeSeriesProperties> {
   try {
     const instances = await retryOnRateLimit(() =>
       connector.fetchItems<DMSInstance>({
@@ -635,20 +640,31 @@ export async function getTimeSeriesUnit(
 
     if (instances.length > 0) {
       const tsProps = instances[0].properties?.['cdf_cdm']?.['CogniteTimeSeries/v1'];
-      // Try both 'unit' and 'sourceUnit' properties
-      const unit = tsProps?.unit || tsProps?.sourceUnit;
-      
-      // Handle both string and object formats
-      if (typeof unit === 'string') {
-        return unit;
-      } else if (unit && typeof unit === 'object' && 'externalId' in unit) {
-        return unit.externalId;
+      // Try both 'unit' and 'sourceUnit'; each may be a string or an object with externalId
+      const rawUnit = tsProps?.unit || tsProps?.sourceUnit;
+      let unit: string | undefined;
+      if (typeof rawUnit === 'string') {
+        unit = rawUnit;
+      } else if (rawUnit && typeof rawUnit === 'object' && 'externalId' in rawUnit) {
+        unit = rawUnit.externalId;
       }
+
+      const rawType = tsProps?.type;
+      const type = typeof rawType === 'string' ? rawType : undefined;
+
+      return { unit, type };
     }
   } catch (err) {
-    console.warn('Failed to fetch timeseries unit:', err);
+    console.warn('Failed to fetch timeseries properties:', err);
   }
-  return undefined;
+  return {};
+}
+
+export async function getTimeSeriesUnit(
+  connector: Connector,
+  instanceId: { space: string; externalId: string }
+): Promise<string | undefined> {
+  return (await getTimeSeriesProperties(connector, instanceId)).unit;
 }
 
 // Fetch views that implement the CogniteTimeSeries container

--- a/src/components/cogniteTimeSeriesSearchTab.tsx
+++ b/src/components/cogniteTimeSeriesSearchTab.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { Select, AsyncSelect, Alert, InlineFieldRow, InlineField, InlineSwitch } from '@grafana/ui';
+import { Select, AsyncSelect, Alert, Badge, BadgeColor, InlineFieldRow, InlineField, InlineSwitch } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { SelectedProps } from '../types';
-import { searchDMSInstances, fetchCogniteUnits, getTimeSeriesUnit, stringifyError, fetchCogniteTimeSeriesViews, fetchCogniteActivityViews } from '../cdf/client';
+import { searchDMSInstances, fetchCogniteUnits, getTimeSeriesProperties, stringifyError, fetchCogniteTimeSeriesViews, fetchCogniteActivityViews } from '../cdf/client';
 import { DMSInstance, DMSSearchRequest, CogniteUnit, InvolvedView } from '../types/dms';
 import { CommonEditors, LabelEditor } from './commonEditors';
 import { Connector } from '../connector';
@@ -10,6 +10,15 @@ import { Connector } from '../connector';
 interface CogniteTimeSeriesSearchTabProps extends SelectedProps {
   connector: Connector;
 }
+
+const TYPE_BADGE_COLORS: Record<string, BadgeColor> = {
+  numeric: 'blue',
+  string: 'orange',
+  state: 'purple',
+};
+
+export const getTypeBadgeColor = (type: string): BadgeColor =>
+  TYPE_BADGE_COLORS[type] ?? 'darkgrey';
 
 const LatestValueCheckbox = (props: SelectedProps) => {
   const { query, onQueryChange } = props;
@@ -41,6 +50,7 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
   const [error, setError] = useState<string | null>(null);
   const [units, setUnits] = useState<CogniteUnit[]>([]);
   const [timeSeriesUnit, setTimeSeriesUnit] = useState<string | undefined>(undefined);
+  const [timeSeriesType, setTimeSeriesType] = useState<string | undefined>(undefined);
   const [loadingUnits, setLoadingUnits] = useState(false);
   
   // Activity overlay state
@@ -90,27 +100,22 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
           version: cogniteTimeSeries.version,
         },
         query: searchQuery.trim(),
-        filter: {
-          not: {
-            equals: {
-              property: ['type'],
-              value: 'string',
-            },
-          },
-        },
         limit: 1000,
       };
 
       const instances = await searchDMSInstances(connector, searchRequest);
       const tsOptions = instances.map((instance: DMSInstance) => {
-        const name = instance.properties?.[cogniteTimeSeries.space]?.[`${cogniteTimeSeries.externalId}/${cogniteTimeSeries.version}`]?.name || instance.externalId;
+        const props = instance.properties?.[cogniteTimeSeries.space]?.[`${cogniteTimeSeries.externalId}/${cogniteTimeSeries.version}`];
+        const name = props?.name || instance.externalId;
+        const type = props?.type;
         return {
           label: name,
           value: `${instance.space}:${instance.externalId}`,
           description: `Space: ${instance.space}, External ID: ${instance.externalId}`,
           space: instance.space,
           externalId: instance.externalId,
-          name: name,
+          name,
+          type,
         };
       });
       return tsOptions;
@@ -164,27 +169,37 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
     loadUnits();
   }, [connector]);
 
-  // Fetch the unit of the selected timeseries
+  // Fetch the unit and type of the selected timeseries in a single byids call
   useEffect(() => {
-    const fetchUnit = async () => {
+    const fetchProperties = async () => {
       const instanceId = cogniteTimeSeries.instanceId;
       if (instanceId?.space && instanceId?.externalId) {
         setLoadingUnits(true);
         try {
-          const unit = await getTimeSeriesUnit(connector, instanceId);
+          const { unit, type } = await getTimeSeriesProperties(connector, instanceId);
           setTimeSeriesUnit(unit);
+          setTimeSeriesType(type);
         } catch (err) {
-          console.warn('Failed to fetch timeseries unit:', stringifyError(err));
+          console.warn('Failed to fetch timeseries properties:', stringifyError(err));
           setTimeSeriesUnit(undefined);
+          setTimeSeriesType(undefined);
         } finally {
           setLoadingUnits(false);
         }
       } else {
         setTimeSeriesUnit(undefined);
+        setTimeSeriesType(undefined);
       }
     };
-    fetchUnit();
+    fetchProperties();
   }, [connector, instanceIdKey, cogniteTimeSeries.instanceId]);
+
+  // String timeseries don't support aggregations — pin aggregation to 'none'
+  useEffect(() => {
+    if (timeSeriesType === 'string' && query.aggregation !== 'none') {
+      onQueryChange({ aggregation: 'none' });
+    }
+  }, [timeSeriesType, query.aggregation, onQueryChange]);
 
   const handleViewChange = (selectedOption: SelectableValue<InvolvedView> | null) => {
     const view = selectedOption?.value;
@@ -200,17 +215,20 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
   };
 
   const handleTimeseriesSelection = (selectedTimeseries: SelectableValue | null) => {
+    setTimeSeriesType(selectedTimeseries?.type);
     onQueryChange({
       cogniteTimeSeries: {
         ...cogniteTimeSeries,
         instanceId: selectedTimeseries ? {
-          // PR Feedback: We need space field here because top-level space (e.g., "cdf_cdm") 
-          // is used for searching/listing in DMS view, while instanceId.space 
+          // PR Feedback: We need space field here because top-level space (e.g., "cdf_cdm")
+          // is used for searching/listing in DMS view, while instanceId.space
           // (e.g., "cdm_try") is where the actual selected instance lives for data queries
           space: selectedTimeseries.space,
           externalId: selectedTimeseries.externalId,
         } : undefined,
       },
+      // String timeseries don't support aggregations — pin to 'none' on selection
+      ...(selectedTimeseries?.type === 'string' ? { aggregation: 'none' } : {}),
     });
   };
 
@@ -273,6 +291,7 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
   };
 
   const isUnitConversionEnabled = !!timeSeriesUnit && !!cogniteTimeSeries.instanceId;
+  const isStateType = timeSeriesType === 'state';
 
   // Activity overlay handlers
   const handleActivityOverlayToggle = (checked: boolean) => {
@@ -369,9 +388,17 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
               width={40}
               noOptionsMessage="No timeseries found"
               inputId={`cognite-timeseries-search-${query.refId}`}
+              formatOptionLabel={(option: SelectableValue & { type?: string }) => (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                  <span>{option.label}</span>
+                  {option.type && (
+                    <Badge text={option.type} color={getTypeBadgeColor(option.type)} />
+                  )}
+                </div>
+              )}
             />
           </InlineField>
-          {timeSeriesUnit && (
+          {timeSeriesUnit && !isStateType && (
             <div style={{
               display: 'flex',
               alignItems: 'center',
@@ -385,7 +412,13 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
           )}
         </InlineFieldRow>
 
-        {cogniteTimeSeries.instanceId && isUnitConversionEnabled && (
+        {cogniteTimeSeries.instanceId && isStateType && (
+          <Alert title="Unsupported time series type" severity="info">
+            State time series are not currently supported in Grafana.
+          </Alert>
+        )}
+
+        {cogniteTimeSeries.instanceId && isUnitConversionEnabled && !isStateType && (
           <InlineFieldRow>
             <InlineField
               label="Target Unit"
@@ -406,7 +439,7 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
         )}
 
         {/* Activity Overlay Section - only show when time series is selected */}
-        {cogniteTimeSeries.instanceId && (
+        {cogniteTimeSeries.instanceId && !isStateType && (
           <>
             <InlineFieldRow>
               <InlineField
@@ -462,9 +495,16 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
           </>
         )}
 
-        <LatestValueCheckbox {...{ query, onQueryChange }} />
-        {!query.latestValue && (
-          <CommonEditors {...{ query, onQueryChange }} />
+        {!isStateType && (
+          <>
+            <LatestValueCheckbox {...{ query, onQueryChange }} />
+            {!query.latestValue && (
+              <CommonEditors
+                {...{ query, onQueryChange }}
+                hideAggregation={timeSeriesType === 'string'}
+              />
+            )}
+          </>
         )}
 
         {error && (
@@ -473,7 +513,7 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
           </Alert>
         )}
       </div>
-      {query.latestValue && (
+      {query.latestValue && !isStateType && (
         <LabelEditor {...{ onQueryChange, query }} />
       )}
     </div>

--- a/src/components/commonEditors.tsx
+++ b/src/components/commonEditors.tsx
@@ -88,7 +88,7 @@ export const LabelEditor = (props: SelectedProps) => {
 
 export const CommonEditors = ({ onQueryChange, query, ...etc }: SelectedProps & any) => (
   <InlineFieldRow>
-    <AggregationEditor {...{ onQueryChange, query }} />
+    {!etc?.hideAggregation && <AggregationEditor {...{ onQueryChange, query }} />}
     <GranularityEditor {...{ onQueryChange, query }} />
     {!etc?.visible && <LabelEditor {...{ onQueryChange, query }} />}
   </InlineFieldRow>


### PR DESCRIPTION
This PR adds support for fetching CogniteTimeSeries of mixed types (numeric, string and state) with proper handling of features for each type.

- The type is rendered as a chip in the selection dropdown, to allow users to easily identify the type associated with a given CogniteTimeSeries entry.

<img width="1728" height="995" alt="image" src="https://github.com/user-attachments/assets/529936fd-f0b8-4340-91b1-0c1754d59653" />
<img width="1728" height="996" alt="image" src="https://github.com/user-attachments/assets/652ea441-ef7c-4882-9a8a-aef0c72cab52" />

- Aggregates selector is disabled for string type, since it is not supported by the API currently.

<img width="1728" height="766" alt="image" src="https://github.com/user-attachments/assets/c26a01a3-e648-40a6-a351-082c91b0a2ac" />

- State time series is not supported and shows a warning to the user (we will add support for state time series in a future PR).

<img width="1728" height="728" alt="image" src="https://github.com/user-attachments/assets/fe3424da-5ac2-456b-b08b-f1388870f540" />
