### PR TITLE
# Add support for State time series (beta)

### DIFF
--- a/src/__tests__/cdf.client.test.ts
+++ b/src/__tests__/cdf.client.test.ts
@@ -1,4 +1,4 @@
-import { Err, Ok } from '../types';
+import { Err, Ok, Tab, defaultCogniteTimeSeries } from '../types';
 import {
   datapoints2Tuples,
   reduceTimeseries,
@@ -85,6 +85,294 @@ describe('CDF client', () => {
       expect(reduced.datapoints).toEqual([[0, 1549336675000]]);
       expect(reduced.target).toEqual(`${id}`);
     });
+
+    it('fans out state TS stateDuration: one series per state, 0 when absent, sorted by numericValue', () => {
+      const target = {
+        tab: Tab.CogniteTimeSeriesSearch,
+        aggregation: 'stateDuration',
+        cogniteTimeSeries: {
+          ...defaultCogniteTimeSeries,
+          type: 'state' as const,
+          instanceId: { space: 's1', externalId: 'ts1' },
+          displayAsNumeric: false,
+        },
+      };
+
+      const metaResponses: any[] = [
+        {
+          result: {
+            data: {
+              items: [
+                {
+                  id: 1,
+                  externalId: 'x',
+                  datapoints: [
+                    {
+                      timestamp: 1000,
+                      stateAggregates: [
+                        { numericValue: 1, stringValue: 'ON', stateDuration: 200 },
+                        { numericValue: 0, stringValue: 'OFF', stateDuration: 100 },
+                      ],
+                    },
+                    {
+                      timestamp: 2000,
+                      stateAggregates: [
+                        { numericValue: 0, stringValue: 'OFF', stateDuration: 50 },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            config: { data: { aggregates: 'stateDuration' } },
+          },
+          metadata: {
+            labels: ['s1:ts1'],
+            target,
+            type: 'data',
+          },
+        },
+      ];
+
+      const reduced = reduceTimeseries(metaResponses, [0, 5000]);
+      expect(reduced).toHaveLength(2);
+      expect(reduced[0].target).toBe('s1:ts1 - OFF');
+      expect(reduced[1].target).toBe('s1:ts1 - ON');
+      expect(reduced[0].datapoints).toEqual([
+        [100, 1000],
+        [50, 2000],
+      ]);
+      expect(reduced[1].datapoints).toEqual([
+        [200, 1000],
+        [0, 2000],
+      ]);
+    });
+
+    it('replaces {{$state}} with state label only (no base suffix)', () => {
+      const target = {
+        tab: Tab.CogniteTimeSeriesSearch,
+        aggregation: 'stateDuration',
+        cogniteTimeSeries: {
+          ...defaultCogniteTimeSeries,
+          type: 'state' as const,
+          instanceId: { space: 's1', externalId: 'ts1' },
+        },
+      };
+
+      const metaResponses: any[] = [
+        {
+          result: {
+            data: {
+              items: [
+                {
+                  id: 1,
+                  datapoints: [
+                    {
+                      timestamp: 1000,
+                      stateAggregates: [
+                        { numericValue: 0, stringValue: 'OFF', stateDuration: 1 },
+                        { numericValue: 1, stringValue: 'ON', stateDuration: 2 },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            config: { data: { aggregates: 'stateDuration' } },
+          },
+          metadata: {
+            labels: ['{{$state}}'],
+            target,
+            type: 'data',
+          },
+        },
+      ];
+
+      const reduced = reduceTimeseries(metaResponses, [0, 5000]);
+      expect(reduced.map((s) => s.target)).toEqual(['OFF', 'ON']);
+    });
+
+    it('embeds {{$state}} inside a custom label without extra " - "', () => {
+      const target = {
+        tab: Tab.CogniteTimeSeriesSearch,
+        aggregation: 'stateDuration',
+        cogniteTimeSeries: {
+          ...defaultCogniteTimeSeries,
+          type: 'state' as const,
+          instanceId: { space: 's1', externalId: 'ts1' },
+        },
+      };
+
+      const metaResponses: any[] = [
+        {
+          result: {
+            data: {
+              items: [
+                {
+                  id: 1,
+                  datapoints: [
+                    {
+                      timestamp: 1000,
+                      stateAggregates: [
+                        { numericValue: 0, stringValue: 'OFF', stateDuration: 1 },
+                        { numericValue: 1, stringValue: 'ON', stateDuration: 2 },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            config: { data: { aggregates: 'stateDuration' } },
+          },
+          metadata: {
+            labels: ['Status: {{$state}}'],
+            target,
+            type: 'data',
+          },
+        },
+      ];
+
+      const reduced = reduceTimeseries(metaResponses, [0, 5000]);
+      expect(reduced.map((s) => s.target)).toEqual(['Status: OFF', 'Status: ON']);
+    });
+
+    it('does not append " - <state>" when user provided a custom Label without {{$state}}', () => {
+      const target = {
+        tab: Tab.CogniteTimeSeriesSearch,
+        aggregation: 'stateDuration',
+        label: '{{name}}',
+        cogniteTimeSeries: {
+          ...defaultCogniteTimeSeries,
+          type: 'state' as const,
+          instanceId: { space: 's1', externalId: 'ts1' },
+        },
+      };
+
+      const metaResponses: any[] = [
+        {
+          result: {
+            data: {
+              items: [
+                {
+                  id: 1,
+                  datapoints: [
+                    {
+                      timestamp: 1000,
+                      stateAggregates: [
+                        { numericValue: 0, stringValue: 'OFF', stateDuration: 1 },
+                        { numericValue: 1, stringValue: 'ON', stateDuration: 2 },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            config: { data: { aggregates: 'stateDuration' } },
+          },
+          metadata: {
+            labels: ['Pump'],
+            target,
+            type: 'data',
+          },
+        },
+      ];
+
+      const reduced = reduceTimeseries(metaResponses, [0, 5000]);
+      expect(reduced.map((s) => s.target)).toEqual(['Pump', 'Pump']);
+    });
+
+    it('always uses string state name in suffix, even when displayAsNumeric is set', () => {
+      const target = {
+        tab: Tab.CogniteTimeSeriesSearch,
+        aggregation: 'stateDuration',
+        cogniteTimeSeries: {
+          ...defaultCogniteTimeSeries,
+          type: 'state' as const,
+          instanceId: { space: 's1', externalId: 'ts1' },
+          displayAsNumeric: true,
+        },
+      };
+
+      const metaResponses: any[] = [
+        {
+          result: {
+            data: {
+              items: [
+                {
+                  id: 1,
+                  datapoints: [
+                    {
+                      timestamp: 1000,
+                      stateAggregates: [
+                        { numericValue: 1, stringValue: 'ON', stateDuration: 5 },
+                        { numericValue: 0, stringValue: 'OFF', stateDuration: 3 },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            config: { data: { aggregates: 'stateDuration' } },
+          },
+          metadata: {
+            labels: ['base'],
+            target,
+            type: 'data',
+          },
+        },
+      ];
+
+      const [a, b] = reduceTimeseries(metaResponses, [0, 5000]);
+      expect(a.target).toBe('base - OFF');
+      expect(b.target).toBe('base - ON');
+    });
+
+    it('pulls stateCount from each state entry', () => {
+      const target = {
+        tab: Tab.CogniteTimeSeriesSearch,
+        aggregation: 'stateCount',
+        cogniteTimeSeries: {
+          ...defaultCogniteTimeSeries,
+          type: 'state' as const,
+          instanceId: { space: 's1', externalId: 'ts1' },
+        },
+      };
+
+      const metaResponses: any[] = [
+        {
+          result: {
+            data: {
+              items: [
+                {
+                  id: 1,
+                  datapoints: [
+                    {
+                      timestamp: 500,
+                      stateAggregates: [
+                        { numericValue: 0, stringValue: 'A', stateCount: 2 },
+                        { numericValue: 2, stringValue: 'B', stateCount: 7 },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            config: { data: { aggregates: 'stateCount' } },
+          },
+          metadata: {
+            labels: ['lbl'],
+            target,
+            type: 'data',
+          },
+        },
+      ];
+
+      const out = reduceTimeseries(metaResponses, [0, 1000]);
+      expect(out).toHaveLength(2);
+      expect(out.map((s) => s.target)).toEqual(['lbl - A', 'lbl - B']);
+      expect(out[0].datapoints).toEqual([[2, 500]]);
+      expect(out[1].datapoints).toEqual([[7, 500]]);
+    });
   });
 
   describe('concurrent', () => {
@@ -149,6 +437,19 @@ describe('CDF client', () => {
       );
 
       expect(out).toBe('inst_s/inst_e/N');
+    });
+
+    it('preserves reserved {{$state}} through interpolation alongside view props', () => {
+      const props = { space: 'inst_s', externalId: 'inst_e', name: 'Pump' };
+      const viewProps = ['name'];
+
+      const out = interpolateCogniteTimeSeriesInstanceLabel(
+        '{{name}} {{$state}}',
+        props,
+        viewProps
+      );
+
+      expect(out).toBe('Pump {{$state}}');
     });
   });
 

--- a/src/__tests__/connector.featureFlags.test.ts
+++ b/src/__tests__/connector.featureFlags.test.ts
@@ -27,6 +27,7 @@ describe("Connector Feature Flags", () => {
         false,
         false,
         false, // deprecated features (3 total)
+        false, // enableStateTimeSeries
       );
       expect(connectorEnabled.isCogniteTimeSeriesEnabled()).toBe(true);
 
@@ -50,6 +51,7 @@ describe("Connector Feature Flags", () => {
         false,
         false,
         false, // deprecated features (3 total)
+        false, // enableStateTimeSeries
       );
       expect(connectorMasterDisabled.isCogniteTimeSeriesEnabled()).toBe(false);
 
@@ -73,6 +75,7 @@ describe("Connector Feature Flags", () => {
         false,
         false,
         false, // deprecated features (3 total)
+        false, // enableStateTimeSeries
       );
       expect(connectorFeatureDisabled.isCogniteTimeSeriesEnabled()).toBe(false);
 
@@ -96,8 +99,57 @@ describe("Connector Feature Flags", () => {
         false,
         false,
         false, // deprecated features (3 total)
+        false, // enableStateTimeSeries
       );
       expect(connectorBothDisabled.isCogniteTimeSeriesEnabled()).toBe(false);
+    });
+
+    it("should enable state time series only when core, Cognite Time Series, and state flags are enabled", () => {
+      const connectorAllOn = new Connector(
+        project,
+        protocol,
+        fetcher,
+        false,
+        false,
+        true, // enableCoreDataModelFeatures
+        true, // enableLegacyDataModelFeatures
+        true, // enableCogniteTimeSeries
+        true, // enableCogniteActivities
+        true, // enableFlexibleDataModelling
+        true,
+        true,
+        true,
+        true,
+        true, // legacy features (5 total)
+        false,
+        false,
+        false, // deprecated features (3 total)
+        true, // enableStateTimeSeries
+      );
+      expect(connectorAllOn.isStateTimeSeriesEnabled()).toBe(true);
+
+      const connectorStateOff = new Connector(
+        project,
+        protocol,
+        fetcher,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false, // enableStateTimeSeries
+      );
+      expect(connectorStateOff.isStateTimeSeriesEnabled()).toBe(false);
     });
 
     it("should enable CogniteActivities only when both master and feature flags are enabled", () => {
@@ -120,6 +172,7 @@ describe("Connector Feature Flags", () => {
         false,
         false,
         false, // deprecated features (3 total)
+        false, // enableStateTimeSeries
       );
       expect(connectorEnabled.isCogniteActivitiesEnabled()).toBe(true);
 
@@ -142,6 +195,7 @@ describe("Connector Feature Flags", () => {
         false,
         false,
         false, // deprecated features (3 total)
+        false, // enableStateTimeSeries
       );
       expect(connectorMasterDisabled.isCogniteActivitiesEnabled()).toBe(false);
 
@@ -164,6 +218,7 @@ describe("Connector Feature Flags", () => {
         false,
         false,
         false, // deprecated features (3 total)
+        false, // enableStateTimeSeries
       );
       expect(connectorFeatureDisabled.isCogniteActivitiesEnabled()).toBe(false);
 
@@ -186,6 +241,7 @@ describe("Connector Feature Flags", () => {
         false,
         false,
         false, // deprecated features (3 total)
+        false, // enableStateTimeSeries
       );
       expect(connectorBothDisabled.isCogniteActivitiesEnabled()).toBe(false);
     });
@@ -211,6 +267,7 @@ describe("Connector Feature Flags", () => {
         false,
         false,
         false, // deprecated features (3 total)
+        false, // enableStateTimeSeries
       );
       expect(connectorEnabled.isFlexibleDataModellingEnabled()).toBe(true);
 
@@ -234,6 +291,7 @@ describe("Connector Feature Flags", () => {
         false,
         false,
         false, // deprecated features (3 total)
+        false, // enableStateTimeSeries
       );
       expect(connectorMasterDisabled.isFlexibleDataModellingEnabled()).toBe(
         false,
@@ -259,6 +317,7 @@ describe("Connector Feature Flags", () => {
         false,
         false,
         false, // deprecated features (3 total)
+        false, // enableStateTimeSeries
       );
       expect(connectorFeatureDisabled.isFlexibleDataModellingEnabled()).toBe(
         false,
@@ -288,6 +347,7 @@ describe("Connector Feature Flags", () => {
         false,
         false,
         false, // deprecated features (3 total)
+        false, // enableStateTimeSeries
       );
       expect(connectorEnabled.isTimeseriesSearchEnabled()).toBe(true);
 
@@ -311,6 +371,7 @@ describe("Connector Feature Flags", () => {
         false,
         false,
         false, // deprecated features (3 total)
+        false, // enableStateTimeSeries
       );
       expect(connectorMasterDisabled.isTimeseriesSearchEnabled()).toBe(false);
 
@@ -334,6 +395,7 @@ describe("Connector Feature Flags", () => {
         false,
         false,
         false, // deprecated features (3 total)
+        false, // enableStateTimeSeries
       );
       expect(connectorFeatureDisabled.isTimeseriesSearchEnabled()).toBe(false);
     });
@@ -359,6 +421,7 @@ describe("Connector Feature Flags", () => {
         false,
         false,
         false, // deprecated features (3 total)
+        false, // enableStateTimeSeries
       );
       expect(connectorEnabled.isEventsAdvancedFilteringEnabled()).toBe(true);
 
@@ -382,6 +445,7 @@ describe("Connector Feature Flags", () => {
         false,
         false,
         false, // deprecated features (3 total)
+        false, // enableStateTimeSeries
       );
       expect(connectorMasterDisabled.isEventsAdvancedFilteringEnabled()).toBe(
         false,
@@ -407,6 +471,7 @@ describe("Connector Feature Flags", () => {
         false,
         false,
         false, // deprecated features (3 total)
+        false, // enableStateTimeSeries
       );
       expect(connectorFeatureDisabled.isEventsAdvancedFilteringEnabled()).toBe(
         false,
@@ -433,6 +498,7 @@ describe("Connector Feature Flags", () => {
         false,
         false,
         false, // deprecated features (3 total)
+        false, // enableStateTimeSeries
       );
 
       expect(connector.isTimeseriesSearchEnabled()).toBe(true);
@@ -462,6 +528,7 @@ describe("Connector Feature Flags", () => {
         false,
         false,
         false, // deprecated features (3 total)
+        false, // enableStateTimeSeries
       );
 
       expect(connector.isTimeseriesSearchEnabled()).toBe(false);
@@ -493,6 +560,7 @@ describe("Connector Feature Flags", () => {
         true,
         true,
         true, // all deprecated features enabled
+        false, // enableStateTimeSeries
       );
 
       // Deprecated features should work regardless of master toggles
@@ -521,6 +589,7 @@ describe("Connector Feature Flags", () => {
         false,
         false,
         false, // all deprecated features disabled
+        false, // enableStateTimeSeries
       );
 
       expect(connector.isTemplatesEnabled()).toBe(false);
@@ -550,6 +619,7 @@ describe("Connector Feature Flags", () => {
         true,
         true,
         true, // deprecated features
+        false, // enableStateTimeSeries
       );
 
       // Core features should work (master enabled)

--- a/src/__tests__/connector.test.ts
+++ b/src/__tests__/connector.test.ts
@@ -21,10 +21,10 @@ describe('connector', () => {
     const method = HttpMethod.POST;
     const path = '/ø';
     const url = `${protocol}/cdf-oauth/${API_V1}/${project}${path}`;
-    const reqBase = { url, method };
+    const reqBase = { url, method, headers: undefined };
 
     beforeEach(() => {
-      connector = new Connector(project, protocol, fetcher, false, false, true, true, true, true, true, true, true, true, true, true, true);
+      connector = new Connector(project, protocol, fetcher, false, false, true, true, true, true, true, true, true, true, true, true, true, false);
     });
 
     it('should not chunk under the limit', async () => {
@@ -83,7 +83,7 @@ describe('connector', () => {
     };
 
     beforeEach(() => {
-      connector = new Connector(project, protocol, fetcher, false, false, true, true, true, true, true, true, true, true, true, true, true);
+      connector = new Connector(project, protocol, fetcher, false, false, true, true, true, true, true, true, true, true, true, true, true, false);
     });
 
     it('returns all 10k elements', async () => {
@@ -123,7 +123,7 @@ describe('connector', () => {
     const response = async () => ({ data: { items: [1] } });
 
     beforeEach(() => {
-      connector = new Connector(project, protocol, fetcher, false, false, true, true, true, true, true, true, true, true, true, true, true);
+      connector = new Connector(project, protocol, fetcher, false, false, true, true, true, true, true, true, true, true, true, true, true, false);
       jest.useFakeTimers();
     });
 
@@ -189,7 +189,7 @@ describe('connector', () => {
     const request = { path: '' };
 
     beforeEach(() => {
-      connector = new Connector(project, protocol, fetcher, true, false, true, true, true, true, true, true, true, true, true, true, true);
+      connector = new Connector(project, protocol, fetcher, true, false, true, true, true, true, true, true, true, true, true, true, true, false);
     });
 
     it('uses cdf-oauth route when oauthPassThru=true', async () => {
@@ -206,7 +206,7 @@ describe('connector', () => {
     const request = { path: '' };
 
     beforeEach(() => {
-      connector = new Connector(project, protocol, fetcher, false, true, true, true, true, true, true, true, true, true, true, true, true);
+      connector = new Connector(project, protocol, fetcher, false, true, true, true, true, true, true, true, true, true, true, true, true, false);
     });
 
     it('uses cdf-cc-oauth route when oauthClientCreds=true', async () => {

--- a/src/__tests__/datasource.unit.test.ts
+++ b/src/__tests__/datasource.unit.test.ts
@@ -1,10 +1,20 @@
 import { dateTime } from '@grafana/data';
 import { formQueryForItems } from '../cdf/client';
 import { Connector } from '../connector';
-import { defaultQuery, CogniteQuery, QueryOptions } from '../types';
+import { defaultQuery, CogniteQuery, QueryOptions, Tab, defaultCogniteTimeSeries } from '../types';
 import { getDataQueryRequestItems } from '../datasources/TimeseriesDatasource';
 
 const defaultCogniteQuery = defaultQuery as CogniteQuery;
+
+const stateTsQueryBase: CogniteQuery = {
+  ...(defaultQuery as CogniteQuery),
+  tab: Tab.CogniteTimeSeriesSearch,
+  cogniteTimeSeries: {
+    ...defaultCogniteTimeSeries,
+    type: 'state',
+    instanceId: { space: 'sp', externalId: 'ts1' },
+  },
+};
 
 describe('getDataQueryRequestItems: generate cdf data points request items', () => {
   const connector: Connector = {
@@ -107,5 +117,25 @@ describe('formQueryForItems: enrich items with additional props for request', ()
         },
       ],
     });
+  });
+
+  it.each([
+    ['stateDuration', ['stateDuration']],
+    ['stateCount', ['stateCount']],
+    ['stateTransitions', ['stateTransitions']],
+  ] as const)('for state CogniteTimeSeries %s forwards aggregates', (aggregation, expectedAggregates) => {
+    const queryItems = formQueryForItems(
+      {
+        items: [{ externalId: 'ext' }],
+        type: 'data',
+        target: {
+          ...stateTsQueryBase,
+          aggregation,
+        },
+      },
+      queryOptions
+    );
+
+    expect(queryItems.aggregates).toEqual(expectedAggregates);
   });
 });

--- a/src/__tests__/unitConversion.test.ts
+++ b/src/__tests__/unitConversion.test.ts
@@ -343,7 +343,7 @@ describe('Unit Conversion', () => {
         externalId: 'test-ts',
       });
 
-      expect(result).toEqual({ type: 'numeric', unit: 'temperature:deg_c' });
+      expect(result).toEqual({ type: 'numeric', unit: 'temperature:deg_c', stateSet: undefined });
       expect(mockConnector.fetchItems).toHaveBeenCalledTimes(1);
     });
 

--- a/src/cdf/client.ts
+++ b/src/cdf/client.ts
@@ -59,6 +59,13 @@ import { filterdataSetIds, filterExternalId, filterLabels } from './helper';
 const { Asset, Custom, Timeseries } = Tab;
 const variableLabelRegex = /{{([^{}]+)}}/g;
 
+/** Per-bucket `stateAggregates[]` with one series per state in the panel. */
+const STATE_MULTI_AGGREGATES = new Set([
+  'stateDuration',
+  'stateCount',
+  'stateTransitions',
+]);
+
 export function formQueryForItems(
   { items, type, target }: QueriesDataItem,
   { range, intervalMs, timeZone }: QueryOptions & { timeZone: string }
@@ -79,23 +86,37 @@ export function formQueryForItems(
       };
     }
     default: {
-      let aggregations: Aggregates & Granularity & TimeZone = null;
+      const isStateTS = cogniteTimeSeries?.type === 'state';
       const isAggregated = aggregation && aggregation !== 'none';
+      let aggregations: Aggregates & Granularity & TimeZone = null;
       if (isAggregated) {
+        let aggregates: string[];
+        if (isStateTS) {
+          if (STATE_MULTI_AGGREGATES.has(aggregation)) {
+            aggregates = [aggregation];
+          } else if (aggregation === 'count') {
+            aggregates = ['count'];
+          } else {
+            // dominantState: single series from stateDuration; API still returns stateAggregates
+            aggregates = ['stateDuration'];
+          }
+        } else {
+          aggregates = [aggregation];
+        }
         aggregations = {
-          aggregates: [aggregation],
+          aggregates,
           granularity: granularity || toGranularityWithLowerBound(intervalMs),
           timeZone,
         };
       }
       const limit = calculateDPLimitPerQuery(items.length, isAggregated);
-      
-      // Add targetUnit to items if specified for CogniteTimeSeries queries
-      const targetUnit = cogniteTimeSeries?.targetUnit;
+
+      // Add targetUnit to items if specified for numeric CogniteTimeSeries queries (state TS doesn't use units)
+      const targetUnit = !isStateTS ? cogniteTimeSeries?.targetUnit : undefined;
       const itemsWithUnit = targetUnit
         ? items.map((item) => item.instanceId ? { ...item, targetUnit } : item)
         : items;
-      
+
       return {
         ...aggregations,
         end,
@@ -208,6 +229,9 @@ export function interpolateCogniteTimeSeriesInstanceLabel(
   // schema), but are exposed in `props` and useful in labels.
   const validPropNames = new Set([...viewPropertyNames, 'space', 'externalId']);
   return labelSrc.replace(variableLabelRegex, (_full, group) => {
+    if (group.startsWith('$')) {
+      return `{{${group}}}`;
+    }
     const rootKey = group.split('.')[0];
     if (!validPropNames.has(rootKey)) {
       return `:${group}`;
@@ -291,6 +315,83 @@ function generateTargetTsLabel(
   return type === 'latest' ? idEither : `${aggregateStr}${idEither}`;
 }
 
+type StateAggregateEntry = {
+  numericValue?: number;
+  stringValue?: string;
+  stateCount?: number;
+  stateTransitions?: number;
+  stateDuration?: number;
+};
+
+type StateBucket = {
+  timestamp: number;
+  stateAggregates?: StateAggregateEntry[];
+};
+
+/** Replaces all `{{$state}}` occurrences in a multi-state series label. */
+const STATE_TOKEN_RE = /\{\{\s*\$state\s*\}\}/g;
+
+function pickStateLabel(state: { numericValue: number; stringValue?: string }): string {
+  return state.stringValue ?? String(state.numericValue);
+}
+
+function valueFromStateEntry(
+  entry: StateAggregateEntry | undefined,
+  field: 'stateDuration' | 'stateCount' | 'stateTransitions'
+): number {
+  if (!entry) return 0;
+  switch (field) {
+    case 'stateDuration':
+      return entry.stateDuration ?? 0;
+    case 'stateCount':
+      return entry.stateCount ?? 0;
+    case 'stateTransitions':
+      return entry.stateTransitions ?? 0;
+    default:
+      return 0;
+  }
+}
+
+/** One Grafana series per distinct state; missing entries in a bucket become 0. */
+function expandMultiStateSeries(
+  datapoints: StateBucket[],
+  baseLabel: string,
+  field: 'stateDuration' | 'stateCount' | 'stateTransitions',
+  appendStateSuffix: boolean
+): TimeSeries[] {
+  const seen = new Map<number, { numericValue: number; stringValue?: string }>();
+  for (const bucket of datapoints) {
+    for (const e of bucket.stateAggregates ?? []) {
+      if (e.numericValue === undefined) continue;
+      if (!seen.has(e.numericValue)) {
+        seen.set(e.numericValue, {
+          numericValue: e.numericValue,
+          stringValue: e.stringValue,
+        });
+      }
+    }
+  }
+  const states = Array.from(seen.values()).sort((a, b) => a.numericValue - b.numericValue);
+  return states.map((state) => {
+    const suffix = pickStateLabel(state);
+    const replaced = baseLabel.replace(STATE_TOKEN_RE, suffix);
+    const target =
+      replaced !== baseLabel
+        ? replaced
+        : appendStateSuffix
+          ? `${baseLabel} - ${suffix}`
+          : baseLabel;
+    const datapointsOut: Array<[number, number]> = datapoints.map((bucket) => {
+      const entry = (bucket.stateAggregates ?? []).find(
+        (e) => e.numericValue === state.numericValue
+      );
+      const v = valueFromStateEntry(entry, field);
+      return [v, bucket.timestamp];
+    });
+    return { target, datapoints: datapointsOut };
+  });
+}
+
 export function reduceTimeseries(
   metaResponses: SuccessResponse[],
   [start, end]: Tuple<number>
@@ -298,26 +399,112 @@ export function reduceTimeseries(
   const responseTimeseries: TimeSeries[] = [];
 
   metaResponses.forEach(({ result, metadata }) => {
-    const { labels, type } = metadata;
+    const { labels, type, target } = metadata;
     const { aggregates } = result.config.data;
     const { items } = result.data;
 
-    const series = items.map(({ datapoints, externalId, id }, i) => {
+    const isStateTS = target?.cogniteTimeSeries?.type === 'state';
+    let stateAggregation = isStateTS
+      ? (type === 'latest' ? 'none' : target?.aggregation)
+      : undefined;
+    const stateAsNumeric = isStateTS && !!target?.cogniteTimeSeries?.displayAsNumeric;
+    const useStateReducer = isStateTS && stateAggregation !== 'count';
+    const isMultiStateAgg =
+      isStateTS &&
+      !!stateAggregation &&
+      STATE_MULTI_AGGREGATES.has(stateAggregation);
+
+    const series = items.flatMap(({ datapoints, externalId, id }, i) => {
       const label = labels && labels[i];
-      const resTarget = label || generateTargetTsLabel(id, aggregates, type, externalId);
+      const baseLabel = label || generateTargetTsLabel(id, aggregates, type, externalId);
       const dpsInRange =
         type === 'latest' ? datapoints : filterDpsOutOfRange(datapoints, start, end);
-      const rawDatapoints = datapoints2Tuples(dpsInRange, aggregates);
-      return {
-        target: resTarget,
-        datapoints: rawDatapoints,
-      };
+
+      if (isMultiStateAgg && stateAggregation) {
+        // Only auto-append " - <state>" for the default label (user left Label blank).
+        const appendStateSuffix = !target?.label;
+        return expandMultiStateSeries(
+          dpsInRange as StateBucket[],
+          baseLabel,
+          stateAggregation as 'stateDuration' | 'stateCount' | 'stateTransitions',
+          appendStateSuffix
+        );
+      }
+
+      const tuples = useStateReducer
+        ? stateDatapoints2Tuples(dpsInRange, stateAggregation, stateAsNumeric)
+        : datapoints2Tuples(dpsInRange, aggregates);
+      return [
+        {
+          target: baseLabel,
+          datapoints: tuples,
+        } as TimeSeries,
+      ];
     });
 
-    responseTimeseries.push(...series);
+    responseTimeseries.push(...(series as TimeSeries[]));
   });
 
   return responseTimeseries;
+}
+
+type StateValue = number | string | null;
+type StateTuple = [StateValue, number];
+
+const entryValue = (
+  e: StateAggregateEntry | undefined,
+  asNumeric: boolean
+): StateValue => {
+  if (!e) return null;
+  if (asNumeric) return e.numericValue ?? null;
+  return e.stringValue ?? e.numericValue ?? null;
+};
+
+function reduceStateBucket(
+  bucket: StateBucket,
+  aggregation: string,
+  asNumeric: boolean
+): StateValue {
+  const entries = bucket.stateAggregates;
+  if (!entries || entries.length === 0) {
+    return null;
+  }
+  switch (aggregation) {
+    case 'dominantState': {
+      let dominant = entries[0];
+      for (const e of entries) {
+        if ((e.stateDuration ?? 0) > (dominant.stateDuration ?? 0)) {
+          dominant = e;
+        }
+      }
+      return entryValue(dominant, asNumeric);
+    }
+    default:
+      return null;
+  }
+}
+
+export function stateDatapoints2Tuples(
+  datapoints: any[],
+  aggregation: string | undefined,
+  asNumeric = false
+): StateTuple[] {
+  if (!aggregation || aggregation === 'none') {
+    return datapoints
+      .map((dp): StateTuple | null => {
+        const value: StateValue = asNumeric
+          ? (dp.numericValue ?? null)
+          : (dp.stringValue ?? dp.numericValue ?? null);
+        return value === null ? null : [value, dp.timestamp];
+      })
+      .filter((t): t is StateTuple => t !== null);
+  }
+  return datapoints
+    .map((bucket: StateBucket): StateTuple | null => {
+      const value = reduceStateBucket(bucket, aggregation, asNumeric);
+      return value === null ? null : [value, bucket.timestamp];
+    })
+    .filter((t): t is StateTuple => t !== null);
 }
 
 export function datapoints2Tuples<T extends Timestamp[]>(
@@ -642,6 +829,12 @@ export async function fetchCogniteUnits(
 export interface TimeSeriesProperties {
   unit?: string;
   type?: string;
+  stateSet?: { space: string; externalId: string };
+}
+
+export interface StateSetEntry {
+  numericValue: number;
+  stringValue: string;
 }
 
 export async function getTimeSeriesProperties(
@@ -686,7 +879,14 @@ export async function getTimeSeriesProperties(
       const rawType = tsProps?.type;
       const type = typeof rawType === 'string' ? rawType : undefined;
 
-      return { unit, type };
+      const rawStateSet = tsProps?.stateSet;
+      const stateSet = rawStateSet && typeof rawStateSet === 'object'
+        && typeof rawStateSet.space === 'string'
+        && typeof rawStateSet.externalId === 'string'
+          ? { space: rawStateSet.space, externalId: rawStateSet.externalId }
+          : undefined;
+
+      return { unit, type, stateSet };
     }
   } catch (err) {
     console.warn('Failed to fetch timeseries properties:', err);
@@ -699,6 +899,58 @@ export async function getTimeSeriesUnit(
   instanceId: { space: string; externalId: string }
 ): Promise<string | undefined> {
   return (await getTimeSeriesProperties(connector, instanceId)).unit;
+}
+
+// Fetch the entries of a CogniteStateSet by its instance reference.
+// Returns the list of { numericValue, stringValue } pairs that the state TS can resolve to.
+export async function getStateSetStates(
+  connector: Connector,
+  ref: { space: string; externalId: string }
+): Promise<StateSetEntry[]> {
+  if (!connector.isStateTimeSeriesEnabled()) {
+    return [];
+  }
+  try {
+    const instances = await retryOnRateLimit(() =>
+      connector.fetchItems<DMSInstance>({
+        method: HttpMethod.POST,
+        path: '/models/instances/byids',
+        data: {
+          sources: [{
+            source: {
+              type: 'view',
+              space: 'cdf_cdm',
+              externalId: 'CogniteStateSet',
+              version: 'v1',
+            },
+          }],
+          items: [{
+            instanceType: 'node',
+            space: ref.space,
+            externalId: ref.externalId,
+          }],
+          includeTyping: false,
+        },
+        headers: { 'cdf-version': 'beta' },
+      })
+    );
+
+    if (!instances.length) return [];
+    const props = instances[0].properties?.['cdf_cdm']?.['CogniteStateSet/v1'];
+    const rawStates = Array.isArray(props?.states) ? props.states : [];
+    return rawStates
+      .map((s: any): StateSetEntry | null => {
+        const numericValue = typeof s?.numericValue === 'number' ? s.numericValue : undefined;
+        const stringValue = typeof s?.stringValue === 'string' ? s.stringValue : undefined;
+        if (numericValue === undefined || stringValue === undefined) return null;
+        return { numericValue, stringValue };
+      })
+      .filter((s: StateSetEntry | null): s is StateSetEntry => s !== null)
+      .sort((a: StateSetEntry, b: StateSetEntry) => a.numericValue - b.numericValue);
+  } catch (err) {
+    console.warn('Failed to fetch state set states:', err);
+    return [];
+  }
 }
 
 // Fetch the full property bag of a CogniteTimeSeries instance from a specific view, so
@@ -714,23 +966,19 @@ export async function fetchCogniteTimeSeriesInstance(
         method: HttpMethod.POST,
         path: '/models/instances/byids',
         data: {
-          sources: [
-            {
-              source: {
-                type: 'view',
-                space: viewSpec.space,
-                externalId: viewSpec.externalId,
-                version: viewSpec.version,
-              },
+          sources: [{
+            source: {
+              type: 'view',
+              space: viewSpec.space,
+              externalId: viewSpec.externalId,
+              version: viewSpec.version,
             },
-          ],
-          items: [
-            {
-              instanceType: 'node',
-              space: instanceId.space,
-              externalId: instanceId.externalId,
-            },
-          ],
+          }],
+          items: [{
+            instanceType: 'node',
+            space: instanceId.space,
+            externalId: instanceId.externalId,
+          }],
           includeTyping: false,
         },
       })

--- a/src/cdf/client.ts
+++ b/src/cdf/client.ts
@@ -339,7 +339,9 @@ function valueFromStateEntry(
   entry: StateAggregateEntry | undefined,
   field: 'stateDuration' | 'stateCount' | 'stateTransitions'
 ): number {
-  if (!entry) return 0;
+  if (!entry) {
+    return 0;
+  }
   switch (field) {
     case 'stateDuration':
       return entry.stateDuration ?? 0;
@@ -362,7 +364,9 @@ function expandMultiStateSeries(
   const seen = new Map<number, { numericValue: number; stringValue?: string }>();
   for (const bucket of datapoints) {
     for (const e of bucket.stateAggregates ?? []) {
-      if (e.numericValue === undefined) continue;
+      if (e.numericValue === undefined) {
+        continue;
+      }
       if (!seen.has(e.numericValue)) {
         seen.set(e.numericValue, {
           numericValue: e.numericValue,
@@ -455,8 +459,12 @@ const entryValue = (
   e: StateAggregateEntry | undefined,
   asNumeric: boolean
 ): StateValue => {
-  if (!e) return null;
-  if (asNumeric) return e.numericValue ?? null;
+  if (!e) {
+    return null;
+  }
+  if (asNumeric) {
+    return e.numericValue ?? null;
+  }
   return e.stringValue ?? e.numericValue ?? null;
 };
 
@@ -935,14 +943,18 @@ export async function getStateSetStates(
       })
     );
 
-    if (!instances.length) return [];
+    if (!instances.length) {
+      return [];
+    }
     const props = instances[0].properties?.['cdf_cdm']?.['CogniteStateSet/v1'];
     const rawStates = Array.isArray(props?.states) ? props.states : [];
     return rawStates
       .map((s: any): StateSetEntry | null => {
         const numericValue = typeof s?.numericValue === 'number' ? s.numericValue : undefined;
         const stringValue = typeof s?.stringValue === 'string' ? s.stringValue : undefined;
-        if (numericValue === undefined || stringValue === undefined) return null;
+        if (numericValue === undefined || stringValue === undefined) {
+          return null;
+        }
         return { numericValue, stringValue };
       })
       .filter((s: StateSetEntry | null): s is StateSetEntry => s !== null)

--- a/src/components/cogniteTimeSeriesSearchTab.tsx
+++ b/src/components/cogniteTimeSeriesSearchTab.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { Select, AsyncSelect, Alert, Badge, BadgeColor, InlineFieldRow, InlineField, InlineSwitch } from '@grafana/ui';
+import { Select, AsyncSelect, Alert, Badge, BadgeColor, InlineFieldRow, InlineField, InlineSwitch, Toggletip, Button, Tooltip, Icon } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
-import { SelectedProps } from '../types';
-import { searchDMSInstances, fetchCogniteUnits, getTimeSeriesProperties, stringifyError, fetchCogniteTimeSeriesViews, fetchCogniteActivityViews } from '../cdf/client';
+import { SelectedProps, CogniteTimeSeries } from '../types';
+import { searchDMSInstances, fetchCogniteUnits, getTimeSeriesProperties, getStateSetStates, stringifyError, fetchCogniteTimeSeriesViews, fetchCogniteActivityViews, StateSetEntry } from '../cdf/client';
 import { DMSInstance, DMSSearchRequest, CogniteUnit, InvolvedView } from '../types/dms';
 import { CommonEditors, LabelEditor } from './commonEditors';
 import { Connector } from '../connector';
@@ -30,7 +30,7 @@ const LatestValueCheckbox = (props: SelectedProps) => {
         tooltip="Fetch the latest data point in the provided time range"
       >
         <InlineSwitch
-          label='Latest value'
+          label="Latest value"
           id={`latest-value-${query.refId}`}
           value={query.latestValue}
           onChange={({ currentTarget }) => onQueryChange({ latestValue: currentTarget.checked })}
@@ -39,6 +39,35 @@ const LatestValueCheckbox = (props: SelectedProps) => {
     </InlineFieldRow>
   );
 };
+
+const NUMERIC_AGGREGATIONS = new Set([
+  'none', 'average', 'max', 'min', 'count', 'sum', 'interpolation',
+  'stepInterpolation', 'continuousVariance', 'discreteVariance', 'totalVariation',
+]);
+const STATE_AGGREGATIONS = new Set([
+  'none',
+  'dominantState',
+  'count',
+  'stateDuration',
+  'stateCount',
+  'stateTransitions',
+]);
+
+// Returns a partial query update that snaps `aggregation` back to a valid value
+// for the newly selected TS type. Returns {} if the current aggregation is still valid.
+function normalizeAggregationForType(
+  type: CogniteTimeSeries['type'] | undefined,
+  current: string | undefined
+): { aggregation?: string } {
+  if (type === 'string') {
+    return current === 'none' ? {} : { aggregation: 'none' };
+  }
+  if (type === 'state') {
+    return current && STATE_AGGREGATIONS.has(current) ? {} : { aggregation: 'dominantState' };
+  }
+  // numeric (or unknown — fall back to numeric defaults)
+  return current && NUMERIC_AGGREGATIONS.has(current) ? {} : { aggregation: 'average' };
+}
 
 export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProps> = ({
   query,
@@ -51,6 +80,8 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
   const [units, setUnits] = useState<CogniteUnit[]>([]);
   const [timeSeriesUnit, setTimeSeriesUnit] = useState<string | undefined>(undefined);
   const [timeSeriesType, setTimeSeriesType] = useState<string | undefined>(undefined);
+  const [stateSetStates, setStateSetStates] = useState<StateSetEntry[]>([]);
+  const [loadingStateSet, setLoadingStateSet] = useState(false);
   const [loadingUnits, setLoadingUnits] = useState(false);
   
   // Activity overlay state
@@ -176,19 +207,42 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
       if (instanceId?.space && instanceId?.externalId) {
         setLoadingUnits(true);
         try {
-          const { unit, type } = await getTimeSeriesProperties(connector, instanceId);
+          const { unit, type, stateSet } = await getTimeSeriesProperties(connector, instanceId);
           setTimeSeriesUnit(unit);
           setTimeSeriesType(type);
+          if (type && cogniteTimeSeries.type !== type) {
+            const persistedType = type as CogniteTimeSeries['type'];
+            onQueryChange({
+              cogniteTimeSeries: {
+                ...cogniteTimeSeries,
+                type: persistedType,
+              },
+              ...normalizeAggregationForType(persistedType, query.aggregation),
+            });
+          }
+          if (type === 'state' && stateSet && connector.isStateTimeSeriesEnabled()) {
+            setLoadingStateSet(true);
+            try {
+              const states = await getStateSetStates(connector, stateSet);
+              setStateSetStates(states);
+            } finally {
+              setLoadingStateSet(false);
+            }
+          } else {
+            setStateSetStates([]);
+          }
         } catch (err) {
           console.warn('Failed to fetch timeseries properties:', stringifyError(err));
           setTimeSeriesUnit(undefined);
           setTimeSeriesType(undefined);
+          setStateSetStates([]);
         } finally {
           setLoadingUnits(false);
         }
       } else {
         setTimeSeriesUnit(undefined);
         setTimeSeriesType(undefined);
+        setStateSetStates([]);
       }
     };
     fetchProperties();
@@ -216,6 +270,7 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
 
   const handleTimeseriesSelection = (selectedTimeseries: SelectableValue | null) => {
     setTimeSeriesType(selectedTimeseries?.type);
+    const selectedType = selectedTimeseries?.type as CogniteTimeSeries['type'] | undefined;
     onQueryChange({
       cogniteTimeSeries: {
         ...cogniteTimeSeries,
@@ -226,9 +281,11 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
           space: selectedTimeseries.space,
           externalId: selectedTimeseries.externalId,
         } : undefined,
+        type: selectedType,
+        // Clear targetUnit when selecting a state TS (units don't apply)
+        ...(selectedType === 'state' ? { targetUnit: undefined } : {}),
       },
-      // String timeseries don't support aggregations — pin to 'none' on selection
-      ...(selectedTimeseries?.type === 'string' ? { aggregation: 'none' } : {}),
+      ...normalizeAggregationForType(selectedType, query.aggregation),
     });
   };
 
@@ -291,7 +348,9 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
   };
 
   const isUnitConversionEnabled = !!timeSeriesUnit && !!cogniteTimeSeries.instanceId;
+  const stateTimeSeriesFeatureEnabled = connector.isStateTimeSeriesEnabled();
   const isStateType = timeSeriesType === 'state';
+  const stateTsUiActive = isStateType && stateTimeSeriesFeatureEnabled;
 
   // Activity overlay handlers
   const handleActivityOverlayToggle = (checked: boolean) => {
@@ -398,11 +457,16 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
               )}
             />
           </InlineField>
+          {cogniteTimeSeries.instanceId && timeSeriesType && (!isStateType || stateTsUiActive) && (
+            <InlineField transparent style={{ alignItems: 'center' }}>
+              <Badge text={timeSeriesType} color={getTypeBadgeColor(timeSeriesType)} />
+            </InlineField>
+          )}
         </InlineFieldRow>
 
-        {cogniteTimeSeries.instanceId && isStateType && (
+        {cogniteTimeSeries.instanceId && isStateType && !stateTimeSeriesFeatureEnabled && (
           <Alert title="Unsupported time series type" severity="info">
-            State time series are not currently supported in Grafana.
+            State time series are not enabled for this data source. Ask an administrator to enable &quot;State time series (beta)&quot; in the data source Features tab.
           </Alert>
         )}
 
@@ -434,8 +498,8 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
           </InlineFieldRow>
         )}
 
-        {/* Activity Overlay Section - only show when time series is selected */}
-        {cogniteTimeSeries.instanceId && !isStateType && (
+        {/* Activity overlay — not offered for state TS unless the beta feature is enabled */}
+        {cogniteTimeSeries.instanceId && (!isStateType || stateTsUiActive) && (
           <>
             <InlineFieldRow>
               <InlineField
@@ -498,6 +562,98 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
               <CommonEditors
                 {...{ query, onQueryChange }}
                 hideAggregation={timeSeriesType === 'string'}
+                labelContext="cdmNumeric"
+              />
+            )}
+          </>
+        )}
+
+        {stateTsUiActive && (
+          <>
+            <InlineFieldRow>
+              <InlineField
+                label="Latest value"
+                labelWidth={14}
+                tooltip="Fetch the latest data point in the provided time range"
+              >
+                <InlineSwitch
+                  label="Latest value"
+                  id={`latest-value-${query.refId}`}
+                  value={query.latestValue}
+                  onChange={({ currentTarget }) => onQueryChange({ latestValue: currentTarget.checked })}
+                />
+              </InlineField>
+              {(query.latestValue || query.aggregation === 'dominantState' || query.aggregation === 'none') && (
+                <InlineField
+                  label="Numeric value"
+                  labelWidth={16}
+                  tooltip="Display the numeric state code instead of the textual state label"
+                >
+                  <InlineSwitch
+                    label="Numeric value"
+                    id={`state-display-numeric-${query.refId}`}
+                    value={!!cogniteTimeSeries.displayAsNumeric}
+                    onChange={({ currentTarget }) =>
+                      onQueryChange({
+                        cogniteTimeSeries: {
+                          ...cogniteTimeSeries,
+                          displayAsNumeric: currentTarget.checked,
+                        },
+                      })
+                    }
+                  />
+                </InlineField>
+              )}
+              {stateSetStates.length > 0 && (
+                <InlineField transparent>
+                  <Toggletip
+                    closeButton={false}
+                    content={
+                      <div style={{ maxHeight: '240px', overflowY: 'auto', display: 'inline-block', margin: '-8px 0' }}>
+                        <table style={{ borderCollapse: 'collapse', fontSize: '12px' }}>
+                          <tbody>
+                            {stateSetStates.map((s) => (
+                              <tr key={s.numericValue}>
+                                <td style={{
+                                  padding: '4px 16px 4px 0',
+                                  textAlign: 'left',
+                                  fontVariantNumeric: 'tabular-nums',
+                                  color: 'rgba(204, 204, 220, 0.65)',
+                                }}>
+                                  {s.numericValue}
+                                </td>
+                                <td style={{ padding: '4px 0', textAlign: 'left' }}>{s.stringValue}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    }
+                    placement="right"
+                  >
+                    <Button
+                      variant="secondary"
+                      size="md"
+                      disabled={loadingStateSet}
+                      style={{ fontSize: '12px' }}
+                    >
+                      <span style={{ display: 'inline-flex', alignItems: 'center', gap: '6px' }}>
+                        View state set
+                        <Tooltip content="Show the integer-to-label mapping for each entry in this state set.">
+                          <Icon name="info-circle" size="sm" />
+                        </Tooltip>
+                      </span>
+                    </Button>
+                  </Toggletip>
+                </InlineField>
+              )}
+            </InlineFieldRow>
+            {!query.latestValue && (
+              <CommonEditors
+                {...{ query, onQueryChange }}
+                hideAggregation={false}
+                isStateType
+                labelContext="cdmState"
               />
             )}
           </>
@@ -509,8 +665,13 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
           </Alert>
         )}
       </div>
-      {query.latestValue && !isStateType && (
-        <LabelEditor {...{ onQueryChange, query }} />
+      {query.latestValue && (!isStateType || stateTsUiActive) && (
+        <LabelEditor
+          {...{ onQueryChange, query }}
+          labelContext={
+            isStateType && stateTsUiActive ? 'cdmState' : 'cdmNumeric'
+          }
+        />
       )}
     </div>
   );

--- a/src/components/cogniteTimeSeriesSearchTab.tsx
+++ b/src/components/cogniteTimeSeriesSearchTab.tsx
@@ -246,6 +246,9 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
       }
     };
     fetchProperties();
+    // We intentionally re-run only when the selected instance changes; the latest
+    // `cogniteTimeSeries`, `onQueryChange`, and `query.aggregation` are captured via closure.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [connector, instanceIdKey, cogniteTimeSeries.instanceId]);
 
   // String timeseries don't support aggregations — pin aggregation to 'none'

--- a/src/components/commonEditors.tsx
+++ b/src/components/commonEditors.tsx
@@ -16,6 +16,28 @@ const aggregateOptions = [
   { value: 'totalVariation', label: 'Total Variation' },
 ];
 
+export const stateAggregateOptions = [
+  { value: 'none', label: 'None' },
+  { value: 'dominantState', label: 'Dominant State' },
+  { value: 'count', label: 'Count' },
+  { value: 'stateDuration', label: 'State Duration' },
+  { value: 'stateCount', label: 'State Count' },
+  { value: 'stateTransitions', label: 'State Transitions' },
+];
+
+export type LabelContext = 'legacy' | 'cdmNumeric' | 'cdmState';
+
+const LABEL_TOOLTIPS: Record<LabelContext, string> = {
+  legacy:
+    'Label for each time series. Access time series properties via {{property}}, e.g. {{description}}-{{metadata.key}}.',
+  cdmNumeric:
+    'Label for each time series. Access view properties via {{property}}, e.g. {{name}} or {{unit.externalId}}.',
+  cdmState:
+    'Label for each time series. Access view properties via {{property}}, e.g. {{name}}. ' +
+    'For the State Duration / State Count / State Transitions aggregations (which produce one series per state), ' +
+    'use the reserved {{$state}} token to embed the state name in the label.',
+};
+
 const GranularityEditor = (props: SelectedProps) => {
   const { query, onQueryChange } = props;
   return (
@@ -42,8 +64,9 @@ const GranularityEditor = (props: SelectedProps) => {
   );
 };
 
-const AggregationEditor = (props: SelectedProps) => {
-  const { query, onQueryChange } = props;
+const AggregationEditor = (props: SelectedProps & { isStateType?: boolean }) => {
+  const { query, onQueryChange, isStateType } = props;
+  const options = isStateType ? stateAggregateOptions : aggregateOptions;
   return (
     <InlineFieldRow>
       <InlineField
@@ -53,7 +76,7 @@ const AggregationEditor = (props: SelectedProps) => {
         <Select
           inputId={`aggregation-${query.refId}`}
           onChange={({ value }) => onQueryChange({ aggregation: value })}
-          options={aggregateOptions}
+          options={options}
           menuPosition="fixed"
           value={query.aggregation}
           className="width-10"
@@ -63,16 +86,15 @@ const AggregationEditor = (props: SelectedProps) => {
   );
 };
 
-export const LabelEditor = (props: SelectedProps) => {
-  const { query, onQueryChange } = props;
+export const LabelEditor = (props: SelectedProps & { labelContext?: LabelContext }) => {
+  const { query, onQueryChange, labelContext = 'legacy' } = props;
+  const tooltip = LABEL_TOOLTIPS[labelContext];
   return (
     <InlineSegmentGroup>
       <InlineField
         label="Label"
         labelWidth={10}
-        tooltip={
-          'Label for each time series. Can also access time series properties via {{property}}, e.g. {{description}}-{{metadata.key}}.'
-        }
+        tooltip={tooltip}
       >
         <Input
           id={`label-${query.refId}`}
@@ -86,10 +108,16 @@ export const LabelEditor = (props: SelectedProps) => {
   );
 };
 
-export const CommonEditors = ({ onQueryChange, query, ...etc }: SelectedProps & any) => (
+export const CommonEditors = ({
+  onQueryChange,
+  query,
+  ...etc
+}: SelectedProps & { visible?: boolean; hideAggregation?: boolean; isStateType?: boolean; labelContext?: LabelContext }) => (
   <InlineFieldRow>
-    {!etc?.hideAggregation && <AggregationEditor {...{ onQueryChange, query }} />}
+    {!etc?.hideAggregation && <AggregationEditor {...{ onQueryChange, query, isStateType: etc?.isStateType }} />}
     <GranularityEditor {...{ onQueryChange, query }} />
-    {!etc?.visible && <LabelEditor {...{ onQueryChange, query }} />}
+    {!etc?.visible && (
+      <LabelEditor {...{ onQueryChange, query, labelContext: etc?.labelContext ?? 'legacy' }} />
+    )}
   </InlineFieldRow>
 );

--- a/src/components/configEditor.tsx
+++ b/src/components/configEditor.tsx
@@ -54,6 +54,9 @@ const oAuthScopeTooltip =
 const enableCogniteTimeSeriesTooltip =
   `Enable the Time Series tab to browse and select time series instances from the Core Data Model (CogniteTimeSeries type).`;
 
+const enableStateTimeSeriesTooltip =
+  `Beta: enable querying state time series.`;
+
 const enableCogniteActivitiesTooltip =
   `Enable the Activities tab to query CogniteActivity instances from the Core Data Model.`;
 
@@ -140,6 +143,7 @@ export function ConfigEditor(props: ConfigEditorProps) {
     enableFlexibleDataModelling = FEATURE_DEFAULTS.enableFlexibleDataModelling,
     enableExtractionPipelines = FEATURE_DEFAULTS.enableExtractionPipelines,
     enableRelationships = FEATURE_DEFAULTS.enableRelationships,
+    enableStateTimeSeries = FEATURE_DEFAULTS.enableStateTimeSeries,
   } = jsonData;
 
   const onJsonDataChange = (
@@ -413,6 +417,23 @@ export function ConfigEditor(props: ConfigEditorProps) {
                       onChange={onJsonBoolValueChange("enableCogniteTimeSeries")}
                     />
                   </InlineFieldRow>
+                  {enableCogniteTimeSeries && (
+                    <InlineFieldRow style={{ marginBottom: "4px" }}>
+                      <InlineFormLabel
+                        htmlFor="enable-state-time-series"
+                        tooltip={enableStateTimeSeriesTooltip}
+                        width={FEATURE_LABEL_WIDTH}
+                      >
+                        State time series (beta)
+                      </InlineFormLabel>
+                      <InlineSwitch
+                        id="enable-state-time-series"
+                        label="State time series (beta)"
+                        value={enableStateTimeSeries}
+                        onChange={onJsonBoolValueChange("enableStateTimeSeries")}
+                      />
+                    </InlineFieldRow>
+                  )}
                   <InlineFieldRow style={{ marginBottom: "4px" }}>
                     <InlineFormLabel
                       htmlFor="enable-cognite-activities"

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -43,6 +43,8 @@ export class Connector {
     private enableTemplates?: boolean,
     private enableExtractionPipelines?: boolean,
     private enableRelationships?: boolean,
+    /** Beta CDM feature — requires Core + Cognite Time Series toggles */
+    private enableStateTimeSeries?: boolean,
   ) {}
 
   cachedRequests = new Map<string, Promise<any>>();
@@ -157,6 +159,15 @@ export class Connector {
   // Core data model (CDM) features
   isCogniteTimeSeriesEnabled() {
     return this.enableCoreDataModelFeatures && this.enableCogniteTimeSeries;
+  }
+
+  /** State time series (beta) */
+  isStateTimeSeriesEnabled() {
+    return (
+      this.enableCoreDataModelFeatures &&
+      this.enableCogniteTimeSeries &&
+      !!this.enableStateTimeSeries
+    );
   }
 
   isCogniteActivitiesEnabled() {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -112,6 +112,7 @@ export default class CogniteDatasource extends DataSourceWithBackend<
         FEATURE_DEFAULTS.enableFlexibleDataModelling,
       enableExtractionPipelines = FEATURE_DEFAULTS.enableExtractionPipelines,
       enableRelationships = FEATURE_DEFAULTS.enableRelationships,
+      enableStateTimeSeries = FEATURE_DEFAULTS.enableStateTimeSeries,
     } = jsonData;
     this.backendSrv = getBackendSrv();
     this.templateSrv = getTemplateSrv();
@@ -140,6 +141,7 @@ export default class CogniteDatasource extends DataSourceWithBackend<
       enableTemplates,
       enableExtractionPipelines,
       enableRelationships,
+      enableStateTimeSeries,
     );
     this.initSources(connector);
   }

--- a/src/datasources/TimeseriesDatasource.ts
+++ b/src/datasources/TimeseriesDatasource.ts
@@ -129,6 +129,11 @@ export async function getDataQueryRequestItems(
       break;
     }
     case Tab.CogniteTimeSeriesSearch: {
+      if (cogniteTimeSeries?.type === 'state' && !connector.isStateTimeSeriesEnabled()) {
+        throw new Error(
+          'State time series are disabled for this data source. Enable "State time series (beta)" in the data source Features tab.',
+        );
+      }
       // By this point, filterEmptyQueryTargets should have already filtered out empty queries
       items = [{
         instanceId: {
@@ -185,12 +190,17 @@ export class TimeseriesDatasource {
     const queryProxy = async ([data, metadata]: [CDFDataQueryRequest, ResponseMetadata]) => {
       const { target, type } = metadata;
       const chunkSize = type === 'synthetic' ? 10 : 100;
+      const useStateTsBetaHeader =
+        target.tab === Tab.CogniteTimeSeriesSearch &&
+        target.cogniteTimeSeries?.type === 'state' &&
+        this.connector.isStateTimeSeriesEnabled();
       const request = {
         data,
         path: datapointsPath(type),
         method: HttpMethod.POST,
         requestId: getRequestId(options, target),
-      };
+        ...(useStateTsBetaHeader ? { headers: { 'cdf-version': 'beta' } } : {}),
+      } as const;
 
       try {
         const result = await this.connector.chunkAndFetch<

--- a/src/featureDefaults.ts
+++ b/src/featureDefaults.ts
@@ -12,6 +12,8 @@ export const FEATURE_DEFAULTS = {
   enableCogniteTimeSeries: true,
   enableCogniteActivities: true,
   enableFlexibleDataModelling: true, // GraphQL / Data Models tab
+  /** State time series (beta) */
+  enableStateTimeSeries: false,
 
   // Legacy data model features - default to enabled for backward compatibility
   enableTimeseriesSearch: true,

--- a/src/test_utils.ts
+++ b/src/test_utils.ts
@@ -84,6 +84,7 @@ export const getMockedDataSource = (
     true, // enableTemplates
     true, // enableExtractionPipelines
     true, // enableRelationships
+    true, // enableStateTimeSeries (tests may exercise state TS paths)
   );
   ds.initSources(connector);
   return ds;

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,6 +121,8 @@ export interface CogniteTimeSeries {
   };
   targetUnit?: string;
   targetUnitSystem?: string;
+  type?: "numeric" | "state" | "string";
+  displayAsNumeric?: boolean;
 }
 
 export interface CogniteActivityQuery {
@@ -254,6 +256,8 @@ export interface CogniteDataSourceOptions extends DataSourceJsonData {
   enableLegacyDataModelFeatures?: boolean;
   // Core data model (CDM) features
   enableCogniteTimeSeries?: boolean;
+  /** Beta: state time series querying with cdf-version: beta on relevant APIs */
+  enableStateTimeSeries?: boolean;
   enableCogniteActivities?: boolean;
   enableFlexibleDataModelling?: boolean;
   // Legacy data model features


### PR DESCRIPTION
## Summary

Adds a new beta data source feature for querying CogniteTimeSeries instances of `type === 'state'` from the Core Data Model. State TS expose discrete states (e.g. `OFF`/`ON`, `CLEAR`/`CLOUDY`) and need their own aggregation set, label rendering, and request headers.

The feature is gated end-to-end behind a new `enableStateTimeSeries` toggle in the data source config (default off, requires the existing CogniteTimeSeries feature to be enabled).

<img width="1418" height="803" alt="image" src="https://github.com/user-attachments/assets/6965c0f8-68d2-4400-ba13-7a6845b427dd" />

<br>

<img width="1419" height="818" alt="image" src="https://github.com/user-attachments/assets/fbaefa5e-5087-4a30-a268-f252542e5f55" />

## What's new

### Data source config
- New **State time series (beta)** switch under the CDM features section.

<img width="413" height="387" alt="image" src="https://github.com/user-attachments/assets/4129ad6d-8fcc-4b96-ba51-377b08ce39fe" />
<br>

- `Connector.isStateTimeSeriesEnabled()` returns `true` only when the master CDM toggle, CogniteTimeSeries, and this new flag are all on.
- When enabled, `cdf-version: beta` is attached to datapoint requests for state TS targets.

### Query editor (CogniteTimeSeries tab)
- Detects state TS on selection, shows a `state` badge, hides numeric-only controls, and exposes:
  - **Latest value** toggle.
  - **Numeric value** toggle (display state code instead of label, useful for `none`/`dominantState`/Latest).
  - **View state set** popover listing the integer-to-label mapping for the bound state set.

<img width="998" height="343" alt="image" src="https://github.com/user-attachments/assets/bab42b0e-ca0c-44a3-94bf-f098fa9764c7" />
<br>

- New aggregations selectable for state TS:
  - `none` (raw datapoints) - > 1 value per timestamp (1 trace)
  - `dominantState` (computed client side based on the state with largest `stateDuration` for each time bucket) -> 1 value per timestamp (1 trace)
  - `count` -> 1 value per timestamp (1 trace)
  - `stateDuration` -> 1 value per state per timestamp (multiple traces)
  - `stateCount` -> 1 value per state per timestamp (multiple traces)
  - `stateTransitions` -> 1 value per state per timestamp (multiple traces)

<img width="1001" height="514" alt="image" src="https://github.com/user-attachments/assets/26665736-958d-4544-a689-ae2d58959cee" />
<br>

- Label tooltip is now context-aware (legacy / CDM-numeric&string / CDM-state) so the help text reflects the active editor.

<img width="991" height="293" alt="image" src="https://github.com/user-attachments/assets/51151bbf-1525-40f6-9a56-1a6846b78332" />
<br>

### Multi-state series fan-out
- For `stateDuration` / `stateCount` / `stateTransitions`, a single query is fanned out into one Grafana series per distinct state observed in the response (sorted by `numericValue`, missing entries in a bucket render as `0`).
- Series labels are built from `getLabelsForTarget` and customized per state:
  - **No user label**: defaults to `{space}:{externalId} - {stateName}`.
  - **Custom label with `{{$state}}`**: token is replaced per series, no `- {stateName}` suffix is appended.
  - **Custom label without `{{$state}}`**: used as-is for every series (the user opted out of differentiation).
- `{{$state}}` is a reserved token (`$` prefix is illegal in DMS property identifiers, so no collisions) that allows to render the specific item state when dealing with multiple traces.

## Tests

- New unit tests in [`src/__tests__/cdf.client.test.ts`](src/__tests__/cdf.client.test.ts) for the multi-state reducer (sort order, 0-fill, `{{$state}}` replacement, custom-label suppression) and `interpolateCogniteTimeSeriesInstanceLabel` token preservation.
- New `formQueryForItems` cases in [`src/__tests__/datasource.unit.test.ts`](src/__tests__/datasource.unit.test.ts) covering the three multi-state aggregate payloads.
- Feature-flag tests for `Connector.isStateTimeSeriesEnabled()` in [`src/__tests__/connector.featureFlags.test.ts`](src/__tests__/connector.featureFlags.test.ts).
- Full suite: 366 tests passing.

## How to enable

1. Open the data source settings page.
2. Under **Features → Core Data Model**, ensure **CogniteTimeSeries** is on.
3. Toggle **State time series (beta)** on.
4. In a panel, pick a CogniteTimeSeries view, search a state series, and choose one of the new aggregations. Use `{{$state}}` in the **Label** field to customize the per-state legend (e.g. `Pump: {{$state}}`).