### PR TITLE
Refactor feature flags into named options and one toggle row

### DIFF
--- a/src/__tests__/configEditorUtils.test.ts
+++ b/src/__tests__/configEditorUtils.test.ts
@@ -3,11 +3,9 @@ import {
   boolValueHandler, 
   secretValueHandler, 
   resetSecretHandler,
-  masterToggleHandler,
   sanitizeHostname,
   hostnameValueHandler
 } from '../configEditorUtils';
-import { FEATURE_DEFAULTS } from '../featureDefaults';
 
 describe('ConfigEditor Utility Functions', () => {
   let mockOnJsonDataChange: jest.Mock;
@@ -213,94 +211,4 @@ describe('ConfigEditor Utility Functions', () => {
     });
   });
 
-  describe('masterToggleHandler', () => {
-    it('should create a handler that enables master toggle and sets dependent features to defaults', () => {
-      const handler = masterToggleHandler(
-        'enableCoreDataModelFeatures',
-        ['enableCogniteTimeSeries', 'enableFlexibleDataModelling'],
-        mockOnJsonDataChange
-      );
-
-      const mockEvent = {
-        currentTarget: { checked: true }
-      } as React.ChangeEvent<HTMLInputElement>;
-
-      handler(mockEvent);
-
-      const call = mockOnJsonDataChange.mock.calls[0][0];
-      expect(call.enableCoreDataModelFeatures).toBe(true);
-      expect(call.enableCogniteTimeSeries).toBe(true); // Core features are enabled when master is enabled
-      expect(call.enableFlexibleDataModelling).toBe(true); // Core features are enabled when master is enabled
-    });
-
-    it('should create a handler that disables master toggle and sets dependent features to false', () => {
-      const handler = masterToggleHandler(
-        'enableCoreDataModelFeatures',
-        ['enableCogniteTimeSeries', 'enableFlexibleDataModelling'],
-        mockOnJsonDataChange
-      );
-
-      const mockEvent = {
-        currentTarget: { checked: false }
-      } as React.ChangeEvent<HTMLInputElement>;
-
-      handler(mockEvent);
-
-      const call = mockOnJsonDataChange.mock.calls[0][0];
-      expect(call.enableCoreDataModelFeatures).toBe(false);
-      expect(call.enableCogniteTimeSeries).toBe(false);
-      expect(call.enableFlexibleDataModelling).toBe(false);
-    });
-
-    it('should handle legacy data model features with correct defaults', () => {
-      const handler = masterToggleHandler(
-        'enableLegacyDataModelFeatures',
-        [
-          'enableTimeseriesSearch',
-          'enableTimeseriesFromAsset', 
-          'enableTimeseriesCustomQuery',
-          'enableEvents',
-          'enableEventsAdvancedFiltering'
-        ],
-        mockOnJsonDataChange
-      );
-
-      const mockEvent = {
-        currentTarget: { checked: true }
-      } as React.ChangeEvent<HTMLInputElement>;
-
-      handler(mockEvent);
-
-      const call = mockOnJsonDataChange.mock.calls[0][0];
-      expect(call.enableLegacyDataModelFeatures).toBe(true);
-      expect(call.enableTimeseriesSearch).toBe(FEATURE_DEFAULTS.enableTimeseriesSearch);
-      expect(call.enableTimeseriesFromAsset).toBe(FEATURE_DEFAULTS.enableTimeseriesFromAsset);
-      expect(call.enableTimeseriesCustomQuery).toBe(FEATURE_DEFAULTS.enableTimeseriesCustomQuery);
-      expect(call.enableEvents).toBe(FEATURE_DEFAULTS.enableEvents);
-      expect(call.enableEventsAdvancedFiltering).toBe(FEATURE_DEFAULTS.enableEventsAdvancedFiltering);
-      
-      // Verify that enableEventsAdvancedFiltering matches the default
-      expect(call.enableEventsAdvancedFiltering).toBe(false);
-      expect(FEATURE_DEFAULTS.enableEventsAdvancedFiltering).toBe(false);
-    });
-
-    it('should create a handler for legacy features that uses defaults when enabling', () => {
-      const handler = masterToggleHandler(
-        'enableLegacyDataModelFeatures',
-        ['enableTimeseriesSearch', 'enableEvents'],
-        mockOnJsonDataChange
-      );
-
-      const mockEvent = {
-        currentTarget: { checked: true }
-      } as React.ChangeEvent<HTMLInputElement>;
-
-      handler(mockEvent);
-
-      const call = mockOnJsonDataChange.mock.calls[0][0];
-      expect(call.enableLegacyDataModelFeatures).toBe(true);
-      expect(call.enableTimeseriesSearch).toBe(FEATURE_DEFAULTS.enableTimeseriesSearch); // Legacy uses defaults
-      expect(call.enableEvents).toBe(FEATURE_DEFAULTS.enableEvents); // Legacy uses defaults
-    });
   });
-});

--- a/src/__tests__/connector.featureFlags.test.ts
+++ b/src/__tests__/connector.featureFlags.test.ts
@@ -1,570 +1,119 @@
-import { Connector } from "../connector";
+import { Connector, ConnectorOptions } from "../connector";
+import { FeatureKey } from "../featureDefaults";
 
