### PR TITLE
Interpolate `{{property}}` labels and tighten unit handling

### DIFF
--- a/src/__tests__/cdf.client.test.ts
+++ b/src/__tests__/cdf.client.test.ts
@@ -3,6 +3,7 @@ import {
   datapoints2Tuples,
   reduceTimeseries,
   labelContainsVariableProps,
+  interpolateCogniteTimeSeriesInstanceLabel,
   concurrent,
   convertItemsToTable,
 } from '../cdf/client';
@@ -113,6 +114,41 @@ describe('CDF client', () => {
 
     test('no props', () => {
       expect(labelContainsVariableProps('pure text')).toEqual(false);
+    });
+  });
+
+  describe('CogniteTimeSeriesSearch label interpolation', () => {
+    it('interpolates fields, JSONifies objects, invalid root, null, nested typos', () => {
+      const props = {
+        space: 'inst_s',
+        externalId: 'inst_e',
+        name: 'TS-A',
+        unit: { externalId: 'kg' },
+        nullableField: null,
+        nested: { ok: 1 },
+      };
+      const viewProps = ['name', 'unit', 'nullableField', 'nested'];
+
+      const out = interpolateCogniteTimeSeriesInstanceLabel(
+        '{{name}} | {{nope}} | {{unit}} | {{nullableField}} | {{nested.bad}} | {{nested.ok}}',
+        props,
+        viewProps
+      );
+
+      expect(out).toBe('TS-A | :nope | {"externalId":"kg"} | null | :nested.bad | 1');
+    });
+
+    it('allows {{space}} and {{externalId}} from instance node', () => {
+      const props = { space: 'inst_s', externalId: 'inst_e', name: 'N' };
+      const viewProps = ['name'];
+
+      const out = interpolateCogniteTimeSeriesInstanceLabel(
+        '{{space}}/{{externalId}}/{{name}}',
+        props,
+        viewProps
+      );
+
+      expect(out).toBe('inst_s/inst_e/N');
     });
   });
 

