### PR TITLE
chore: bump version to 4.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This article documents the ongoing improvements we're making to the **Cognite
 Data Source for Grafana**.
 
-## Unreleased
+## 4.5.2 - August 25th, 2026
 
 ### Features
 
@@ -12,7 +12,7 @@ Data Source for Grafana**.
 - A bare `{{unit}}` serializes the full resolved unit, so the properties available for dot notation are discoverable straight from the label
 - The `CogniteUnit` catalog is fetched and indexed once per connection and shared between the Target Unit selector and label interpolation, so unit tokens don't add a request per query
 
-### Fixes
+### Bug fixes
 
 - The unit catalog fetch now follows pagination cursors, so catalogs with more than 1000 units are fully available in the Target Unit selector and in labels
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/cognite-grafana-datasource",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "Cognite Data Fusion datasource",
   "repository": "https://github.com/cognitedata/cognite-grafana-datasource",
   "author": "Cognite AS",


### PR DESCRIPTION
## Summary

- Bumps version from 4.5.1 to 4.5.2
- Updates CHANGELOG.md with entries for all changes since the v4.5.1 tag

## Changes included in this release

**#668 — Resolve `{{unit}}` label tokens against the effective data point unit**
- CogniteTimeSeries labels now resolve `{{unit}}` against the query's Target Unit when selected, otherwise the time series' storage unit
- All `CogniteUnit` properties are available on the token (`{{unit.symbol}}`, `{{unit.name}}`, `{{unit.description}}`, `{{unit.quantity}}`, `{{unit.externalId}}`)
- A bare `{{unit}}` serializes the full resolved unit
- The `CogniteUnit` catalog is fetched and indexed once per connection and shared between the Target Unit selector and label interpolation
- The unit catalog fetch now follows pagination cursors, so catalogs with more than 1000 units are fully available

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)