### PR TITLE
Resolve {{unit}} label tokens against the effective data point unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 This article documents the ongoing improvements we're making to the **Cognite
 Data Source for Grafana**.
 
+## Unreleased
+
+### Features
+
+- CogniteTimeSeries labels now resolve `{{unit}}` against the unit the data points are actually returned in: the query's **Target Unit** when one is selected, otherwise the time series' storage unit
+- All `CogniteUnit` properties are available on the token, e.g. `{{unit.symbol}}`, `{{unit.name}}`, `{{unit.description}}`, `{{unit.quantity}}`, `{{unit.externalId}}`
+- A bare `{{unit}}` serializes the full resolved unit, so the properties available for dot notation are discoverable straight from the label
+- The `CogniteUnit` catalog is fetched and indexed once per connection and shared between the Target Unit selector and label interpolation, so unit tokens don't add a request per query
+
+### Fixes
+
+- The unit catalog fetch now follows pagination cursors, so catalogs with more than 1000 units are fully available in the Target Unit selector and in labels
+
 ## 4.5.1 - May 4th, 2026
 
 ### Features

--- a/src/__tests__/cdf.client.test.ts
+++ b/src/__tests__/cdf.client.test.ts
@@ -3,6 +3,7 @@ import {
   datapoints2Tuples,
   reduceTimeseries,
   labelContainsVariableProps,
+  labelReferencesProp,
   interpolateCogniteTimeSeriesInstanceLabel,
   concurrent,
   convertItemsToTable,
@@ -149,6 +150,66 @@ describe('CDF client', () => {
       );
 
       expect(out).toBe('inst_s/inst_e/N');
+    });
+
+    it('resolves unit properties injected by the caller, even if absent from the view', () => {
+      const props = {
+        space: 'inst_s',
+        externalId: 'inst_e',
+        name: 'TS-A',
+        unit: {
+          space: 'cdf_cdm_units',
+          externalId: 'volume_flow_rate:ft3-per-hr',
+          name: 'Cubic Foot Per Hour',
+          symbol: 'ft\u00b3/h',
+          quantity: 'Volume Flow Rate',
+        },
+      };
+
+      const out = interpolateCogniteTimeSeriesInstanceLabel(
+        '{{name}} - {{unit.symbol}} ({{unit.quantity}})',
+        props,
+        ['name']
+      );
+
+      expect(out).toBe('TS-A - ft\u00b3/h (Volume Flow Rate)');
+    });
+
+    it('does not treat inherited object properties as caller-injected props', () => {
+      const out = interpolateCogniteTimeSeriesInstanceLabel(
+        '{{toString}}/{{constructor}}',
+        { name: 'TS-A' },
+        ['name']
+      );
+
+      expect(out).toBe(':toString/:constructor');
+    });
+
+    it('serializes a bare {{unit}} so the available dot-notation props are discoverable', () => {
+      const unit = {
+        space: 'cdf_cdm_units',
+        externalId: 'volume_flow_rate:ft3-per-hr',
+        name: 'Cubic Foot Per Hour',
+        symbol: 'ft\u00b3/h',
+        quantity: 'Volume Flow Rate',
+      };
+
+      expect(interpolateCogniteTimeSeriesInstanceLabel('{{unit}}', { unit }, ['unit'])).toBe(
+        JSON.stringify(unit)
+      );
+    });
+  });
+
+  describe('labelReferencesProp', () => {
+    test.each([
+      ['{{unit}}', true],
+      ['{{unit.symbol}}', true],
+      ['{{name}} - {{unit.symbol}}', true],
+      ['{{name}}', false],
+      ['{{unitless}}', false],
+      ['', false],
+    ])('%s -> %s', (label, expected) => {
+      expect(labelReferencesProp(label, 'unit')).toBe(expected);
     });
   });
 