--- a/src/__tests__/unitConversion.test.ts
+++ b/src/__tests__/unitConversion.test.ts
@@ -140,7 +140,7 @@ describe('Unit Conversion', () => {
   });
 
   describe('getTimeSeriesUnit', () => {
-    it('should fetch unit from timeseries instance (string format)', async () => {
+    it('does not return a string-typed unit property as storage unit (only direct relation)', async () => {
       const mockInstances: DMSInstance[] = [
         {
           instanceType: 'node',
@@ -188,7 +188,7 @@ describe('Unit Conversion', () => {
         },
       });
 
-      expect(unit).toBe('temperature:deg_c');
+      expect(unit).toBeUndefined();
     });
 
     it('should fetch unit from timeseries instance (object format)', async () => {
@@ -224,7 +224,7 @@ describe('Unit Conversion', () => {
       expect(unit).toBe('temperature:deg_c');
     });
 
-    it('should fallback to sourceUnit if unit is not present', async () => {
+    it('does not treat sourceUnit as a resolvable storage unit when structured unit is absent', async () => {
       const mockInstances: DMSInstance[] = [
         {
           instanceType: 'node',
@@ -251,7 +251,7 @@ describe('Unit Conversion', () => {
         externalId: 'test-ts',
       });
 
-      expect(unit).toBe('temperature:deg_c');
+      expect(unit).toBeUndefined();
     });
 
     it('should return undefined if no unit is found', async () => {
@@ -332,7 +332,10 @@ describe('Unit Conversion', () => {
 
     it('returns unit and type together in a single fetch', async () => {
       mockConnector.fetchItems.mockResolvedValue(
-        buildInstance({ type: 'numeric', unit: 'temperature:deg_c' })
+        buildInstance({
+          type: 'numeric',
+          unit: { space: 'cdf_cdm_units', externalId: 'temperature:deg_c' },
+        })
       );
 
       const result = await getTimeSeriesProperties(mockConnector, {

--- a/src/cdf/client.ts
+++ b/src/cdf/client.ts
@@ -209,12 +209,16 @@ export function interpolateCogniteTimeSeriesInstanceLabel(
   const validPropNames = new Set([...viewPropertyNames, 'space', 'externalId']);
   return labelSrc.replace(variableLabelRegex, (_full, group) => {
     const rootKey = group.split('.')[0];
-    if (!validPropNames.has(rootKey)) return `:${group}`;
+    if (!validPropNames.has(rootKey)) {
+      return `:${group}`;
+    }
     const val = get(props, group);
     if (val == null) {
       return group.includes('.') ? `:${group}` : 'null';
     }
-    if (typeof val === 'object') return JSON.stringify(val);
+    if (typeof val === 'object') {
+      return JSON.stringify(val);
+    }
     return String(val);
   });
 }
@@ -731,7 +735,9 @@ export async function fetchCogniteTimeSeriesInstance(
         },
       })
     );
-    if (!instances.length) return {};
+    if (!instances.length) {
+      return {};
+    }
     const instance = instances[0];
     const props =
       instance.properties?.[viewSpec.space]?.[`${viewSpec.externalId}/${viewSpec.version}`] ?? {};

--- a/src/cdf/client.ts
+++ b/src/cdf/client.ts
@@ -141,15 +141,24 @@ export async function getLabelsForTarget(
       return timeseries.map((ts) => getLabelWithInjectedProps(labelSrc, ts));
     }
     case Tab.CogniteTimeSeriesSearch: {
-      // For CogniteTimeSeriesSearch, we use the instanceId format as a fallback
-      // since name should be loaded at runtime, not persisted in JSON
+      // Default label for CogniteTimeSeries: <space>:<externalId> of the picked instance.
       if (target.cogniteTimeSeries?.instanceId) {
         const space = target.cogniteTimeSeries.instanceId.space;
         const externalId = target.cogniteTimeSeries.instanceId.externalId;
-        const instanceId = `${space}:${externalId}`;
-        // If we have a custom label with variables, we can't inject properties from regular timeseries metadata
-        // since this is a DMS instance, so we'll use the instanceId as fallback
-        return labelSrc && !labelContainsVariableProps(labelSrc) ? [labelSrc] : [instanceId];
+        const instanceLabel = `${space}:${externalId}`;
+        if (labelSrc && labelContainsVariableProps(labelSrc)) {
+          const viewSpec = {
+            space: target.cogniteTimeSeries.space,
+            externalId: target.cogniteTimeSeries.externalId,
+            version: target.cogniteTimeSeries.version,
+          };
+          const [props, viewProps] = await Promise.all([
+            fetchCogniteTimeSeriesInstance(connector, viewSpec, target.cogniteTimeSeries.instanceId),
+            fetchDMSViewProperties(connector, viewSpec),
+          ]);
+          return [interpolateCogniteTimeSeriesInstanceLabel(labelSrc, props, viewProps)];
+        }
+        return [labelSrc || instanceLabel];
       }
       return [labelSrc || 'CogniteTimeSeries'];
     }
@@ -187,6 +196,27 @@ export function getLabelWithInjectedProps(
 
 export function labelContainsVariableProps(label: string): boolean {
   return label && !!label.match(variableLabelRegex);
+}
+
+/** Interpolate `{{property}}` tokens from a CogniteTimeSeries DMS instance + view schema. */
+export function interpolateCogniteTimeSeriesInstanceLabel(
+  labelSrc: string,
+  props: Record<string, any>,
+  viewPropertyNames: string[]
+): string {
+  // `space` and `externalId` come from the instance node itself (not the view
+  // schema), but are exposed in `props` and useful in labels.
+  const validPropNames = new Set([...viewPropertyNames, 'space', 'externalId']);
+  return labelSrc.replace(variableLabelRegex, (_full, group) => {
+    const rootKey = group.split('.')[0];
+    if (!validPropNames.has(rootKey)) return `:${group}`;
+    const val = get(props, group);
+    if (val == null) {
+      return group.includes('.') ? `:${group}` : 'null';
+    }
+    if (typeof val === 'object') return JSON.stringify(val);
+    return String(val);
+  });
 }
 
 export async function getTimeseries(
@@ -640,14 +670,14 @@ export async function getTimeSeriesProperties(
 
     if (instances.length > 0) {
       const tsProps = instances[0].properties?.['cdf_cdm']?.['CogniteTimeSeries/v1'];
-      // Try both 'unit' and 'sourceUnit'; each may be a string or an object with externalId
-      const rawUnit = tsProps?.unit || tsProps?.sourceUnit;
-      let unit: string | undefined;
-      if (typeof rawUnit === 'string') {
-        unit = rawUnit;
-      } else if (rawUnit && typeof rawUnit === 'object' && 'externalId' in rawUnit) {
-        unit = rawUnit.externalId;
-      }
+      // Only the structured `unit` direct relation (a CogniteUnit reference) qualifies as
+      // a storage unit for conversion. The free-text `sourceUnit` is informational and not
+      // resolvable against the unit catalog, so we ignore it here.
+      const rawUnit = tsProps?.unit;
+      const unit =
+        rawUnit && typeof rawUnit === 'object' && typeof rawUnit.externalId === 'string'
+          ? rawUnit.externalId
+          : undefined;
 
       const rawType = tsProps?.type;
       const type = typeof rawType === 'string' ? rawType : undefined;
@@ -665,6 +695,55 @@ export async function getTimeSeriesUnit(
   instanceId: { space: string; externalId: string }
 ): Promise<string | undefined> {
   return (await getTimeSeriesProperties(connector, instanceId)).unit;
+}
+
+// Fetch the full property bag of a CogniteTimeSeries instance from a specific view, so
+// label templates like `{{name}}` or `{{metadata.foo}}` can be interpolated at query time.
+export async function fetchCogniteTimeSeriesInstance(
+  connector: Connector,
+  viewSpec: { space: string; externalId: string; version: string },
+  instanceId: { space: string; externalId: string }
+): Promise<Record<string, any>> {
+  try {
+    const instances = await retryOnRateLimit(() =>
+      connector.fetchItems<DMSInstance>({
+        method: HttpMethod.POST,
+        path: '/models/instances/byids',
+        data: {
+          sources: [
+            {
+              source: {
+                type: 'view',
+                space: viewSpec.space,
+                externalId: viewSpec.externalId,
+                version: viewSpec.version,
+              },
+            },
+          ],
+          items: [
+            {
+              instanceType: 'node',
+              space: instanceId.space,
+              externalId: instanceId.externalId,
+            },
+          ],
+          includeTyping: false,
+        },
+      })
+    );
+    if (!instances.length) return {};
+    const instance = instances[0];
+    const props =
+      instance.properties?.[viewSpec.space]?.[`${viewSpec.externalId}/${viewSpec.version}`] ?? {};
+    return {
+      space: instance.space,
+      externalId: instance.externalId,
+      ...props,
+    };
+  } catch (err) {
+    console.warn('Failed to fetch CogniteTimeSeries instance:', err);
+    return {};
+  }
 }
 
 // Fetch views that implement the CogniteTimeSeries container

--- a/src/components/cogniteTimeSeriesSearchTab.tsx
+++ b/src/components/cogniteTimeSeriesSearchTab.tsx
@@ -352,7 +352,7 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
 
   return (
     <div>
-      <div className="gf-form-group">
+      <div>
         <InlineFieldRow>
           <InlineField
             label="View"
@@ -398,18 +398,6 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
               )}
             />
           </InlineField>
-          {timeSeriesUnit && !isStateType && (
-            <div style={{
-              display: 'flex',
-              alignItems: 'center',
-              marginLeft: '8px',
-              color: 'rgba(204, 204, 220, 0.65)',
-              fontSize: '12px',
-              whiteSpace: 'nowrap'
-            }}>
-              Unit: {getUnitDisplayName(timeSeriesUnit)}
-            </div>
-          )}
         </InlineFieldRow>
 
         {cogniteTimeSeries.instanceId && isStateType && (
@@ -435,6 +423,14 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
                 width={40}
               />
             </InlineField>
+            {timeSeriesUnit && (
+              <InlineField transparent style={{ alignItems: 'center' }}>
+                <Badge
+                  text={`Storage unit: ${getUnitDisplayName(timeSeriesUnit)}`}
+                  color="darkgrey"
+                />
+              </InlineField>
+            )}
           </InlineFieldRow>
         )}
 


### PR DESCRIPTION
## Summary

Two related improvements to the CogniteTimeSeries (DMS) query tab:

### 1. Dynamic label interpolation with `{{property}}`

The Label field for a CogniteTimeSeries query now supports `{{...}}` tokens that are resolved against the selected instance's view properties at query time, similar to how the classic Time Series tab handles `{{name}}`/`{{description}}`.

- Tokens are resolved using the picked view's schema and the instance's property bag (fetched in parallel via `/models/instances/byids` + `/models/views/byids`).
- `{{space}}` and `{{externalId}}` are always available (taken from the instance node identity).
- Nested paths like `{{property.foo}}` are supported via `lodash.get`.
- Object/array values are rendered with `JSON.stringify` so direct relations and lists render as readable strings instead of `[object Object]`.
- Error handling for invalid templates:
  - Unknown root key (typo, not in the view schema) → emitted as `:field` so the user sees the bad reference inline.
  - Known field whose value is `null`/`undefined` → emitted as the literal `null` for top-level paths, or `:nested.path` for nested misses.
- When the label has no variables, no extra DMS calls are made and the previous `space:externalId` fallback is preserved.

New helper `fetchCogniteTimeSeriesInstance` and pure helper `interpolateCogniteTimeSeriesInstanceLabel` are introduced in `src/cdf/client.ts`. The pure helper is unit-tested for all four cases above.

### 2. Stricter unit validation and clearer storage-unit display

- `getTimeSeriesProperties` now only treats the structured `unit` direct relation (`{ space, externalId }`) as a resolvable storage unit. The free-text `sourceUnit` and string-typed `unit` values are no longer surfaced, since they cannot be resolved against the CogniteUnit catalog and were causing the `Target Unit` field to render incorrectly. Also without `unit`reference unit conversion fails, so we should not render `Target Unit` at all.
- The "Unit: …" inline text next to the Search field is removed.
- A `Badge` reading "Storage unit: …" is rendered next to the `Target Unit` select, on the same row, so the source unit context lives where conversion is actually configured.
- Removed the trailing `gf-form-group` wrapper that produced extra padding under the last row of the tab.

## Test plan

- [x] `npx jest --ci` — 23 suites, 355 tests, all green.
- [ ] In Grafana, on a CogniteTimeSeries query:
  - [ ] Set Label to `{{name}} | {{property.foo}} | {{nope}} | {{nullableField}}` and verify each token renders per the rules above (object as JSON, typo as `:nope`, null as `null`).
  - [ ] Pick a time series whose `unit.externalId` is set and confirm `Target Unit` renders with the "Storage unit: …" chip on the same row.
  - [ ] Pick a time series with only `sourceUnit` (free text) and confirm `Target Unit` is hidden.
  - [ ] Confirm the previously visible padding gap below the last row is gone.