### PR TITLE
chore: bump version to 4.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Data Source for Grafana**.
 - Time series type is now displayed as a chip in the selection dropdown
 - Aggregates selector is disabled for string type time series
 - State time series shows a warning (support to be added in a future release)
+- Added dynamic label interpolation for CogniteTimeSeries queries: the Label field now supports `{{property}}` tokens resolved against the selected instance's view properties at query time
+- `{{space}}` and `{{externalId}}` tokens are always available; nested paths like `{{property.foo}}` are supported
+
+### Bug fixes
+
+- Tightened unit validation: only structured `unit` direct relations are treated as resolvable storage units; free-text `sourceUnit` values are no longer surfaced in the Target Unit field
+- Storage unit is now displayed as a badge next to the Target Unit selector instead of inline text next to the search field
 
 ## 4.5.0 - April 27th, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,6 @@ Data Source for Grafana**.
 - Aggregates selector is disabled for string type time series
 - State time series shows a warning (support to be added in a future release)
 
-### Dependencies
-
-- Upgraded `grafana-plugin-sdk-go` to v0.292.0
-- Added yarn resolutions to fix npm CVEs
-
 ## 4.5.0 - April 27th, 2026
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 This article documents the ongoing improvements we're making to the **Cognite
 Data Source for Grafana**.
 
+## 4.5.1 - May 4th, 2026
+
+### Features
+
+- Added support for mixed CogniteTimeSeries types (numeric, string, and state) in the CDM query editor
+- Time series type is now displayed as a chip in the selection dropdown
+- Aggregates selector is disabled for string type time series
+- State time series shows a warning (support to be added in a future release)
+
+### Bug fixes
+
+- Fixed broken README links
+
+### Dependencies
+
+- Upgraded `grafana-plugin-sdk-go` to v0.292.0
+- Added yarn resolutions to fix npm CVEs
+
 ## 4.5.0 - April 27th, 2026
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@ Data Source for Grafana**.
 - Aggregates selector is disabled for string type time series
 - State time series shows a warning (support to be added in a future release)
 
-### Bug fixes
-
-- Fixed broken README links
-
 ### Dependencies
 
 - Upgraded `grafana-plugin-sdk-go` to v0.292.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/cognite-grafana-datasource",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "Cognite Data Fusion datasource",
   "repository": "https://github.com/cognitedata/cognite-grafana-datasource",
   "author": "Cognite AS",


### PR DESCRIPTION
## Summary

- Bumps version from 4.5.0 to 4.5.1
- Updates CHANGELOG.md with entries for all changes since the v4.5.0 tag

## Changes included in this release

**#663 — Added support for mixed CogniteTimeSeries types**
- Mixed numeric, string, and state time series are now handled in the CDM query editor
- Time series type is displayed as a chip in the selection dropdown
- Aggregates selector is disabled for string type time series
- State time series shows a warning (support to be added in a future release)

**#665 — Interpolate `{{property}}` labels and tighten unit handling**
- The Label field now supports `{{property}}` tokens resolved against the selected instance's view properties at query time
- `{{space}}` and `{{externalId}}` are always available; nested paths like `{{property.foo}}` are supported
- Tightened unit validation: only structured `unit` direct relations are surfaced in the Target Unit field
- Storage unit is now displayed as a badge next to the Target Unit selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)