-describe("Connector Feature Flags", () => {
-  const project = "test";
-  const protocol = "protocol:/";
-  const fetcher = { fetch: jest.fn() };
+const project = "test";
+const protocol = "protocol:/";
+const fetcher = { fetch: jest.fn() };
 
-  describe("Core data model (CDM) features", () => {
-    it("should enable CogniteTimeSeries only when both master and feature flags are enabled", () => {
-      // Both master and feature enabled
-      const connectorEnabled = new Connector(
-        project,
-        protocol,
-        fetcher,
-        false,
-        false,
-        true, // enableCoreDataModelFeatures
-        true, // enableLegacyDataModelFeatures
-        true, // enableCogniteTimeSeries
-        true, // enableCogniteActivities
-        true, // enableFlexibleDataModelling
-        true,
-        true,
-        true,
-        true,
-        true, // legacy features (5 total)
-        false,
-        false,
-        false, // deprecated features (3 total)
-      );
-      expect(connectorEnabled.isCogniteTimeSeriesEnabled()).toBe(true);
+const connectorWith = (options: ConnectorOptions) =>
+  new Connector(project, protocol, fetcher, options);
 
-      // Master disabled, feature enabled
-      const connectorMasterDisabled = new Connector(
-        project,
-        protocol,
-        fetcher,
-        false,
-        false,
-        false, // enableCoreDataModelFeatures - DISABLED
-        true, // enableLegacyDataModelFeatures
-        true, // enableCogniteTimeSeries
-        true, // enableCogniteActivities
-        true, // enableFlexibleDataModelling
-        true,
-        true,
-        true,
-        true,
-        true, // legacy features (5 total)
-        false,
-        false,
-        false, // deprecated features (3 total)
-      );
-      expect(connectorMasterDisabled.isCogniteTimeSeriesEnabled()).toBe(false);
+type Accessor = keyof {
+  [K in keyof Connector as Connector[K] extends () => boolean ? K : never]: true;
+};
 
-      // Master enabled, feature disabled
-      const connectorFeatureDisabled = new Connector(
-        project,
-        protocol,
-        fetcher,
-        false,
-        false,
-        true, // enableCoreDataModelFeatures
-        true, // enableLegacyDataModelFeatures
-        false, // enableCogniteTimeSeries - DISABLED
-        false, // enableCogniteActivities
-        true, // enableFlexibleDataModelling
-        true,
-        true,
-        true,
-        true,
-        true, // legacy features (5 total)
-        false,
-        false,
-        false, // deprecated features (3 total)
-      );
-      expect(connectorFeatureDisabled.isCogniteTimeSeriesEnabled()).toBe(false);
+/** Each gated feature, its master, and the accessor that answers for it. */
+const CDM_FEATURES: Array<[FeatureKey, Accessor]> = [
+  ["enableCogniteTimeSeries", "isCogniteTimeSeriesEnabled"],
+  ["enableCogniteActivities", "isCogniteActivitiesEnabled"],
+  ["enableFlexibleDataModelling", "isFlexibleDataModellingEnabled"],
+];
 
-      // Both disabled
-      const connectorBothDisabled = new Connector(
-        project,
-        protocol,
-        fetcher,
-        false,
-        false,
-        false, // enableCoreDataModelFeatures - DISABLED
-        true, // enableLegacyDataModelFeatures
-        false, // enableCogniteTimeSeries - DISABLED
-        false, // enableCogniteActivities
-        true, // enableFlexibleDataModelling
-        true,
-        true,
-        true,
-        true,
-        true, // legacy features (5 total)
-        false,
-        false,
-        false, // deprecated features (3 total)
-      );
-      expect(connectorBothDisabled.isCogniteTimeSeriesEnabled()).toBe(false);
+const LEGACY_FEATURES: Array<[FeatureKey, Accessor]> = [
+  ["enableTimeseriesSearch", "isTimeseriesSearchEnabled"],
+  ["enableTimeseriesFromAsset", "isTimeseriesFromAssetEnabled"],
+  ["enableTimeseriesCustomQuery", "isTimeseriesCustomQueryEnabled"],
+  ["enableEvents", "isEventsEnabled"],
+  ["enableEventsAdvancedFiltering", "isEventsAdvancedFilteringEnabled"],
+];
+
+const DEPRECATED_FEATURES: Array<[FeatureKey, Accessor]> = [
+  ["enableTemplates", "isTemplatesEnabled"],
+  ["enableExtractionPipelines", "isExtractionPipelinesEnabled"],
+  ["enableRelationships", "isRelationshipsEnabled"],
+];
+
+describe("Connector feature flags", () => {
+  // A gated feature needs its master *and* itself; the four combinations are
+  // enumerated rather than spot-checked, which is what the positional argument
+  // lists used to make impractical.
+  describe.each([
+    ["Core data model (CDM)", "enableCoreDataModelFeatures", CDM_FEATURES],
+    ["Legacy data model", "enableLegacyDataModelFeatures", LEGACY_FEATURES],
+  ] as const)("%s features", (_section, master, features) => {
+    it.each(features)("%s is on only with its master", (flag, accessor) => {
+      expect(connectorWith({ [master]: true, [flag]: true })[accessor]()).toBe(true);
+      expect(connectorWith({ [master]: false, [flag]: true })[accessor]()).toBe(false);
+      expect(connectorWith({ [master]: true, [flag]: false })[accessor]()).toBe(false);
+      expect(connectorWith({ [master]: false, [flag]: false })[accessor]()).toBe(false);
     });
 
-    it("should enable CogniteActivities only when both master and feature flags are enabled", () => {
-      const connectorEnabled = new Connector(
-        project,
-        protocol,
-        fetcher,
-        false,
-        false,
-        true, // enableCoreDataModelFeatures
-        true, // enableLegacyDataModelFeatures
-        true, // enableCogniteTimeSeries
-        true, // enableCogniteActivities
-        true, // enableFlexibleDataModelling
-        true,
-        true,
-        true,
-        true,
-        true, // legacy features (5 total)
-        false,
-        false,
-        false, // deprecated features (3 total)
+    it("reports every feature off when the master is off", () => {
+      const allOn = features.reduce(
+        (options, [flag]) => ({ ...options, [flag]: true }),
+        { [master]: false } as ConnectorOptions
       );
-      expect(connectorEnabled.isCogniteActivitiesEnabled()).toBe(true);
-
-      const connectorMasterDisabled = new Connector(
-        project,
-        protocol,
-        fetcher,
-        false,
-        false,
-        false, // enableCoreDataModelFeatures - DISABLED
-        true, // enableLegacyDataModelFeatures
-        true, // enableCogniteTimeSeries
-        true, // enableCogniteActivities
-        true, // enableFlexibleDataModelling
-        true,
-        true,
-        true,
-        true,
-        true, // legacy features (5 total)
-        false,
-        false,
-        false, // deprecated features (3 total)
-      );
-      expect(connectorMasterDisabled.isCogniteActivitiesEnabled()).toBe(false);
-
-      const connectorFeatureDisabled = new Connector(
-        project,
-        protocol,
-        fetcher,
-        false,
-        false,
-        true, // enableCoreDataModelFeatures
-        true, // enableLegacyDataModelFeatures
-        true, // enableCogniteTimeSeries
-        false, // enableCogniteActivities - DISABLED
-        true, // enableFlexibleDataModelling
-        true,
-        true,
-        true,
-        true,
-        true, // legacy features (5 total)
-        false,
-        false,
-        false, // deprecated features (3 total)
-      );
-      expect(connectorFeatureDisabled.isCogniteActivitiesEnabled()).toBe(false);
-
-      const connectorBothDisabled = new Connector(
-        project,
-        protocol,
-        fetcher,
-        false,
-        false,
-        false, // enableCoreDataModelFeatures - DISABLED
-        true, // enableLegacyDataModelFeatures
-        false, // enableCogniteTimeSeries
-        false, // enableCogniteActivities - DISABLED
-        true, // enableFlexibleDataModelling
-        true,
-        true,
-        true,
-        true,
-        true, // legacy features (5 total)
-        false,
-        false,
-        false, // deprecated features (3 total)
-      );
-      expect(connectorBothDisabled.isCogniteActivitiesEnabled()).toBe(false);
-    });
-
-    it("should enable FlexibleDataModelling only when both core master and feature flags are enabled", () => {
-      // Both enabled
-      const connectorEnabled = new Connector(
-        project,
-        protocol,
-        fetcher,
-        false,
-        false,
-        true, // enableCoreDataModelFeatures
-        true, // enableLegacyDataModelFeatures
-        false, // enableCogniteTimeSeries
-        false, // enableCogniteActivities
-        true, // enableFlexibleDataModelling
-        true,
-        true,
-        true,
-        true,
-        true, // legacy features (5 total)
-        false,
-        false,
-        false, // deprecated features (3 total)
-      );
-      expect(connectorEnabled.isFlexibleDataModellingEnabled()).toBe(true);
-
-      // Core master disabled
-      const connectorMasterDisabled = new Connector(
-        project,
-        protocol,
-        fetcher,
-        false,
-        false,
-        false, // enableCoreDataModelFeatures - DISABLED
-        true, // enableLegacyDataModelFeatures
-        false, // enableCogniteTimeSeries
-        false, // enableCogniteActivities
-        true, // enableFlexibleDataModelling
-        true,
-        true,
-        true,
-        true,
-        true, // legacy features (5 total)
-        false,
-        false,
-        false, // deprecated features (3 total)
-      );
-      expect(connectorMasterDisabled.isFlexibleDataModellingEnabled()).toBe(
-        false,
-      );
-
-      // Feature disabled
-      const connectorFeatureDisabled = new Connector(
-        project,
-        protocol,
-        fetcher,
-        false,
-        false,
-        true, // enableCoreDataModelFeatures
-        true, // enableLegacyDataModelFeatures
-        false, // enableCogniteTimeSeries
-        false, // enableCogniteActivities
-        false, // enableFlexibleDataModelling - DISABLED
-        true,
-        true,
-        true,
-        true,
-        true, // legacy features (5 total)
-        false,
-        false,
-        false, // deprecated features (3 total)
-      );
-      expect(connectorFeatureDisabled.isFlexibleDataModellingEnabled()).toBe(
-        false,
-      );
-    });
-  });
-
-  describe("Legacy data model features", () => {
-    it("should enable TimeseriesSearch only when both master and feature flags are enabled", () => {
-      // Both enabled
-      const connectorEnabled = new Connector(
-        project,
-        protocol,
-        fetcher,
-        false,
-        false,
-        false, // enableCoreDataModelFeatures
-        true, // enableLegacyDataModelFeatures
-        false, // enableCogniteTimeSeries
-        false, // enableCogniteActivities
-        false, // enableFlexibleDataModelling
-        true,
-        true,
-        true,
-        true,
-        true, // legacy features (enableTimeseriesSearch = true)
-        false,
-        false,
-        false, // deprecated features (3 total)
-      );
-      expect(connectorEnabled.isTimeseriesSearchEnabled()).toBe(true);
-
-      // Master disabled, feature enabled
-      const connectorMasterDisabled = new Connector(
-        project,
-        protocol,
-        fetcher,
-        false,
-        false,
-        false, // enableCoreDataModelFeatures
-        false, // enableLegacyDataModelFeatures - DISABLED
-        false, // enableCogniteTimeSeries
-        false, // enableCogniteActivities
-        false, // enableFlexibleDataModelling
-        true,
-        true,
-        true,
-        true,
-        true, // legacy features (enableTimeseriesSearch = true)
-        false,
-        false,
-        false, // deprecated features (3 total)
-      );
-      expect(connectorMasterDisabled.isTimeseriesSearchEnabled()).toBe(false);
-
-      // Master enabled, feature disabled
-      const connectorFeatureDisabled = new Connector(
-        project,
-        protocol,
-        fetcher,
-        false,
-        false,
-        false, // enableCoreDataModelFeatures
-        true, // enableLegacyDataModelFeatures
-        false, // enableCogniteTimeSeries
-        false, // enableCogniteActivities
-        false, // enableFlexibleDataModelling
-        false,
-        true,
-        true,
-        true,
-        true, // legacy features (enableTimeseriesSearch = false)
-        false,
-        false,
-        false, // deprecated features (3 total)
-      );
-      expect(connectorFeatureDisabled.isTimeseriesSearchEnabled()).toBe(false);
-    });
-
-    it("should enable EventsAdvancedFiltering only when both legacy master and feature flags are enabled", () => {
-      // Both enabled
-      const connectorEnabled = new Connector(
-        project,
-        protocol,
-        fetcher,
-        false,
-        false,
-        false, // enableCoreDataModelFeatures
-        true, // enableLegacyDataModelFeatures
-        false, // enableCogniteTimeSeries
-        false, // enableCogniteActivities
-        false, // enableFlexibleDataModelling
-        true,
-        true,
-        true,
-        true,
-        true, // legacy features (enableEventsAdvancedFiltering = true)
-        false,
-        false,
-        false, // deprecated features (3 total)
-      );
-      expect(connectorEnabled.isEventsAdvancedFilteringEnabled()).toBe(true);
-
-      // Legacy master disabled
-      const connectorMasterDisabled = new Connector(
-        project,
-        protocol,
-        fetcher,
-        false,
-        false,
-        false, // enableCoreDataModelFeatures
-        false, // enableLegacyDataModelFeatures - DISABLED
-        false, // enableCogniteTimeSeries
-        false, // enableCogniteActivities
-        false, // enableFlexibleDataModelling
-        true,
-        true,
-        true,
-        true,
-        true, // legacy features (enableEventsAdvancedFiltering = true)
-        false,
-        false,
-        false, // deprecated features (3 total)
-      );
-      expect(connectorMasterDisabled.isEventsAdvancedFilteringEnabled()).toBe(
-        false,
-      );
-
-      // Feature disabled
-      const connectorFeatureDisabled = new Connector(
-        project,
-        protocol,
-        fetcher,
-        false,
-        false,
-        false, // enableCoreDataModelFeatures
-        true, // enableLegacyDataModelFeatures
-        false, // enableCogniteTimeSeries
-        false, // enableCogniteActivities
-        false, // enableFlexibleDataModelling
-        true,
-        true,
-        true,
-        true,
-        false, // legacy features (enableEventsAdvancedFiltering = false)
-        false,
-        false,
-        false, // deprecated features (3 total)
-      );
-      expect(connectorFeatureDisabled.isEventsAdvancedFilteringEnabled()).toBe(
-        false,
-      );
-    });
-
-    it("should enable all legacy features when both master and individual flags are enabled", () => {
-      const connector = new Connector(
-        project,
-        protocol,
-        fetcher,
-        false,
-        false,
-        false, // enableCoreDataModelFeatures
-        true, // enableLegacyDataModelFeatures
-        false, // enableCogniteTimeSeries
-        false, // enableCogniteActivities
-        false, // enableFlexibleDataModelling
-        true,
-        true,
-        true,
-        true,
-        true, // all legacy features enabled
-        false,
-        false,
-        false, // deprecated features (3 total)
-      );
-
-      expect(connector.isTimeseriesSearchEnabled()).toBe(true);
-      expect(connector.isTimeseriesFromAssetEnabled()).toBe(true);
-      expect(connector.isTimeseriesCustomQueryEnabled()).toBe(true);
-      expect(connector.isEventsEnabled()).toBe(true);
-      expect(connector.isEventsAdvancedFilteringEnabled()).toBe(true);
-    });
-
-    it("should disable all legacy features when master is disabled", () => {
-      const connector = new Connector(
-        project,
-        protocol,
-        fetcher,
-        false,
-        false,
-        false, // enableCoreDataModelFeatures
-        false, // enableLegacyDataModelFeatures - DISABLED
-        false, // enableCogniteTimeSeries
-        false, // enableCogniteActivities
-        false, // enableFlexibleDataModelling
-        true,
-        true,
-        true,
-        true,
-        true, // all legacy features enabled but master disabled
-        false,
-        false,
-        false, // deprecated features (3 total)
-      );
-
-      expect(connector.isTimeseriesSearchEnabled()).toBe(false);
-      expect(connector.isTimeseriesFromAssetEnabled()).toBe(false);
-      expect(connector.isTimeseriesCustomQueryEnabled()).toBe(false);
-      expect(connector.isEventsEnabled()).toBe(false);
-      expect(connector.isEventsAdvancedFilteringEnabled()).toBe(false);
+      const connector = connectorWith(allOn);
+      features.forEach(([, accessor]) => expect(connector[accessor]()).toBe(false));
     });
   });
 
   describe("Deprecated features", () => {
-    it("should ignore master toggles for deprecated features", () => {
-      const connector = new Connector(
-        project,
-        protocol,
-        fetcher,
-        false,
-        false,
-        false, // enableCoreDataModelFeatures - disabled
-        false, // enableLegacyDataModelFeatures - disabled
-        false, // enableCogniteTimeSeries
-        false, // enableCogniteActivities
-        false, // enableFlexibleDataModelling
-        false,
-        false,
-        false,
-        false,
-        false, // all legacy features disabled
-        true,
-        true,
-        true, // all deprecated features enabled
-      );
-
-      // Deprecated features should work regardless of master toggles
-      expect(connector.isTemplatesEnabled()).toBe(true);
-      expect(connector.isExtractionPipelinesEnabled()).toBe(true);
-      expect(connector.isRelationshipsEnabled()).toBe(true);
-    });
-
-    it("should respect individual deprecated feature flags", () => {
-      const connector = new Connector(
-        project,
-        protocol,
-        fetcher,
-        false,
-        false,
-        true, // enableCoreDataModelFeatures
-        true, // enableLegacyDataModelFeatures
-        false, // enableCogniteTimeSeries
-        false, // enableCogniteActivities
-        false, // enableFlexibleDataModelling
-        true,
-        true,
-        true,
-        true,
-        true, // legacy features
-        false,
-        false,
-        false, // all deprecated features disabled
-      );
-
-      expect(connector.isTemplatesEnabled()).toBe(false);
-      expect(connector.isExtractionPipelinesEnabled()).toBe(false);
-      expect(connector.isRelationshipsEnabled()).toBe(false);
+    it.each(DEPRECATED_FEATURES)("%s ignores both masters", (flag, accessor) => {
+      const bothMastersOff = {
+        enableCoreDataModelFeatures: false,
+        enableLegacyDataModelFeatures: false,
+      };
+      expect(connectorWith({ ...bothMastersOff, [flag]: true })[accessor]()).toBe(true);
+      expect(connectorWith({ ...bothMastersOff, [flag]: false })[accessor]()).toBe(false);
     });
   });
 
-  describe("Mixed scenarios", () => {
-    it("should handle mixed master toggle states correctly", () => {
-      const connector = new Connector(
-        project,
-        protocol,
-        fetcher,
-        false,
-        false,
-        true, // enableCoreDataModelFeatures - enabled
-        false, // enableLegacyDataModelFeatures - disabled
-        true, // enableCogniteTimeSeries
-        true, // enableCogniteActivities
-        true, // enableFlexibleDataModelling
-        true,
-        true,
-        true,
-        true,
-        true, // legacy features (but master disabled)
-        true,
-        true,
-        true, // deprecated features
+  describe("Legacy master on its own", () => {
+    // Asset-centric variable queries hit /assets/list, which no sub-flag covers,
+    // so the master alone decides whether they are offered.
+    it("is independent of the legacy sub-flags", () => {
+      const noSubFlags = LEGACY_FEATURES.reduce(
+        (options, [flag]) => ({ ...options, [flag]: false }),
+        {} as ConnectorOptions
       );
+      expect(
+        connectorWith({ ...noSubFlags, enableLegacyDataModelFeatures: true })
+          .isLegacyDataModelFeaturesEnabled()
+      ).toBe(true);
+      expect(
+        connectorWith({ ...noSubFlags, enableLegacyDataModelFeatures: false })
+          .isLegacyDataModelFeaturesEnabled()
+      ).toBe(false);
+    });
+  });
 
-      // Core features should work (master enabled)
+  describe("Unset flags", () => {
+    it("reads an omitted flag as off rather than undefined", () => {
+      const connector = connectorWith({});
+      expect(connector.isFlexibleDataModellingEnabled()).toBe(false);
+      expect(connector.isRelationshipsEnabled()).toBe(false);
+      expect(connector.isLegacyDataModelFeaturesEnabled()).toBe(false);
+    });
+  });
+
+  describe("Mixed sections", () => {
+    it("gates each section by its own master", () => {
+      const connector = connectorWith({
+        enableCoreDataModelFeatures: true,
+        enableLegacyDataModelFeatures: false,
+        enableCogniteTimeSeries: true,
+        enableFlexibleDataModelling: true,
+        enableTimeseriesSearch: true,
+        enableEvents: true,
+        enableRelationships: true,
+      });
+
       expect(connector.isCogniteTimeSeriesEnabled()).toBe(true);
       expect(connector.isFlexibleDataModellingEnabled()).toBe(true);
-
-      // Legacy features should not work (master disabled)
       expect(connector.isTimeseriesSearchEnabled()).toBe(false);
       expect(connector.isEventsEnabled()).toBe(false);
-      expect(connector.isEventsAdvancedFilteringEnabled()).toBe(false);
-
-      // Deprecated features should work (ignore masters)
       expect(connector.isRelationshipsEnabled()).toBe(true);
-      expect(connector.isTemplatesEnabled()).toBe(true);
-      expect(connector.isExtractionPipelinesEnabled()).toBe(true);
     });
   });
 });

--- a/src/__tests__/connector.test.ts
+++ b/src/__tests__/connector.test.ts
@@ -24,7 +24,7 @@ describe('connector', () => {
     const reqBase = { url, method };
 
     beforeEach(() => {
-      connector = new Connector(project, protocol, fetcher, false, false, true, true, true, true, true, true, true, true, true, true, true);
+      connector = new Connector(project, protocol, fetcher);
     });
 
     it('should not chunk under the limit', async () => {
@@ -83,7 +83,7 @@ describe('connector', () => {
     };
 
     beforeEach(() => {
-      connector = new Connector(project, protocol, fetcher, false, false, true, true, true, true, true, true, true, true, true, true, true);
+      connector = new Connector(project, protocol, fetcher);
     });
 
     it('returns all 10k elements', async () => {
@@ -123,7 +123,7 @@ describe('connector', () => {
     const response = async () => ({ data: { items: [1] } });
 
     beforeEach(() => {
-      connector = new Connector(project, protocol, fetcher, false, false, true, true, true, true, true, true, true, true, true, true, true);
+      connector = new Connector(project, protocol, fetcher);
       jest.useFakeTimers();
     });
 
@@ -189,7 +189,7 @@ describe('connector', () => {
     const request = { path: '' };
 
     beforeEach(() => {
-      connector = new Connector(project, protocol, fetcher, true, false, true, true, true, true, true, true, true, true, true, true, true);
+      connector = new Connector(project, protocol, fetcher, { oauthPassThru: true, oauthClientCredentials: false });
     });
 
     it('uses cdf-oauth route when oauthPassThru=true', async () => {
@@ -206,7 +206,7 @@ describe('connector', () => {
     const request = { path: '' };
 
     beforeEach(() => {
-      connector = new Connector(project, protocol, fetcher, false, true, true, true, true, true, true, true, true, true, true, true, true);
+      connector = new Connector(project, protocol, fetcher, { oauthPassThru: false, oauthClientCredentials: true });
     });
 
     it('uses cdf-cc-oauth route when oauthClientCreds=true', async () => {

--- a/src/__tests__/featureDefaults.test.ts
+++ b/src/__tests__/featureDefaults.test.ts
@@ -1,0 +1,18 @@
+import { FEATURE_DEFAULTS, resolveFeatureFlags } from '../featureDefaults';
+
+describe('resolveFeatureFlags', () => {
+  it('fills in every flag a datasource leaves unset', () => {
+    expect(resolveFeatureFlags({})).toEqual(FEATURE_DEFAULTS);
+    expect(resolveFeatureFlags()).toEqual(FEATURE_DEFAULTS);
+  });
+
+  it('keeps a flag that is set, including one set off', () => {
+    const flags = resolveFeatureFlags({
+      enableCoreDataModelFeatures: false,
+      enableEventsAdvancedFiltering: true,
+    });
+    expect(flags.enableCoreDataModelFeatures).toBe(false);
+    expect(flags.enableEventsAdvancedFiltering).toBe(true);
+    expect(flags.enableLegacyDataModelFeatures).toBe(FEATURE_DEFAULTS.enableLegacyDataModelFeatures);
+  });
+});

--- a/src/__tests__/featureDefaults.test.ts
+++ b/src/__tests__/featureDefaults.test.ts
@@ -6,6 +6,11 @@ describe('resolveFeatureFlags', () => {
     expect(resolveFeatureFlags()).toEqual(FEATURE_DEFAULTS);
   });
 
+  it('treats an explicit undefined like an unset flag', () => {
+    const flags = resolveFeatureFlags({ enableCogniteTimeSeries: undefined });
+    expect(flags.enableCogniteTimeSeries).toBe(FEATURE_DEFAULTS.enableCogniteTimeSeries);
+  });
+
   it('keeps a flag that is set, including one set off', () => {
     const flags = resolveFeatureFlags({
       enableCoreDataModelFeatures: false,

--- a/src/components/FeatureToggleRow.tsx
+++ b/src/components/FeatureToggleRow.tsx
@@ -1,0 +1,55 @@
+import React, { ChangeEvent } from "react";
+import { InlineFieldRow, InlineFormLabel, InlineSwitch } from "@grafana/ui";
+import { FeatureKey } from "../featureDefaults";
+import { FEATURE_TOOLTIPS } from "./featureTooltips";
+
+/** Shared by every toggle so the switches stay in one column. */
+const FEATURE_LABEL_WIDTH = 16;
+
+type FeatureToggleRowProps = {
+  /** Doubles as the DOM id; the e2e specs locate switches by it. */
+  id: string;
+  label: string;
+  value: boolean;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  labelWidth?: number;
+  /** Rendered after the label, e.g. a Beta chip. */
+  badge?: React.ReactNode;
+} & (
+  /** A feature flag, explained by its entry in FEATURE_TOOLTIPS. */
+  | { feature: FeatureKey; tooltip?: undefined }
+  /** Any other switch, e.g. an authentication option, with its own explanation. */
+  | { feature?: undefined; tooltip: string }
+);
+
+/** One switch with its label, explanation and optional chip. */
+export const FeatureToggleRow = ({
+  id,
+  feature,
+  tooltip,
+  label,
+  value,
+  onChange,
+  labelWidth = FEATURE_LABEL_WIDTH,
+  badge,
+}: FeatureToggleRowProps) => (
+  <InlineFieldRow style={{ marginBottom: "4px" }}>
+    <InlineFormLabel
+      htmlFor={id}
+      tooltip={tooltip ?? FEATURE_TOOLTIPS[feature]}
+      width={labelWidth}
+    >
+      {badge ? (
+        <span
+          style={{ display: "flex", alignItems: "center", gap: "6px" }}
+        >
+          {label}
+          {badge}
+        </span>
+      ) : (
+        label
+      )}
+    </InlineFormLabel>
+    <InlineSwitch id={id} label={label} value={value} onChange={onChange} />
+  </InlineFieldRow>
+);

--- a/src/components/FeatureToggleRow.tsx
+++ b/src/components/FeatureToggleRow.tsx
@@ -3,7 +3,11 @@ import { InlineFieldRow, InlineFormLabel, InlineSwitch } from "@grafana/ui";
 import { FeatureKey } from "../featureDefaults";
 import { FEATURE_TOOLTIPS } from "./featureTooltips";
 
-/** Shared by every toggle so the switches stay in one column. */
+/**
+ * Shared by every feature toggle so the switches stay in one column. Wider than
+ * the connection tab's 14 so the longest labels ("Time series from asset",
+ * "Events advanced filter") fit beside their tooltip icon on one line.
+ */
 const FEATURE_LABEL_WIDTH = 16;
 
 type FeatureToggleRowProps = {

--- a/src/components/configEditor.tsx
+++ b/src/components/configEditor.tsx
@@ -5,7 +5,6 @@ import {
   InlineField,
   InlineFieldRow,
   InlineFormLabel,
-  InlineSwitch,
   Input,
   SecretInput,
   Tab,
@@ -15,7 +14,7 @@ import {
 } from "@grafana/ui";
 import { DataSourcePluginOptionsEditorProps } from "@grafana/data";
 import { CogniteDataSourceOptions, CogniteSecureJsonData } from "../types";
-import { FEATURE_DEFAULTS, FeatureKey } from "../featureDefaults";
+import { FEATURE_DEFAULTS, FeatureKey, resolveFeatureFlags } from "../featureDefaults";
 import {
   boolValueHandler,
   hostnameValueHandler,
@@ -23,6 +22,7 @@ import {
   secretValueHandler,
   stringValueHandler,
 } from "../configEditorUtils";
+import { FeatureToggleRow } from "./FeatureToggleRow";
 import "../css/common.css";
 
 type ConfigEditorProps = DataSourcePluginOptionsEditorProps<
@@ -51,45 +51,6 @@ const oAuthClientSecretTooltip =
 const oAuthScopeTooltip =
   `The OAuth 2.0 scope for CDF API access. Use your cluster's base URL with the .default suffix. E.g. https://api.cognitedata.com/.default or https://<cluster>.cognitedata.com/.default.`;
 
-const enableCogniteTimeSeriesTooltip =
-  `Enable the Time Series tab to browse and select time series instances from the Core Data Model (CogniteTimeSeries type).`;
-
-const enableCogniteActivitiesTooltip =
-  `Enable the Activities tab to query CogniteActivity instances from the Core Data Model.`;
-
-const enableTimeseriesSearchTooltip =
-  `Enable the Time series search tab to find and select time series by name, description, or metadata.`;
-
-const enableTimeseriesFromAssetTooltip =
-  `Enable the Time series from asset tab to browse the asset hierarchy and select time series linked to specific assets.`;
-
-const enableTimeseriesCustomQueryTooltip =
-  `Enable the Custom query tab to retrieve time series by external ID, with support for synthetic time series expressions and custom aggregations.`;
-
-const enableEventsTooltip =
-  `Enable the Events tab to query CDF events. Events represent time-bounded occurrences (e.g. alarms, maintenance activities) linked to assets.`;
-
-const enableRelationshipsTooltip =
-  `Enable the Relationships tab to query connections between CDF resources. This tab is deprecated in the plugin; use the Data Models tab instead.`;
-
-const enableTemplatesTooltip =
-  `Enable the Templates tab. Cognite Templates were retired in May 2025. Migrate to Data Models (DMS).`;
-
-const enableEventsAdvancedFilteringTooltip =
-  `Add advanced event filtering with boolean logic (AND, OR, NOT) and metadata-based filters within the Events tab. Supports filtering by type, subtype, time ranges, and asset links.`;
-
-const enableFlexibleDataModellingTooltip =
-  `Enable the Data Models tab to query custom data models in CDF using GraphQL. Supports listing, searching, and aggregating data model instances.`;
-
-const enableExtractionPipelinesTooltip =
-  `Enable the Extraction Pipelines tab to monitor data flow from extractors into CDF. This tab is deprecated in the plugin.`;
-
-const enableCoreDataModelFeaturesTooltip =
-  `Master toggle for Core Data Model (CDM) features. When disabled, all CDM features will be hidden. Enabling this will disable asset-centric features.`;
-
-const enableLegacyDataModelFeaturesTooltip =
-  `Master toggle for asset-centric (legacy) features. When disabled, all asset-centric features will be hidden. Enabling this will disable CDM features.`;
-
 const CORE_DEPENDENT_KEYS: FeatureKey[] = [
   "enableCogniteTimeSeries",
   "enableCogniteActivities",
@@ -103,7 +64,12 @@ const LEGACY_DEPENDENT_KEYS: FeatureKey[] = [
   "enableEventsAdvancedFiltering",
 ];
 
-const FEATURE_LABEL_WIDTH = 14;
+const SECTION_STYLE = { marginTop: '8px', marginBottom: '8px' };
+
+/** Separates the feature sections. */
+const SectionDivider = () => (
+  <hr style={{ border: 'none', borderTop: '1px solid rgba(204,204,220,0.12)', margin: '16px 0' }} />
+);
 const CONNECTION_LABEL_WIDTH = 14;
 const INPUT_WIDTH = 42;
 
@@ -125,22 +91,22 @@ export function ConfigEditor(props: ConfigEditorProps) {
     oauthClientId,
     oauthTokenUrl,
     oauthScope,
-    enableCoreDataModelFeatures = FEATURE_DEFAULTS.enableCoreDataModelFeatures,
-    enableLegacyDataModelFeatures =
-      FEATURE_DEFAULTS.enableLegacyDataModelFeatures,
-    enableCogniteTimeSeries = FEATURE_DEFAULTS.enableCogniteTimeSeries,
-    enableCogniteActivities = FEATURE_DEFAULTS.enableCogniteActivities,
-    enableTimeseriesSearch = FEATURE_DEFAULTS.enableTimeseriesSearch,
-    enableTimeseriesFromAsset = FEATURE_DEFAULTS.enableTimeseriesFromAsset,
-    enableTimeseriesCustomQuery = FEATURE_DEFAULTS.enableTimeseriesCustomQuery,
-    enableEvents = FEATURE_DEFAULTS.enableEvents,
-    enableTemplates = FEATURE_DEFAULTS.enableTemplates,
-    enableEventsAdvancedFiltering =
-      FEATURE_DEFAULTS.enableEventsAdvancedFiltering,
-    enableFlexibleDataModelling = FEATURE_DEFAULTS.enableFlexibleDataModelling,
-    enableExtractionPipelines = FEATURE_DEFAULTS.enableExtractionPipelines,
-    enableRelationships = FEATURE_DEFAULTS.enableRelationships,
   } = jsonData;
+  const {
+    enableCoreDataModelFeatures,
+    enableLegacyDataModelFeatures,
+    enableCogniteTimeSeries,
+    enableCogniteActivities,
+    enableTimeseriesSearch,
+    enableTimeseriesFromAsset,
+    enableTimeseriesCustomQuery,
+    enableEvents,
+    enableTemplates,
+    enableEventsAdvancedFiltering,
+    enableFlexibleDataModelling,
+    enableExtractionPipelines,
+    enableRelationships,
+  } = resolveFeatureFlags(jsonData);
 
   const onJsonDataChange = (
     patch: Partial<ConfigEditorProps["options"]["jsonData"]>,
@@ -172,11 +138,7 @@ export function ConfigEditor(props: ConfigEditorProps) {
       [masterKey]: isEnabled,
     };
     dependentKeys.forEach((key) => {
-      patch[key] = isEnabled
-        ? (masterKey === "enableCoreDataModelFeatures"
-          ? true
-          : FEATURE_DEFAULTS[key])
-        : false;
+      patch[key] = isEnabled ? FEATURE_DEFAULTS[key] : false;
     });
     if (isEnabled) {
       patch[oppositeKey] = false;
@@ -244,7 +206,7 @@ export function ConfigEditor(props: ConfigEditorProps) {
               </InlineField>
             </div>
 
-            <hr style={{ border: 'none', borderTop: '1px solid rgba(204,204,220,0.12)', margin: '16px 0' }} />
+            <SectionDivider />
 
             <h6 style={{ marginBottom: 4 }}>
               Authentication{" "}
@@ -267,36 +229,23 @@ export function ConfigEditor(props: ConfigEditorProps) {
                   </a>
                 </pre>
               )}
-              <InlineFieldRow style={{ marginBottom: "4px" }}>
-                <InlineFormLabel
-                  htmlFor="oauth-pass-thru"
-                  tooltip={oAuthPassThruTooltip}
-                  width={CONNECTION_LABEL_WIDTH}
-                >
-                  Forward OAuth Identity
-                </InlineFormLabel>
-                <InlineSwitch
-                  label="Forward OAuth Identity"
-                  id="oauth-pass-thru"
-                  value={oauthPassThru}
-                  onChange={onJsonBoolValueChange("oauthPassThru")}
-                />
-              </InlineFieldRow>
+              <FeatureToggleRow
+                id="oauth-pass-thru"
+                label="Forward OAuth Identity"
+                tooltip={oAuthPassThruTooltip}
+                labelWidth={CONNECTION_LABEL_WIDTH}
+                value={!!oauthPassThru}
+                onChange={onJsonBoolValueChange("oauthPassThru")}
+              />
               {!oauthPassThru && (
-                <InlineFieldRow style={{ marginBottom: "4px" }}>
-                  <InlineFormLabel
-                    htmlFor="oauth-client-creds"
-                    tooltip={oAuthClientCredsTooltip}
-                    width={CONNECTION_LABEL_WIDTH}
-                  >
-                    OAuth2 client credentials
-                  </InlineFormLabel>
-                  <InlineSwitch
-                    label="OAuth2 client credentials"
-                    value={oauthClientCreds}
-                    onChange={onJsonBoolValueChange("oauthClientCreds")}
-                  />
-                </InlineFieldRow>
+                <FeatureToggleRow
+                  id="oauth-client-creds"
+                  label="OAuth2 client credentials"
+                  tooltip={oAuthClientCredsTooltip}
+                  labelWidth={CONNECTION_LABEL_WIDTH}
+                  value={!!oauthClientCreds}
+                  onChange={onJsonBoolValueChange("oauthClientCreds")}
+                />
               )}
               {!oauthPassThru && oauthClientCreds && (
                 <>
@@ -375,236 +324,130 @@ export function ConfigEditor(props: ConfigEditorProps) {
         {activeTab === "features" && (
           <>
             <h6 style={{ marginBottom: 4 }}>Core Data Model (CDM)</h6>
-            <div style={{ marginTop: '8px', marginBottom: '8px' }}>
-              <InlineFieldRow style={{ marginBottom: "4px" }}>
-                <InlineFormLabel
-                  htmlFor="enable-core-data-model-features"
-                  tooltip={enableCoreDataModelFeaturesTooltip}
-                  width={FEATURE_LABEL_WIDTH}
-                >
-                  Enable CDM features
-                </InlineFormLabel>
-                <InlineSwitch
-                  id="enable-core-data-model-features"
-                  label="Enable CDM features"
-                  value={enableCoreDataModelFeatures}
-                  onChange={onExclusiveMasterToggle(
-                    "enableCoreDataModelFeatures",
-                    CORE_DEPENDENT_KEYS,
-                    "enableLegacyDataModelFeatures",
-                    LEGACY_DEPENDENT_KEYS,
-                  )}
-                />
-              </InlineFieldRow>
+            <div style={SECTION_STYLE}>
+              <FeatureToggleRow
+                id="enable-core-data-model-features"
+                feature="enableCoreDataModelFeatures"
+                label="Enable CDM features"
+                value={enableCoreDataModelFeatures}
+                onChange={onExclusiveMasterToggle(
+                  "enableCoreDataModelFeatures",
+                  CORE_DEPENDENT_KEYS,
+                  "enableLegacyDataModelFeatures",
+                  LEGACY_DEPENDENT_KEYS,
+                )}
+              />
               {enableCoreDataModelFeatures && (
                 <>
-                  <InlineFieldRow style={{ marginBottom: "4px" }}>
-                    <InlineFormLabel
-                      htmlFor="enable-cognite-timeseries"
-                      tooltip={enableCogniteTimeSeriesTooltip}
-                      width={FEATURE_LABEL_WIDTH}
-                    >
-                      Time Series
-                    </InlineFormLabel>
-                    <InlineSwitch
-                      id="enable-cognite-timeseries"
-                      label="Time Series"
-                      value={enableCogniteTimeSeries}
-                      onChange={onJsonBoolValueChange("enableCogniteTimeSeries")}
-                    />
-                  </InlineFieldRow>
-                  <InlineFieldRow style={{ marginBottom: "4px" }}>
-                    <InlineFormLabel
-                      htmlFor="enable-cognite-activities"
-                      tooltip={enableCogniteActivitiesTooltip}
-                      width={FEATURE_LABEL_WIDTH}
-                    >
-                      Activities
-                    </InlineFormLabel>
-                    <InlineSwitch
-                      id="enable-cognite-activities"
-                      label="Activities"
-                      value={enableCogniteActivities}
-                      onChange={onJsonBoolValueChange("enableCogniteActivities")}
-                    />
-                  </InlineFieldRow>
-                  <InlineFieldRow style={{ marginBottom: "4px" }}>
-                    <InlineFormLabel
-                      htmlFor="enable-flexible-data-modelling"
-                      tooltip={enableFlexibleDataModellingTooltip}
-                      width={FEATURE_LABEL_WIDTH}
-                    >
-                      GraphQL
-                    </InlineFormLabel>
-                    <InlineSwitch
-                      id="enable-flexible-data-modelling"
-                      label="GraphQL"
-                      value={enableFlexibleDataModelling}
-                      onChange={onJsonBoolValueChange("enableFlexibleDataModelling")}
-                    />
-                  </InlineFieldRow>
+                  <FeatureToggleRow
+                    id="enable-cognite-timeseries"
+                    feature="enableCogniteTimeSeries"
+                    label="Time Series"
+                    value={enableCogniteTimeSeries}
+                    onChange={onJsonBoolValueChange("enableCogniteTimeSeries")}
+                  />
+                  <FeatureToggleRow
+                    id="enable-cognite-activities"
+                    feature="enableCogniteActivities"
+                    label="Activities"
+                    value={enableCogniteActivities}
+                    onChange={onJsonBoolValueChange("enableCogniteActivities")}
+                  />
+                  <FeatureToggleRow
+                    id="enable-flexible-data-modelling"
+                    feature="enableFlexibleDataModelling"
+                    label="GraphQL"
+                    value={enableFlexibleDataModelling}
+                    onChange={onJsonBoolValueChange("enableFlexibleDataModelling")}
+                  />
                 </>
               )}
             </div>
 
-            <hr style={{ border: 'none', borderTop: '1px solid rgba(204,204,220,0.12)', margin: '16px 0' }} />
+            <SectionDivider />
 
             <h6 style={{ marginBottom: 4, display: 'flex', alignItems: 'center', gap: '8px' }}>
               Asset-centric <Badge text="legacy" color="orange" />
             </h6>
-            <div style={{ marginTop: '8px', marginBottom: '8px' }}>
-              <InlineFieldRow style={{ marginBottom: "4px" }}>
-                <InlineFormLabel
-                  htmlFor="enable-legacy-data-model-features"
-                  tooltip={enableLegacyDataModelFeaturesTooltip}
-                  width={FEATURE_LABEL_WIDTH}
-                >
-                  Enable asset-centric
-                </InlineFormLabel>
-                <InlineSwitch
-                  id="enable-legacy-data-model-features"
-                  label="Enable asset-centric"
-                  value={enableLegacyDataModelFeatures}
-                  onChange={onExclusiveMasterToggle(
-                    "enableLegacyDataModelFeatures",
-                    LEGACY_DEPENDENT_KEYS,
-                    "enableCoreDataModelFeatures",
-                    CORE_DEPENDENT_KEYS,
-                  )}
-                />
-              </InlineFieldRow>
+            <div style={SECTION_STYLE}>
+              <FeatureToggleRow
+                id="enable-legacy-data-model-features"
+                feature="enableLegacyDataModelFeatures"
+                label="Enable asset-centric"
+                value={enableLegacyDataModelFeatures}
+                onChange={onExclusiveMasterToggle(
+                  "enableLegacyDataModelFeatures",
+                  LEGACY_DEPENDENT_KEYS,
+                  "enableCoreDataModelFeatures",
+                  CORE_DEPENDENT_KEYS,
+                )}
+              />
               {enableLegacyDataModelFeatures && (
                 <>
-                  <InlineFieldRow style={{ marginBottom: "4px" }}>
-                    <InlineFormLabel
-                      htmlFor="enable-timeseries-search"
-                      tooltip={enableTimeseriesSearchTooltip}
-                      width={FEATURE_LABEL_WIDTH}
-                    >
-                      Time series search
-                    </InlineFormLabel>
-                    <InlineSwitch
-                      id="enable-timeseries-search"
-                      label="Time series search"
-                      value={enableTimeseriesSearch}
-                      onChange={onJsonBoolValueChange("enableTimeseriesSearch")}
-                    />
-                  </InlineFieldRow>
-                  <InlineFieldRow style={{ marginBottom: "4px" }}>
-                    <InlineFormLabel
-                      htmlFor="enable-timeseries-from-asset"
-                      tooltip={enableTimeseriesFromAssetTooltip}
-                      width={FEATURE_LABEL_WIDTH}
-                    >
-                      Time series from asset
-                    </InlineFormLabel>
-                    <InlineSwitch
-                      id="enable-timeseries-from-asset"
-                      label="Time series from asset"
-                      value={enableTimeseriesFromAsset}
-                      onChange={onJsonBoolValueChange("enableTimeseriesFromAsset")}
-                    />
-                  </InlineFieldRow>
-                  <InlineFieldRow style={{ marginBottom: "4px" }}>
-                    <InlineFormLabel
-                      htmlFor="enable-timeseries-custom-query"
-                      tooltip={enableTimeseriesCustomQueryTooltip}
-                      width={FEATURE_LABEL_WIDTH}
-                    >
-                      Custom query
-                    </InlineFormLabel>
-                    <InlineSwitch
-                      id="enable-timeseries-custom-query"
-                      label="Custom query"
-                      value={enableTimeseriesCustomQuery}
-                      onChange={onJsonBoolValueChange("enableTimeseriesCustomQuery")}
-                    />
-                  </InlineFieldRow>
-                  <InlineFieldRow style={{ marginBottom: "4px" }}>
-                    <InlineFormLabel
-                      htmlFor="enable-events"
-                      tooltip={enableEventsTooltip}
-                      width={FEATURE_LABEL_WIDTH}
-                    >
-                      Events
-                    </InlineFormLabel>
-                    <InlineSwitch
-                      id="enable-events"
-                      label="Events"
-                      value={enableEvents}
-                      onChange={onJsonBoolValueChange("enableEvents")}
-                    />
-                  </InlineFieldRow>
-                  <InlineFieldRow style={{ marginBottom: "4px" }}>
-                    <InlineFormLabel
-                      htmlFor="enable-events-advanced-filtering"
-                      tooltip={enableEventsAdvancedFilteringTooltip}
-                      width={FEATURE_LABEL_WIDTH}
-                    >
-                      Events advanced filter
-                    </InlineFormLabel>
-                    <InlineSwitch
-                      id="enable-events-advanced-filtering"
-                      label="Events advanced filter"
-                      value={enableEventsAdvancedFiltering}
-                      onChange={onJsonBoolValueChange(
-                        "enableEventsAdvancedFiltering",
-                      )}
-                    />
-                  </InlineFieldRow>
+                  <FeatureToggleRow
+                    id="enable-timeseries-search"
+                    feature="enableTimeseriesSearch"
+                    label="Time series search"
+                    value={enableTimeseriesSearch}
+                    onChange={onJsonBoolValueChange("enableTimeseriesSearch")}
+                  />
+                  <FeatureToggleRow
+                    id="enable-timeseries-from-asset"
+                    feature="enableTimeseriesFromAsset"
+                    label="Time series from asset"
+                    value={enableTimeseriesFromAsset}
+                    onChange={onJsonBoolValueChange("enableTimeseriesFromAsset")}
+                  />
+                  <FeatureToggleRow
+                    id="enable-timeseries-custom-query"
+                    feature="enableTimeseriesCustomQuery"
+                    label="Custom query"
+                    value={enableTimeseriesCustomQuery}
+                    onChange={onJsonBoolValueChange("enableTimeseriesCustomQuery")}
+                  />
+                  <FeatureToggleRow
+                    id="enable-events"
+                    feature="enableEvents"
+                    label="Events"
+                    value={enableEvents}
+                    onChange={onJsonBoolValueChange("enableEvents")}
+                  />
+                  <FeatureToggleRow
+                    id="enable-events-advanced-filtering"
+                    feature="enableEventsAdvancedFiltering"
+                    label="Events advanced filter"
+                    value={enableEventsAdvancedFiltering}
+                    onChange={onJsonBoolValueChange("enableEventsAdvancedFiltering")}
+                  />
                 </>
               )}
             </div>
 
-            <hr style={{ border: 'none', borderTop: '1px solid rgba(204,204,220,0.12)', margin: '16px 0' }} />
+            <SectionDivider />
 
             <h6 style={{ marginBottom: 4 }}>Deprecated</h6>
-            <div style={{ marginTop: '8px', marginBottom: '8px' }}>
-              <InlineFieldRow style={{ marginBottom: "4px" }}>
-                <InlineFormLabel
-                  htmlFor="enable-relationships"
-                  tooltip={enableRelationshipsTooltip}
-                  width={FEATURE_LABEL_WIDTH}
-                >
-                  Relationships
-                </InlineFormLabel>
-                <InlineSwitch
-                  id="enable-relationships"
-                  label="Relationships"
-                  value={enableRelationships}
-                  onChange={onJsonBoolValueChange("enableRelationships")}
-                />
-              </InlineFieldRow>
-              <InlineFieldRow style={{ marginBottom: "4px" }}>
-                <InlineFormLabel
-                  htmlFor="enable-extraction-pipelines"
-                  tooltip={enableExtractionPipelinesTooltip}
-                  width={FEATURE_LABEL_WIDTH}
-                >
-                  Extraction Pipelines
-                </InlineFormLabel>
-                <InlineSwitch
-                  id="enable-extraction-pipelines"
-                  label="Extraction Pipelines"
-                  value={enableExtractionPipelines}
-                  onChange={onJsonBoolValueChange("enableExtractionPipelines")}
-                />
-              </InlineFieldRow>
-              <InlineFieldRow style={{ marginBottom: "4px" }}>
-                <InlineFormLabel
-                  htmlFor="enable-templates"
-                  tooltip={enableTemplatesTooltip}
-                  width={FEATURE_LABEL_WIDTH}
-                >
-                  Cognite Templates
-                </InlineFormLabel>
-                <InlineSwitch
-                  id="enable-templates"
-                  label="Cognite Templates"
-                  value={enableTemplates}
-                  onChange={onJsonBoolValueChange("enableTemplates")}
-                />
-              </InlineFieldRow>
+            <div style={SECTION_STYLE}>
+              <FeatureToggleRow
+                id="enable-relationships"
+                feature="enableRelationships"
+                label="Relationships"
+                value={enableRelationships}
+                onChange={onJsonBoolValueChange("enableRelationships")}
+              />
+              <FeatureToggleRow
+                id="enable-extraction-pipelines"
+                feature="enableExtractionPipelines"
+                label="Extraction Pipelines"
+                value={enableExtractionPipelines}
+                onChange={onJsonBoolValueChange("enableExtractionPipelines")}
+              />
+              <FeatureToggleRow
+                id="enable-templates"
+                feature="enableTemplates"
+                label="Cognite Templates"
+                value={enableTemplates}
+                onChange={onJsonBoolValueChange("enableTemplates")}
+              />
             </div>
           </>
         )}

--- a/src/components/configEditor.tsx
+++ b/src/components/configEditor.tsx
@@ -137,6 +137,9 @@ export function ConfigEditor(props: ConfigEditorProps) {
     const patch: Partial<CogniteDataSourceOptions> = {
       [masterKey]: isEnabled,
     };
+    // Re-enabling a master restores its sub-flags to their defaults; both
+    // masters follow this one rule. Every CDM sub-flag defaults on, so the
+    // CDM master still enables all of them.
     dependentKeys.forEach((key) => {
       patch[key] = isEnabled ? FEATURE_DEFAULTS[key] : false;
     });

--- a/src/components/featureTooltips.ts
+++ b/src/components/featureTooltips.ts
@@ -1,0 +1,39 @@
+import { FeatureKey } from "../featureDefaults";
+
+/**
+ * What each feature toggle does, in the datasource settings.
+ *
+ * Keyed by flag so the set stays exhaustive: adding a flag without its explanation
+ * is a type error rather than a silently untooltipped switch.
+ */
+export const FEATURE_TOOLTIPS: Record<FeatureKey, string> = {
+  enableCoreDataModelFeatures:
+    `Master toggle for Core Data Model (CDM) features. When disabled, all CDM features will be hidden. Enabling this will disable asset-centric features.`,
+  enableLegacyDataModelFeatures:
+    `Master toggle for asset-centric (legacy) features. When disabled, all asset-centric features will be hidden. Enabling this will disable CDM features.`,
+
+  enableCogniteTimeSeries:
+    `Enable the Time Series tab to browse and select time series instances from the Core Data Model (CogniteTimeSeries type).`,
+  enableCogniteActivities:
+    `Enable the Activities tab to query CogniteActivity instances from the Core Data Model.`,
+  enableFlexibleDataModelling:
+    `Enable the GraphQL tab to query custom data models in CDF using GraphQL. Supports listing, searching, and aggregating data model instances.`,
+
+  enableTimeseriesSearch:
+    `Enable the Time series search tab to find and select time series by name, description, or metadata.`,
+  enableTimeseriesFromAsset:
+    `Enable the Time series from asset tab to browse the asset hierarchy and select time series linked to specific assets.`,
+  enableTimeseriesCustomQuery:
+    `Enable the Custom query tab to retrieve time series by external ID, with support for synthetic time series expressions and custom aggregations.`,
+  enableEvents:
+    `Enable the Events tab to query CDF events. Events represent time-bounded occurrences (e.g. alarms, maintenance activities) linked to assets.`,
+  enableEventsAdvancedFiltering:
+    `Add advanced event filtering with boolean logic (AND, OR, NOT) and metadata-based filters within the Events tab. Supports filtering by type, subtype, time ranges, and asset links.`,
+
+  enableRelationships:
+    `Enable the Relationships tab to query connections between CDF resources. This tab is deprecated in the plugin; use the GraphQL tab instead.`,
+  enableTemplates:
+    `Enable the Templates tab. Cognite Templates were retired in May 2025. Migrate to Data Models (DMS).`,
+  enableExtractionPipelines:
+    `Enable the Extraction Pipelines tab to monitor data flow from extractors into CDF. This tab is deprecated in the plugin.`,
+};

--- a/src/configEditorUtils.ts
+++ b/src/configEditorUtils.ts
@@ -1,5 +1,4 @@
 import { ChangeEvent } from "react";
-import { FEATURE_DEFAULTS, FeatureKey } from "./featureDefaults";
 import { CogniteDataSourceOptions, CogniteSecureJsonData } from "./types";
 
 /**
@@ -78,38 +77,3 @@ export const resetSecretHandler = (
     },
   });
 
-/**
- * Handler for master toggle changes - manages underlying feature toggles based on master state
- */
-export const masterToggleHandler = (
-  masterKey: FeatureKey,
-  dependentKeys: FeatureKey[],
-  onJsonDataChange: (patch: Partial<CogniteDataSourceOptions>) => void,
-) =>
-(event: ChangeEvent<HTMLInputElement>) => {
-  const isEnabled = event.currentTarget.checked;
-
-  // Create patch object with master toggle and dependent features
-  const patch: Partial<Pick<CogniteDataSourceOptions, FeatureKey>> = {
-    [masterKey]: isEnabled,
-  };
-
-  // When enabling master toggle, enable all dependent features
-  // When disabling master toggle, set dependent features to false
-  dependentKeys.forEach((key) => {
-    if (isEnabled) {
-      // For Core data model (CDM) features, enable them when master is enabled
-      if (masterKey === "enableCoreDataModelFeatures") {
-        patch[key] = true;
-      } else {
-        // For other master toggles, use their defaults
-        patch[key] = FEATURE_DEFAULTS[key];
-      }
-    } else {
-      // When disabling master toggle, disable all dependent features
-      patch[key] = false;
-    }
-  });
-
-  onJsonDataChange(patch);
-};

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -14,36 +14,34 @@ import {
 import { Items, Limit } from "./cdf/types";
 import { getQueryString } from "./utils";
 import { API_V1, AuthType, CacheTime } from "./constants";
+import { FeatureFlags, FeatureKey } from "./featureDefaults";
 
 export interface Fetcher {
   fetch: (options: BackendSrvRequest) => Promise<FetchResponse<any>>;
 }
 
+/**
+ * Everything optional a connector is configured with.
+ *
+ * Named rather than positional: the flag list grows, and a list of interchangeable
+ * booleans silently mis-wires itself the moment one is inserted in the middle.
+ */
+export type ConnectorOptions = {
+  oauthPassThru?: boolean;
+  oauthClientCredentials?: boolean;
+} & Partial<FeatureFlags>;
+
 export class Connector {
+  private options: ConnectorOptions;
+
   constructor(
     private project: string,
     private apiUrl: string,
     private fetcher: Fetcher,
-    private oauthPassThru?: boolean,
-    private oauthClientCredentials?: boolean,
-    // Master toggles for feature sections
-    private enableCoreDataModelFeatures?: boolean,
-    private enableLegacyDataModelFeatures?: boolean,
-    // Core data model (CDM) features
-    private enableCogniteTimeSeries?: boolean,
-    private enableCogniteActivities?: boolean,
-    private enableFlexibleDataModelling?: boolean,
-    // Legacy data model features
-    private enableTimeseriesSearch?: boolean,
-    private enableTimeseriesFromAsset?: boolean,
-    private enableTimeseriesCustomQuery?: boolean,
-    private enableEvents?: boolean,
-    private enableEventsAdvancedFiltering?: boolean,
-    // Deprecated features
-    private enableTemplates?: boolean,
-    private enableExtractionPipelines?: boolean,
-    private enableRelationships?: boolean,
-  ) {}
+    options: ConnectorOptions = {},
+  ) {
+    this.options = options;
+  }
 
   cachedRequests = new Map<string, Promise<any>>();
 
@@ -142,10 +140,10 @@ export class Connector {
   private get apiUrlAuth() {
     let auth;
     switch (true) {
-      case !this.oauthPassThru && this.oauthClientCredentials:
+      case !this.options.oauthPassThru && this.options.oauthClientCredentials:
         auth = AuthType.OAuthClientCredentials;
         break;
-      case this.oauthPassThru:
+      case this.options.oauthPassThru:
         auth = AuthType.OAuth;
         break;
       default:
@@ -154,53 +152,72 @@ export class Connector {
     return `${this.apiUrl}/${auth}`;
   }
 
+  /** An unset flag reads as off, so every accessor answers a definite boolean. */
+  private flag(key: FeatureKey): boolean {
+    return !!this.options[key];
+  }
+
   // Core data model (CDM) features
   isCogniteTimeSeriesEnabled() {
-    return this.enableCoreDataModelFeatures && this.enableCogniteTimeSeries;
+    return this.flag("enableCoreDataModelFeatures") &&
+      this.flag("enableCogniteTimeSeries");
   }
 
   isCogniteActivitiesEnabled() {
-    return this.enableCoreDataModelFeatures && this.enableCogniteActivities;
+    return this.flag("enableCoreDataModelFeatures") &&
+      this.flag("enableCogniteActivities");
   }
 
   isFlexibleDataModellingEnabled() {
-    return this.enableCoreDataModelFeatures && this.enableFlexibleDataModelling;
+    return this.flag("enableCoreDataModelFeatures") &&
+      this.flag("enableFlexibleDataModelling");
   }
 
   // Legacy data model features
+  /**
+   * The master switch on its own. Asset-centric variable queries hit /assets/list,
+   * which no sub-flag covers, so the master is the only meaningful gate for them.
+   */
+  isLegacyDataModelFeaturesEnabled() {
+    return this.flag("enableLegacyDataModelFeatures");
+  }
+
   isTimeseriesSearchEnabled() {
-    return this.enableLegacyDataModelFeatures && this.enableTimeseriesSearch;
+    return this.flag("enableLegacyDataModelFeatures") &&
+      this.flag("enableTimeseriesSearch");
   }
 
   isTimeseriesFromAssetEnabled() {
-    return this.enableLegacyDataModelFeatures && this.enableTimeseriesFromAsset;
+    return this.flag("enableLegacyDataModelFeatures") &&
+      this.flag("enableTimeseriesFromAsset");
   }
 
   isTimeseriesCustomQueryEnabled() {
-    return this.enableLegacyDataModelFeatures &&
-      this.enableTimeseriesCustomQuery;
+    return this.flag("enableLegacyDataModelFeatures") &&
+      this.flag("enableTimeseriesCustomQuery");
   }
 
   isEventsEnabled() {
-    return this.enableLegacyDataModelFeatures && this.enableEvents;
+    return this.flag("enableLegacyDataModelFeatures") &&
+      this.flag("enableEvents");
   }
 
   isEventsAdvancedFilteringEnabled() {
-    return this.enableLegacyDataModelFeatures &&
-      this.enableEventsAdvancedFiltering;
+    return this.flag("enableLegacyDataModelFeatures") &&
+      this.flag("enableEventsAdvancedFiltering");
   }
 
   // Deprecated features
   isRelationshipsEnabled() {
-    return this.enableRelationships;
+    return this.flag("enableRelationships");
   }
 
   isTemplatesEnabled() {
-    return this.enableTemplates;
+    return this.flag("enableTemplates");
   }
 
   isExtractionPipelinesEnabled() {
-    return this.enableExtractionPipelines;
+    return this.flag("enableExtractionPipelines");
   }
 
   public cachedRequest = async (

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -177,6 +177,8 @@ export class Connector {
   /**
    * The master switch on its own. Asset-centric variable queries hit /assets/list,
    * which no sub-flag covers, so the master is the only meaningful gate for them.
+   * CDM has no counterpart: every CDM code path belongs to a sub-flag, so there
+   * is deliberately no isCoreDataModelFeaturesEnabled().
    */
   isLegacyDataModelFeaturesEnabled() {
     return this.flag("enableLegacyDataModelFeatures");

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -25,7 +25,7 @@ import {
 } from "./cdf/types";
 import { Connector } from "./connector";
 import { CacheTime } from "./constants";
-import { FEATURE_DEFAULTS } from "./featureDefaults";
+import { resolveFeatureFlags } from "./featureDefaults";
 import { parse as parseQuery } from "./parser/events-assets";
 import { ParsedFilter, QueryCondition } from "./parser/types";
 import {
@@ -85,62 +85,17 @@ export default class CogniteDatasource extends DataSourceWithBackend<
     };
 
     const { url, jsonData } = instanceSettings;
-    const {
-      cogniteProject,
-      defaultProject,
-      oauthPassThru,
-      oauthClientCreds,
-      // Master toggles for feature sections
-      enableCoreDataModelFeatures =
-        FEATURE_DEFAULTS.enableCoreDataModelFeatures,
-      enableLegacyDataModelFeatures =
-        FEATURE_DEFAULTS.enableLegacyDataModelFeatures,
-      // Core data model (CDM) features
-      enableCogniteTimeSeries = FEATURE_DEFAULTS.enableCogniteTimeSeries,
-      enableCogniteActivities = FEATURE_DEFAULTS.enableCogniteActivities,
-      // Legacy data model features
-      enableTimeseriesSearch = FEATURE_DEFAULTS.enableTimeseriesSearch,
-      enableTimeseriesFromAsset = FEATURE_DEFAULTS.enableTimeseriesFromAsset,
-      enableTimeseriesCustomQuery =
-        FEATURE_DEFAULTS.enableTimeseriesCustomQuery,
-      enableEvents = FEATURE_DEFAULTS.enableEvents,
-      // Deprecated features
-      enableTemplates = FEATURE_DEFAULTS.enableTemplates,
-      enableEventsAdvancedFiltering =
-        FEATURE_DEFAULTS.enableEventsAdvancedFiltering,
-      enableFlexibleDataModelling =
-        FEATURE_DEFAULTS.enableFlexibleDataModelling,
-      enableExtractionPipelines = FEATURE_DEFAULTS.enableExtractionPipelines,
-      enableRelationships = FEATURE_DEFAULTS.enableRelationships,
-    } = jsonData;
+    const { cogniteProject, defaultProject, oauthPassThru, oauthClientCreds } =
+      jsonData;
     this.backendSrv = getBackendSrv();
     this.templateSrv = getTemplateSrv();
     this.url = url;
     this.project = cogniteProject ?? defaultProject;
-    const connector = new Connector(
-      this.project,
-      url,
-      defaultFetcher,
+    const connector = new Connector(this.project, url, defaultFetcher, {
       oauthPassThru,
-      oauthClientCreds,
-      // Master toggles for feature sections
-      enableCoreDataModelFeatures,
-      enableLegacyDataModelFeatures,
-      // Core data model (CDM) features
-      enableCogniteTimeSeries,
-      enableCogniteActivities,
-      enableFlexibleDataModelling,
-      // Legacy data model features
-      enableTimeseriesSearch,
-      enableTimeseriesFromAsset,
-      enableTimeseriesCustomQuery,
-      enableEvents,
-      enableEventsAdvancedFiltering,
-      // Deprecated features
-      enableTemplates,
-      enableExtractionPipelines,
-      enableRelationships,
-    );
+      oauthClientCredentials: oauthClientCreds,
+      ...resolveFeatureFlags(jsonData),
+    });
     this.initSources(connector);
   }
 

--- a/src/featureDefaults.ts
+++ b/src/featureDefaults.ts
@@ -30,3 +30,22 @@ export const FEATURE_DEFAULTS = {
  * Type representing all available feature flag keys
  */
 export type FeatureKey = keyof typeof FEATURE_DEFAULTS;
+
+/** Every flag resolved to a definite boolean. */
+export type FeatureFlags = Record<FeatureKey, boolean>;
+
+/**
+ * Fills in the flags a datasource's `jsonData` leaves unset.
+ *
+ * Reading the flags by name keeps the set extensible: adding a flag here reaches
+ * every consumer without anyone having to keep an argument list in the same order.
+ */
+export function resolveFeatureFlags(
+  jsonData: Partial<Record<FeatureKey, boolean>> = {},
+): FeatureFlags {
+  const keys = Object.keys(FEATURE_DEFAULTS) as FeatureKey[];
+  return keys.reduce((flags, key) => {
+    flags[key] = jsonData?.[key] ?? FEATURE_DEFAULTS[key];
+    return flags;
+  }, {} as FeatureFlags);
+}

--- a/src/featureDefaults.ts
+++ b/src/featureDefaults.ts
@@ -11,7 +11,7 @@ export const FEATURE_DEFAULTS = {
   // Core data model (CDM) features - default to enabled when core master toggle is on
   enableCogniteTimeSeries: true,
   enableCogniteActivities: true,
-  enableFlexibleDataModelling: true, // GraphQL / Data Models tab
+  enableFlexibleDataModelling: true, // GraphQL tab
 
   // Legacy data model features - default to enabled for backward compatibility
   enableTimeseriesSearch: true,

--- a/src/test_utils.ts
+++ b/src/test_utils.ts
@@ -8,6 +8,17 @@ import {
   QueryTarget,
 } from "./types";
 import { Connector, Fetcher } from "connector";
+import { FEATURE_DEFAULTS, FeatureFlags, FeatureKey } from "./featureDefaults";
+
+/**
+ * Every feature flag on. Derived from the flag list rather than written out, so a
+ * new flag reaches the test datasource without anyone remembering to add it.
+ */
+export const allFeaturesEnabled = (): FeatureFlags =>
+  (Object.keys(FEATURE_DEFAULTS) as FeatureKey[]).reduce((flags, key) => {
+    flags[key] = true;
+    return flags;
+  }, {} as FeatureFlags);
 
 export function getDataqueryResponse(
   { items, aggregates }: CDFDataQueryRequest,
@@ -65,25 +76,12 @@ export const getMockedDataSource = (
     instanceProps.jsonData.cogniteProject,
     instanceProps.url,
     fetcher,
-    options.oauthPassThru,
-    false, // oauthClientCredentials
-    // Master toggles - enabled for tests
-    true, // enableCoreDataModelFeatures
-    true, // enableLegacyDataModelFeatures
-    // Core data model (CDM) features - enabled for tests
-    true, // enableCogniteTimeSeries
-    true, // enableCogniteActivities
-    true, // enableFlexibleDataModelling
-    // Legacy data model features - enabled for tests
-    true, // enableTimeseriesSearch
-    true, // enableTimeseriesFromAsset
-    true, // enableTimeseriesCustomQuery
-    true, // enableEvents
-    true, // enableEventsAdvancedFiltering
-    // Deprecated features - enabled for tests
-    true, // enableTemplates
-    true, // enableExtractionPipelines
-    true, // enableRelationships
+    {
+      oauthPassThru: options.oauthPassThru,
+      oauthClientCredentials: false,
+      // Every feature on, so a test opts out rather than in.
+      ...allFeaturesEnabled(),
+    },
   );
   ds.initSources(connector);
   return ds;

--- a/src/types.ts
+++ b/src/types.ts
@@ -268,7 +268,6 @@ export interface CogniteDataSourceOptions extends DataSourceJsonData {
   enableTemplates?: boolean;
   enableExtractionPipelines?: boolean;
   enableRelationships?: boolean;
-  featureFlags: { [s: string]: boolean };
 }
 
 export interface CogniteSecureJsonData {

--- a/tests/configEditor.spec.ts
+++ b/tests/configEditor.spec.ts
@@ -25,7 +25,11 @@ test('"Save & test" should be successful when configuration is valid', async ({
   await page.getByRole('textbox', { name: 'Project' }).fill(ds.jsonData.cogniteProject ?? '');
   await page.getByLabel('Base URL').fill(ds.jsonData.cogniteApiUrl ?? '');
   
-  await page.getByLabel('OAuth2 client credentials').click();
+  // Located by the id the plugin sets: the switch has two labels (the form label
+  // and the switch's own), and only Grafana 12+ gives it a switch role. Clicked
+  // through dispatchEvent because the visual label overlays the checkbox -- the
+  // same pattern featureFlags.spec.ts uses.
+  await page.locator('#oauth-client-creds').dispatchEvent('click');
   
   await page.getByLabel('Token URL').fill(ds.jsonData.oauthTokenUrl ?? '');
   await page.getByLabel('Client ID').fill(ds.jsonData.oauthClientId ?? '');
@@ -49,7 +53,11 @@ test('"Save & test" should fail when configuration is invalid', async ({
   await page.getByRole('textbox', { name: 'Project' }).fill(ds.jsonData.cogniteProject ?? '');
   await page.getByLabel('Base URL').fill(ds.jsonData.cogniteApiUrl ?? '');
   
-  await page.getByLabel('OAuth2 client credentials').click();
+  // Located by the id the plugin sets: the switch has two labels (the form label
+  // and the switch's own), and only Grafana 12+ gives it a switch role. Clicked
+  // through dispatchEvent because the visual label overlays the checkbox -- the
+  // same pattern featureFlags.spec.ts uses.
+  await page.locator('#oauth-client-creds').dispatchEvent('click');
   
   await page.getByLabel('Token URL').fill(ds.jsonData.oauthTokenUrl ?? '');
   await page.getByLabel('Client ID').fill(ds.jsonData.oauthClientId ?? '');

--- a/tests/featureFlags.spec.ts
+++ b/tests/featureFlags.spec.ts
@@ -114,6 +114,23 @@ test.describe('Feature Flags - Config Editor', () => {
     await expect(page.locator('#enable-timeseries-from-asset')).toBeChecked();
     await expect(page.locator('#enable-timeseries-custom-query')).toBeChecked();
     await expect(page.locator('#enable-events')).toBeChecked();
+    // Re-enabling restores the defaults, not "everything on": this is the one
+    // legacy flag that defaults to off.
+    await expect(page.locator('#enable-events-advanced-filtering')).not.toBeChecked();
+  });
+
+  test('The two master toggles are mutually exclusive', async () => {
+    await toggleCheckbox(page, '#enable-legacy-data-model-features', true);
+    await expect(page.locator('#enable-legacy-data-model-features')).toBeChecked();
+
+    await toggleCheckbox(page, '#enable-core-data-model-features', true);
+    await expect(page.locator('#enable-core-data-model-features')).toBeChecked();
+    await expect(page.locator('#enable-legacy-data-model-features')).not.toBeChecked();
+    await expect(page.locator('#enable-timeseries-search')).not.toBeVisible();
+
+    await toggleCheckbox(page, '#enable-legacy-data-model-features', true);
+    await expect(page.locator('#enable-core-data-model-features')).not.toBeChecked();
+    await expect(page.locator('#enable-cognite-timeseries')).not.toBeVisible();
   });
 
   test('Should toggle core data model features on/off', async () => {
@@ -203,8 +220,13 @@ test.describe('Feature Flags - Config Editor', () => {
     await expect(page.locator('#enable-timeseries-search')).not.toBeChecked();
     await expect(page.locator('#enable-cognite-timeseries')).not.toBeChecked();
 
+    // Restore the provisioned state (asset-centric on, CDM off) so the other
+    // config tests start from the fixture. The masters are mutually exclusive, so
+    // only one of them is turned back on.
     await toggleCheckbox(page, '#enable-legacy-data-model-features', true);
-    await toggleCheckbox(page, '#enable-core-data-model-features', true);
+    await expect(page.locator('#enable-legacy-data-model-features')).toBeChecked();
+    await expect(page.locator('#enable-core-data-model-features')).not.toBeChecked();
+
     // Navigate back to Connection tab before second save for the same reason
     await page.locator('[role="tab"]').filter({ hasText: /^Connection$/ }).click();
     await page.getByTestId('data-testid Data source settings page Save and Test button').click();


### PR DESCRIPTION
**Problem / User story**

Feature flags reached the `Connector` as fourteen positional booleans, which mis-wire silently the moment one is inserted in the middle, and the same fourteen `key = FEATURE_DEFAULTS.key` defaults were written out again in the datasource constructor and in the config editor. The config editor rendered each toggle by hand: fourteen copies of the id, tooltip and label-width block, in which one row (the OAuth client credentials switch) had already lost its `id`, leaving its label pointing at nothing. `masterToggleHandler` in `configEditorUtils` had no caller. The e2e "save and persist" test claimed to restore the provisioned fixture but saved its inverse (CDM on, asset-centric off), and never asserted the one legacy flag whose default is off.

**Solution**

- `Connector` takes a `ConnectorOptions` object (`oauthPassThru`, `oauthClientCredentials`, plus the feature flags by name). A `flag()` accessor coerces an unset flag to `false`, matching the old `&&`-of-optionals semantics.
- `resolveFeatureFlags(jsonData)` fills in defaults once, from the `FEATURE_DEFAULTS` key list, and both the datasource and the config editor use it. Adding a flag now reaches every consumer without touching an argument list.
- `FeatureToggleRow` renders one switch with its label, tooltip and optional badge. Feature rows look their tooltip up by flag in `FEATURE_TOOLTIPS` (typed `Record<FeatureKey, string>`, so a flag without an explanation is a compile error); the two OAuth rows pass their own tooltip and label width. That restores the missing `id` structurally.
- `isLegacyDataModelFeaturesEnabled()` is exposed on its own: asset-centric variable queries hit `/assets/list`, which no sub-flag covers, so the master switch is the only meaningful gate for them. Consumed by the variable editor in a later PR.
- Dead code removed: `masterToggleHandler` and its tests, and the never-read `featureFlags` map on `CogniteDataSourceOptions`.
- e2e: the persistence test restores the fixture (asset-centric on) instead of turning both masters on in sequence, the mutual exclusion of the masters gets its own non-saving test, and re-enabling the legacy master asserts `enableEventsAdvancedFiltering` stays off.

**Affected Resource types**

None at runtime. Datasource settings UI (Connection and Features tabs) is rebuilt on the shared row but renders the same controls with the same ids. Three small settings-UI changes go beyond a pure refactor:

- Re-enabling either master now restores its sub-flags to their `FEATURE_DEFAULTS` values. The CDM master previously forced every sub-flag on; since every CDM sub-flag defaults on, the result is the same today.
- Tooltips say "GraphQL tab" where they said "Data Models tab" before. The query editor tab is labelled GraphQL, so the old copy was stale.
- Feature toggle labels are two units wider (16, was 14) so the longest labels fit beside their tooltip icon on one line. Connection tab labels keep 14.

**Changes to datasource JSON model**

None. The `jsonData` keys and their defaults are unchanged; only how they are read is different.

**Has documentation been updated**

No — not applicable.

**Have tests been updated?**

Yes. `connector.featureFlags.test.ts` is rewritten as a table over every CDM and legacy feature × all four master/flag combinations (broader than before, at a fifth of the length), with cases for the standalone legacy master and for omitted flags reading as `false`. New `featureDefaults.test.ts` covers `resolveFeatureFlags`. `test_utils` derives its all-on connector from the flag list. e2e `featureFlags.spec.ts` as above. `configEditor.spec.ts` now locates the OAuth client credentials switch by its id and toggles it with `dispatchEvent` (a `switch` role only exists on Grafana 12+): once the switch carries the id its label points at, `getByLabel` matches two elements (the checkbox and the switch's inner label), which strict mode rejects. Verified locally against Grafana 13.2: config editor and feature flag specs green.

**Screenshots and examples**

N/A.