--- a/src/__tests__/unitConversion.test.ts
+++ b/src/__tests__/unitConversion.test.ts
@@ -1,8 +1,18 @@
-import { fetchCogniteUnits, getTimeSeriesUnit, getTimeSeriesProperties, formQueryForItems } from '../cdf/client';
+import {
+  fetchCogniteUnits,
+  getTimeSeriesUnit,
+  getTimeSeriesProperties,
+  formQueryForItems,
+  getCogniteUnitIndex,
+  clearCogniteUnitIndexCache,
+  resolveEffectiveUnit,
+  getLabelsForTarget,
+} from '../cdf/client';
 import { Connector } from '../connector';
 import { CogniteUnit, DMSInstance } from '../types/dms';
-import { HttpMethod, defaultQuery, CogniteQuery, QueryOptions } from '../types';
+import { HttpMethod, defaultQuery, CogniteQuery, QueryOptions, Tab, QueryTarget } from '../types';
 import { dateTime } from '@grafana/data';
+import { CacheTime } from '../constants';
 
 const defaultCogniteQuery = defaultQuery as CogniteQuery;
 
@@ -12,7 +22,10 @@ describe('Unit Conversion', () => {
   beforeEach(() => {
     mockConnector = {
       fetchItems: jest.fn(),
+      fetchData: jest.fn(),
+      fetchAndPaginate: jest.fn(),
     } as any;
+    clearCogniteUnitIndexCache(mockConnector);
   });
 
   describe('fetchCogniteUnits', () => {
@@ -60,11 +73,11 @@ describe('Unit Conversion', () => {
         },
       ];
 
-      mockConnector.fetchItems.mockResolvedValue(mockInstances);
+      mockConnector.fetchAndPaginate.mockResolvedValue(mockInstances);
 
       const units = await fetchCogniteUnits(mockConnector);
 
-      expect(mockConnector.fetchItems).toHaveBeenCalledWith({
+      expect(mockConnector.fetchAndPaginate).toHaveBeenCalledWith({
         method: HttpMethod.POST,
         path: '/models/instances/list',
         data: {
@@ -77,7 +90,7 @@ describe('Unit Conversion', () => {
             },
           }],
           instanceType: 'node',
-          limit: 1000,
+          limit: 5000,
           filter: {
             equals: {
               property: ['node', 'space'],
@@ -85,6 +98,7 @@ describe('Unit Conversion', () => {
             },
           },
         },
+        cacheTime: CacheTime.Units,
       });
 
       expect(units).toHaveLength(2);
@@ -101,7 +115,7 @@ describe('Unit Conversion', () => {
     });
 
     it('should return empty array on error', async () => {
-      mockConnector.fetchItems.mockRejectedValue(new Error('API Error'));
+      mockConnector.fetchAndPaginate.mockRejectedValue(new Error('API Error'));
 
       const units = await fetchCogniteUnits(mockConnector);
 
@@ -121,7 +135,7 @@ describe('Unit Conversion', () => {
         },
       ];
 
-      mockConnector.fetchItems.mockResolvedValue(mockInstances);
+      mockConnector.fetchAndPaginate.mockResolvedValue(mockInstances);
 
       const units = await fetchCogniteUnits(mockConnector);
 
@@ -443,5 +457,247 @@ describe('Unit Conversion', () => {
       expect(result.items[0]).not.toHaveProperty('targetUnit');
     });
   });
-});
 
+  describe('unit index cache', () => {
+    const unitInstance = (externalId: string, props: Record<string, any>): DMSInstance => ({
+      instanceType: 'node',
+      space: 'cdf_cdm_units',
+      externalId,
+      version: 1,
+      lastUpdatedTime: 1,
+      createdTime: 1,
+      properties: { cdf_cdm: { 'CogniteUnit/v1': props } },
+    });
+
+    const catalog = [
+      unitInstance('volume_flow_rate:m3-per-hr', {
+        name: 'M3_PER_HR',
+        description: 'Cubic Meter per Hour',
+        symbol: 'm³/h',
+        quantity: 'Volume Flow Rate',
+      }),
+      unitInstance('volume_flow_rate:ft3-per-hr', {
+        name: 'FT3_PER_HR',
+        description: 'Cubic Foot Per Hour',
+        symbol: 'ft³/h',
+        quantity: 'Volume Flow Rate',
+      }),
+    ];
+
+    it('fetches the catalog once per connector and indexes it by externalId', async () => {
+      mockConnector.fetchAndPaginate.mockResolvedValue(catalog);
+
+      const [first, second] = await Promise.all([
+        getCogniteUnitIndex(mockConnector),
+        getCogniteUnitIndex(mockConnector),
+      ]);
+      const third = await getCogniteUnitIndex(mockConnector);
+
+      expect(mockConnector.fetchAndPaginate).toHaveBeenCalledTimes(1);
+      expect(first).toBe(second);
+      expect(first).toBe(third);
+      expect(first.get('volume_flow_rate:ft3-per-hr')?.symbol).toBe('ft³/h');
+    });
+
+    it('does not cache an empty catalog, so a failed fetch is retried', async () => {
+      mockConnector.fetchAndPaginate.mockRejectedValueOnce(new Error('API Error'));
+      expect((await getCogniteUnitIndex(mockConnector)).size).toBe(0);
+
+      mockConnector.fetchAndPaginate.mockResolvedValue(catalog);
+      expect((await getCogniteUnitIndex(mockConnector)).size).toBe(2);
+      expect(mockConnector.fetchAndPaginate).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('resolveEffectiveUnit', () => {
+    const catalogUnits: CogniteUnit[] = [
+      {
+        space: 'cdf_cdm_units',
+        externalId: 'volume_flow_rate:m3-per-hr',
+        name: 'M3_PER_HR',
+        description: 'Cubic Meter per Hour',
+        symbol: 'm³/h',
+        quantity: 'Volume Flow Rate',
+      },
+      {
+        space: 'cdf_cdm_units',
+        externalId: 'volume_flow_rate:ft3-per-hr',
+        name: 'FT3_PER_HR',
+        description: 'Cubic Foot Per Hour',
+        symbol: 'ft³/h',
+        quantity: 'Volume Flow Rate',
+      },
+    ];
+
+    beforeEach(() => {
+      mockConnector.fetchAndPaginate.mockResolvedValue(
+        catalogUnits.map(({ space, externalId, ...props }) => ({
+          instanceType: 'node',
+          space,
+          externalId,
+          version: 1,
+          lastUpdatedTime: 1,
+          createdTime: 1,
+          properties: { cdf_cdm: { 'CogniteUnit/v1': props } },
+        })) as DMSInstance[]
+      );
+    });
+
+    const storageUnit = { space: 'cdf_cdm_units', externalId: 'volume_flow_rate:m3-per-hr' };
+
+    it('prefers the target unit over the storage unit', async () => {
+      const unit = await resolveEffectiveUnit(
+        mockConnector,
+        storageUnit,
+        'volume_flow_rate:ft3-per-hr'
+      );
+      expect(unit?.symbol).toBe('ft³/h');
+    });
+
+    it('falls back to the storage unit when no target unit is set', async () => {
+      const unit = await resolveEffectiveUnit(mockConnector, storageUnit, undefined);
+      expect(unit?.symbol).toBe('m³/h');
+    });
+
+    it('returns undefined when there is neither a storage nor a target unit', async () => {
+      expect(await resolveEffectiveUnit(mockConnector, undefined, undefined)).toBeUndefined();
+      expect(await resolveEffectiveUnit(mockConnector, 'deg_c', undefined)).toBeUndefined();
+      expect(mockConnector.fetchAndPaginate).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the identifier when the unit is not in the catalog', async () => {
+      const unit = await resolveEffectiveUnit(mockConnector, storageUnit, 'custom:unknown');
+      expect(unit).toEqual({
+        space: 'cdf_cdm_units',
+        externalId: 'custom:unknown',
+        name: 'custom:unknown',
+      });
+    });
+  });
+
+  describe('getLabelsForTarget with unit tokens', () => {
+    const target = (label: string, targetUnit?: string): QueryTarget =>
+      ({
+        ...defaultCogniteQuery,
+        tab: Tab.CogniteTimeSeriesSearch,
+        label,
+        cogniteTimeSeries: {
+          space: 'cdf_cdm',
+          version: 'v1',
+          externalId: 'CogniteTimeSeries',
+          instanceId: { space: 'my_space', externalId: 'TS_40_FT_201_PV' },
+          targetUnit,
+        },
+      }) as QueryTarget;
+
+    beforeEach(() => {
+      mockConnector.fetchItems.mockResolvedValue([
+        {
+          instanceType: 'node',
+          space: 'my_space',
+          externalId: 'TS_40_FT_201_PV',
+          properties: {
+            cdf_cdm: {
+              'CogniteTimeSeries/v1': {
+                name: '40-FT-201-PV',
+                unit: { space: 'cdf_cdm_units', externalId: 'volume_flow_rate:m3-per-hr' },
+              },
+            },
+          },
+        },
+      ]);
+      mockConnector.fetchAndPaginate.mockResolvedValue([
+        {
+          instanceType: 'node',
+          space: 'cdf_cdm_units',
+          externalId: 'volume_flow_rate:ft3-per-hr',
+          properties: {
+            cdf_cdm: {
+              'CogniteUnit/v1': {
+                name: 'FT3_PER_HR',
+                description: 'Cubic Foot Per Hour',
+                symbol: 'ft³/h',
+                quantity: 'Volume Flow Rate',
+              },
+            },
+          },
+        },
+        {
+          instanceType: 'node',
+          space: 'cdf_cdm_units',
+          externalId: 'volume_flow_rate:m3-per-hr',
+          properties: {
+            cdf_cdm: {
+              'CogniteUnit/v1': {
+                name: 'M3_PER_HR',
+                description: 'Cubic Meter per Hour',
+                symbol: 'm³/h',
+                quantity: 'Volume Flow Rate',
+              },
+            },
+          },
+        },
+      ]);
+      mockConnector.fetchData.mockResolvedValue({
+        data: { items: [{ properties: { name: {}, unit: {}, description: {} } }] },
+      } as any);
+    });
+
+    it('resolves {{unit.symbol}} to the target unit', async () => {
+      const labels = await getLabelsForTarget(
+        target('{{name}} - {{unit.symbol}}', 'volume_flow_rate:ft3-per-hr'),
+        [],
+        mockConnector
+      );
+      expect(labels).toEqual(['40-FT-201-PV - ft³/h']);
+    });
+
+    it('resolves {{unit.symbol}} to the storage unit when no target unit is set', async () => {
+      const labels = await getLabelsForTarget(
+        target('{{name}} - {{unit.symbol}}'),
+        [],
+        mockConnector
+      );
+      expect(labels).toEqual(['40-FT-201-PV - m³/h']);
+    });
+
+    it('serializes a bare {{unit}} as the resolved target unit, not the storage relation', async () => {
+      const labels = await getLabelsForTarget(
+        target('{{unit}}', 'volume_flow_rate:ft3-per-hr'),
+        [],
+        mockConnector
+      );
+      expect(labels).toEqual([
+        JSON.stringify({
+          space: 'cdf_cdm_units',
+          externalId: 'volume_flow_rate:ft3-per-hr',
+          name: 'FT3_PER_HR',
+          description: 'Cubic Foot Per Hour',
+          symbol: 'ft³/h',
+          quantity: 'Volume Flow Rate',
+        }),
+      ]);
+    });
+
+    it('serializes a bare {{unit}} as the storage unit when no conversion is set', async () => {
+      const labels = await getLabelsForTarget(target('{{unit}}'), [], mockConnector);
+      expect(labels).toEqual([
+        JSON.stringify({
+          space: 'cdf_cdm_units',
+          externalId: 'volume_flow_rate:m3-per-hr',
+          name: 'M3_PER_HR',
+          description: 'Cubic Meter per Hour',
+          symbol: 'm³/h',
+          quantity: 'Volume Flow Rate',
+        }),
+      ]);
+    });
+
+    it('skips the unit lookup when the label has no unit token', async () => {
+      const labels = await getLabelsForTarget(target('{{name}}'), [], mockConnector);
+
+      expect(labels).toEqual(['40-FT-201-PV']);
+      expect(mockConnector.fetchAndPaginate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/cdf/client.ts
+++ b/src/cdf/client.ts
@@ -58,6 +58,7 @@ import { filterdataSetIds, filterExternalId, filterLabels } from './helper';
 
 const { Asset, Custom, Timeseries } = Tab;
 const variableLabelRegex = /{{([^{}]+)}}/g;
+const UNITS_SPACE = 'cdf_cdm_units';
 
 export function formQueryForItems(
   { items, type, target }: QueriesDataItem,
@@ -156,7 +157,19 @@ export async function getLabelsForTarget(
             fetchCogniteTimeSeriesInstance(connector, viewSpec, target.cogniteTimeSeries.instanceId),
             fetchDMSViewProperties(connector, viewSpec),
           ]);
-          return [interpolateCogniteTimeSeriesInstanceLabel(labelSrc, props, viewProps)];
+          // `unit` on the instance is a direct relation to the storage unit, which is not
+          // what the data points are in once a target unit is applied. Swap in the fully
+          // resolved unit so `{{unit}}` and `{{unit.symbol}}` & co. describe the values
+          // actually plotted.
+          const effectiveUnit = labelReferencesProp(labelSrc, 'unit')
+            ? await resolveEffectiveUnit(
+                connector,
+                props.unit,
+                target.cogniteTimeSeries.targetUnit
+              )
+            : undefined;
+          const labelProps = effectiveUnit ? { ...props, unit: effectiveUnit } : props;
+          return [interpolateCogniteTimeSeriesInstanceLabel(labelSrc, labelProps, viewProps)];
         }
         return [labelSrc || instanceLabel];
       }
@@ -198,6 +211,11 @@ export function labelContainsVariableProps(label: string): boolean {
   return label && !!label.match(variableLabelRegex);
 }
 
+/** True when the label has a `{{prop}}` or `{{prop.path}}` token rooted at `prop`. */
+export function labelReferencesProp(label: string, prop: string): boolean {
+  return [...label.matchAll(variableLabelRegex)].some(([, group]) => group.split('.')[0] === prop);
+}
+
 /** Interpolate `{{property}}` tokens from a CogniteTimeSeries DMS instance + view schema. */
 export function interpolateCogniteTimeSeriesInstanceLabel(
   labelSrc: string,
@@ -209,7 +227,9 @@ export function interpolateCogniteTimeSeriesInstanceLabel(
   const validPropNames = new Set([...viewPropertyNames, 'space', 'externalId']);
   return labelSrc.replace(variableLabelRegex, (_full, group) => {
     const rootKey = group.split('.')[0];
-    if (!validPropNames.has(rootKey)) {
+    // Own props resolved by the caller (e.g. the effective `unit`) count as valid even when
+    // the view schema doesn't declare them.
+    if (!validPropNames.has(rootKey) && !Object.prototype.hasOwnProperty.call(props, rootKey)) {
       return `:${group}`;
     }
     const val = get(props, group);
@@ -217,6 +237,9 @@ export function interpolateCogniteTimeSeriesInstanceLabel(
       return group.includes('.') ? `:${group}` : 'null';
     }
     if (typeof val === 'object') {
+      // Serializing the whole object is deliberate: a bare `{{unit}}` shows the resolved
+      // unit's full property bag, which is how users discover what `{{unit.<prop>}}`
+      // paths are available.
       return JSON.stringify(val);
     }
     return String(val);
@@ -595,28 +618,31 @@ export async function fetchCogniteUnits(
   connector: Connector
 ): Promise<CogniteUnit[]> {
   try {
+    const listUnitsRequest: DMSListRequest = {
+      sources: [{
+        source: {
+          type: 'view',
+          space: 'cdf_cdm',
+          externalId: 'CogniteUnit',
+          version: 'v1',
+        },
+      }],
+      instanceType: 'node',
+      limit: 5000,
+      filter: {
+        equals: {
+          property: ['node', 'space'],
+          value: UNITS_SPACE,
+        },
+      },
+    };
     const instances = await retryOnRateLimit(() =>
-      connector.fetchItems<DMSInstance>({
+      // The catalog can exceed a single page, so follow cursors instead of a one-shot list.
+      connector.fetchAndPaginate<DMSInstance>({
         method: HttpMethod.POST,
         path: '/models/instances/list',
-        data: {
-          sources: [{
-            source: {
-              type: 'view',
-              space: 'cdf_cdm',
-              externalId: 'CogniteUnit',
-              version: 'v1',
-            },
-          }],
-          instanceType: 'node',
-          limit: 1000,
-          filter: {
-            equals: {
-              property: ['node', 'space'],
-              value: 'cdf_cdm_units',
-            },
-          },
-        },
+        data: listUnitsRequest,
+        cacheTime: CacheTime.Units,
       })
     );
     
@@ -637,6 +663,77 @@ export async function fetchCogniteUnits(
     console.warn('Failed to fetch units:', err);
     return [];
   }
+}
+
+/**
+ * The CogniteUnit catalog is static reference data shared by every query, so keep a
+ * per-connector index of it in memory instead of refetching (and re-indexing) it for each
+ * label interpolation. Backed by the connector request cache, so a cold start still costs
+ * at most one request.
+ */
+const unitIndexCache = new WeakMap<Connector, Promise<Map<string, CogniteUnit>>>();
+
+export async function getCogniteUnitIndex(
+  connector: Connector
+): Promise<Map<string, CogniteUnit>> {
+  const cached = unitIndexCache.get(connector);
+  if (cached) {
+    return cached;
+  }
+  const pending = fetchCogniteUnits(connector).then(
+    (units) => {
+      // `fetchCogniteUnits` swallows failures and returns `[]`; don't pin an empty catalog
+      // in the cache forever, let the next label interpolation retry.
+      if (!units.length) {
+        unitIndexCache.delete(connector);
+      }
+      return new Map(units.map((unit) => [unit.externalId, unit]));
+    },
+    (err) => {
+      unitIndexCache.delete(connector);
+      throw err;
+    }
+  );
+  unitIndexCache.set(connector, pending);
+  return pending;
+}
+
+/** Test seam: drops the in-memory unit index for a connector. */
+export function clearCogniteUnitIndexCache(connector: Connector) {
+  unitIndexCache.delete(connector);
+}
+
+/**
+ * Resolve the unit the returned data points are actually expressed in: the query's
+ * `targetUnit` when one is set, otherwise the time series' storage unit. The result is
+ * enriched from the unit catalog so labels can reference `{{unit.symbol}}`,
+ * `{{unit.name}}`, `{{unit.quantity}}` and the rest of the CogniteUnit properties.
+ */
+export async function resolveEffectiveUnit(
+  connector: Connector,
+  storageUnit: unknown,
+  targetUnit?: string
+): Promise<CogniteUnit | undefined> {
+  const storageUnitRef =
+    storageUnit && typeof storageUnit === 'object' ? (storageUnit as Partial<CogniteUnit>) : undefined;
+  const externalId =
+    targetUnit ||
+    (typeof storageUnitRef?.externalId === 'string' ? storageUnitRef.externalId : undefined);
+  if (!externalId) {
+    return undefined;
+  }
+  try {
+    const resolved = (await getCogniteUnitIndex(connector)).get(externalId);
+    if (resolved) {
+      return resolved;
+    }
+  } catch (err) {
+    console.warn('Failed to resolve unit for label:', err);
+  }
+  // Unknown unit (custom space, stale catalog, unreachable catalog): still expose the
+  // identifier so `{{unit}}` and `{{unit.externalId}}` resolve to something meaningful.
+  const space = targetUnit ? UNITS_SPACE : storageUnitRef?.space ?? UNITS_SPACE;
+  return { space, externalId, name: externalId };
 }
 
 export interface TimeSeriesProperties {

--- a/src/components/cogniteTimeSeriesSearchTab.tsx
+++ b/src/components/cogniteTimeSeriesSearchTab.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Select, AsyncSelect, Alert, Badge, BadgeColor, InlineFieldRow, InlineField, InlineSwitch } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { SelectedProps } from '../types';
-import { searchDMSInstances, fetchCogniteUnits, getTimeSeriesProperties, stringifyError, fetchCogniteTimeSeriesViews, fetchCogniteActivityViews } from '../cdf/client';
+import { searchDMSInstances, getCogniteUnitIndex, getTimeSeriesProperties, stringifyError, fetchCogniteTimeSeriesViews, fetchCogniteActivityViews } from '../cdf/client';
 import { DMSInstance, DMSSearchRequest, CogniteUnit, InvolvedView } from '../types/dms';
 import { CommonEditors, LabelEditor } from './commonEditors';
 import { Connector } from '../connector';
@@ -158,8 +158,10 @@ export const CogniteTimeSeriesSearchTab: React.FC<CogniteTimeSeriesSearchTabProp
     const loadUnits = async () => {
       try {
         setLoadingUnits(true);
-        const unitsData = await fetchCogniteUnits(connector);
-        setUnits(unitsData);
+        // Shares the cached catalog with label interpolation, so the units are fetched
+        // and indexed once per connector.
+        const unitIndex = await getCogniteUnitIndex(connector);
+        setUnits([...unitIndex.values()]);
       } catch (err) {
         console.warn('Failed to load units:', stringifyError(err));
       } finally {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,8 @@ export const responseWarningEvent = eventFactory<QueryWarning>('request-warning'
 export const CacheTime = {
   TimeseriesList: '61s',
   ResourceByIds: '61m',
+  // The CogniteUnit catalog is static reference data, so it can be cached aggressively.
+  Units: '61m',
   Default: '11s',
   Dropdown: '3m',
 };

--- a/tests/queryEditor.spec.ts
+++ b/tests/queryEditor.spec.ts
@@ -260,6 +260,12 @@ test('"Event query" as table is OK', async ({ page, gotoDashboardPage, readProvi
   const EVENTS_QUERY_PANEL_ID = '3';
   const panelEditPage = await dashboardPage.gotoPanelEditPage(EVENTS_QUERY_PANEL_ID)
 
+  // The test_event fixtures in the CDF project have fixed timestamps, so the dashboard's
+  // relative time range (now-1y) eventually stops matching them. Pin the window to a
+  // superset of the one that was current on the last green run (2026-05-12), when the
+  // events matched; the extra padding keeps it a superset in any local timezone.
+  await panelEditPage.timeRange.set({ from: '2025-05-01 00:00:00', to: '2026-05-14 00:00:00' });
+
   await expect(panelEditPage.panel.fieldNames).toContainText(["externalId", "description", "startTime", "endTime"]);
 
   const deleteColumnButtonPattern = /event-remove-col-/;


### PR DESCRIPTION
CogniteTimeSeries labels now interpolate {{unit}} and {{unit.<prop>}} against the unit the data points are actually returned in: the query's Target Unit when one is selected, otherwise the storage unit, enriched from the CogniteUnit catalog so symbol/name/quantity/etc. are available.

The catalog is fetched once per connection (in-memory promise index + 61m request cache) and shared with the Target Unit dropdown; the fetch now follows pagination cursors so catalogs beyond 1000 units resolve.

**Problem / User story**
Customer request here: https://hub.cognite.com/product-user-community-428/how-to-add-timeseries-target-unit-to-the-label-in-grafana-6712

**Solution**
Units from the catalog are already fetched in the connector to populate the target unit selector dropdown. This PR makes expands the unit direct relation associated with a datapoints request, exposing the unit property values when interpolating trace labels, so users can easily include the unit in the label using the {{unit.<prop>}} semantics.

**Affected Resource types**
CogniteTimeSeries tab.

**Have tests been updated?**
Yes

**Screenshots and examples**
<img width="1083" height="835" alt="image" src="https://github.com/user-attachments/assets/6049d51f-bdfa-46e0-86f3-0462bfb5910a" />
